### PR TITLE
feature/d2ModelFactory: Allow to reference classes dynamically

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+src/react-app.d.ts

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -57,6 +57,6 @@ Cypress.Commands.add("loadPage", (path = "/") => {
 
 Cypress.on("uncaught:exception", (err, runnable) => {
     // returning false here prevents Cypress from failing the test
-    console.log("uncaught:exception", {err, runnable});
+    console.log("uncaught:exception", { err, runnable });
     return false;
 });

--- a/src/models/d2Model.ts
+++ b/src/models/d2Model.ts
@@ -1,7 +1,7 @@
 import _ from "lodash";
-import {cleanOptions, d2BaseModelColumns, d2BaseModelDetails} from "../utils/d2";
-import {TableFilters, TableLabel, TableList, TablePagination} from "../types/d2-ui-components";
-import {D2, ModelDefinition} from "../types/d2";
+import { cleanOptions, d2BaseModelColumns, d2BaseModelDetails } from "../utils/d2";
+import { TableFilters, TableLabel, TableList, TablePagination } from "../types/d2-ui-components";
+import { D2, ModelDefinition } from "../types/d2";
 
 abstract class D2Model {
     // Metadata Type should be defined on subclasses
@@ -10,23 +10,25 @@ abstract class D2Model {
     // Other static properties can be optionally overridden on subclasses
     protected static columns = d2BaseModelColumns;
     protected static details = d2BaseModelDetails;
-    protected static initialSorting = ['name', 'asc'];
+    protected static initialSorting = ["name", "asc"];
 
     // List method should be executed by a wrapper to preserve static context binding
-    public static async listMethod(d2: D2, filters: TableFilters, pagination: TablePagination): Promise<TableList> {
-        const {search = null} = filters || {};
-        const {page = 1, pageSize = 20, sorting = this.initialSorting} = pagination || {};
+    public static async listMethod(
+        d2: D2,
+        filters: TableFilters,
+        pagination: TablePagination
+    ): Promise<TableList> {
+        const { search = null } = filters || {};
+        const { page = 1, pageSize = 20, sorting = this.initialSorting } = pagination || {};
         const fields = this.details.map(e => e.name);
 
         const [field, direction] = sorting;
         const order = `${field}:i${direction}`;
-        const filter = _.compact([
-            search ? `displayName:ilike:${search}` : null,
-        ]);
+        const filter = _.compact([search ? `displayName:ilike:${search}` : null]);
 
-        const listOptions = cleanOptions({fields, filter, page, pageSize, order});
+        const listOptions = cleanOptions({ fields, filter, page, pageSize, order });
         const collection = await d2.models[this.metadataType].list(listOptions);
-        return {pager: collection.pager, objects: collection.toArray()};
+        return { pager: collection.pager, objects: collection.toArray() };
     }
 
     public static getD2Model(d2: D2): ModelDefinition {
@@ -47,17 +49,17 @@ abstract class D2Model {
 }
 
 export class OrganisationUnitModel extends D2Model {
-    protected static metadataType = 'organisationUnit';
+    protected static metadataType = "organisationUnit";
 }
 
 export class DataElementModel extends D2Model {
-    protected static metadataType = 'dataElement';
+    protected static metadataType = "dataElement";
 }
 
 export class IndicatorModel extends D2Model {
-    protected static metadataType = 'indicator';
+    protected static metadataType = "indicator";
 }
 
 export class ValidationRuleModel extends D2Model {
-    protected static metadataType = 'validationRule';
+    protected static metadataType = "validationRule";
 }

--- a/src/models/d2Model.ts
+++ b/src/models/d2Model.ts
@@ -63,3 +63,9 @@ export class IndicatorModel extends D2Model {
 export class ValidationRuleModel extends D2Model {
     protected static metadataType = "validationRule";
 }
+
+export function defaultModel(pascalCaseModelName: string): any {
+    return class DefaultModel extends D2Model {
+        protected static metadataType = pascalCaseModelName;
+    };
+}

--- a/src/models/d2ModelFactory.js
+++ b/src/models/d2ModelFactory.js
@@ -1,0 +1,24 @@
+import {
+    DataElementModel,
+    defaultModel,
+    IndicatorModel,
+    OrganisationUnitModel,
+    ValidationRuleModel,
+} from "./d2Model";
+
+const classes = {
+    OrganisationUnitModel,
+    DataElementModel,
+    IndicatorModel,
+    ValidationRuleModel,
+};
+
+/**
+ * D2ModelProxy allows to create on-demand d2Model classes
+ * If the class doesn't exist a new default class is created
+ * d2ModelName: string (singular name property from d2.models)
+ */
+export function d2ModelFactory(d2ModelName) {
+    const modelName = d2ModelName.charAt(0).toUpperCase() + d2ModelName.slice(1) + "Model";
+    return classes[modelName] ? classes[modelName] : defaultModel(d2ModelName);
+}

--- a/src/models/dataStore.ts
+++ b/src/models/dataStore.ts
@@ -1,6 +1,6 @@
 import _ from "lodash";
-import {D2, Response} from "../types/d2";
-import {TableFilters, TableList, TablePagination} from "../types/d2-ui-components";
+import { D2, Response } from "../types/d2";
+import { TableFilters, TableList, TablePagination } from "../types/d2-ui-components";
 
 const dataStoreNamespace = "metatada-synchronization";
 const instancesKey = "instances";
@@ -28,17 +28,21 @@ async function saveDataStore(d2: D2, dataStoreKey: string, newValue: any): Promi
     await dataStore.set(dataStoreKey, newValue);
 }
 
-export async function listInstances(d2: D2, filters: TableFilters, pagination: TablePagination): Promise<TableList> {
+export async function listInstances(
+    d2: D2,
+    filters: TableFilters,
+    pagination: TablePagination
+): Promise<TableList> {
     const instanceArray = await getDataStore(d2, instancesKey);
 
     const { search = null } = filters || {};
     const filteredInstances = _.filter(instanceArray, o =>
         _(o)
             .keys()
-            .some(k => o[k].toLowerCase().includes(search ? search.toLowerCase() : ''))
+            .some(k => o[k].toLowerCase().includes(search ? search.toLowerCase() : ""))
     );
 
-    const { sorting = ['id', 'asc'] } = pagination || {};
+    const { sorting = ["id", "asc"] } = pagination || {};
     const [field, direction] = sorting;
     const sortedInstances = _.orderBy(
         filteredInstances,

--- a/src/models/instance.ts
+++ b/src/models/instance.ts
@@ -1,8 +1,8 @@
 import _ from "lodash";
-import {D2} from "../types/d2";
-import {TableFilters, TableList, TablePagination} from "../types/d2-ui-components";
-import {Response} from "../types/d2";
-import {deleteInstance, listInstances, saveNewInstance} from "./dataStore";
+import { D2 } from "../types/d2";
+import { TableFilters, TableList, TablePagination } from "../types/d2-ui-components";
+import { Response } from "../types/d2";
+import { deleteInstance, listInstances, saveNewInstance } from "./dataStore";
 
 export interface Data {
     id: string;
@@ -16,7 +16,7 @@ export default class Instance {
     private readonly data: Data;
 
     constructor(data: Data) {
-        this.data = _.pick(data, ['id', 'url', 'username', 'password', 'description']);
+        this.data = _.pick(data, ["id", "url", "username", "password", "description"]);
     }
 
     public static create(): Instance {
@@ -24,12 +24,16 @@ export default class Instance {
             id: "",
             url: "",
             username: "",
-            password: ""
+            password: "",
         };
         return new Instance(initialData);
     }
 
-    public static async list(d2: D2, filters: TableFilters, pagination: TablePagination): Promise<TableList> {
+    public static async list(
+        d2: D2,
+        filters: TableFilters,
+        pagination: TablePagination
+    ): Promise<TableList> {
         return listInstances(d2, filters, pagination);
     }
 
@@ -42,7 +46,7 @@ export default class Instance {
     }
 
     public setId(id: string): Instance {
-        return new Instance({...this.data, id});
+        return new Instance({ ...this.data, id });
     }
 
     public get id(): string {
@@ -50,7 +54,7 @@ export default class Instance {
     }
 
     public setUrl(url: string): Instance {
-        return new Instance({...this.data, url});
+        return new Instance({ ...this.data, url });
     }
 
     public get url(): string {
@@ -58,7 +62,7 @@ export default class Instance {
     }
 
     public setUsername(username: string): Instance {
-        return new Instance({...this.data, username});
+        return new Instance({ ...this.data, username });
     }
 
     public get username(): string {
@@ -66,7 +70,7 @@ export default class Instance {
     }
 
     public setPassword(password: string): Instance {
-        return new Instance({...this.data, password});
+        return new Instance({ ...this.data, password });
     }
 
     public get password(): string {
@@ -74,7 +78,7 @@ export default class Instance {
     }
 
     public setDescription(description: string): Instance {
-        return new Instance({...this.data, description});
+        return new Instance({ ...this.data, description });
     }
 
     public get description(): string {

--- a/src/types/d2.d.ts
+++ b/src/types/d2.d.ts
@@ -1,4 +1,4 @@
-import {Dictionary} from "lodash";
+import { Dictionary } from "lodash";
 
 export interface DataStoreNamespace {
     delete(key: string): Promise<>;


### PR DESCRIPTION
### :pushpin: References

* **Issue:** Work #8 

### :memo: Implementation

- Create a factory method that dynamically references our model classes by d2 internal name (string).

- If we do not have a given model class, create a default one

### :bookmark_tabs: Others

- In the synchronization logic we use our internal model classes to extract metadata

- To abstract and translate d2 models to our own models we use this factory method

### :fire: Is there anything the reviewer should know to test it?

```js
const myClass = d2ModelFactory('categoryCombo');
// Try to read static class properties
console.log({metadataType: myClass.metadataType});
// Try to execute static class methods
console.log(myClass.getD2Model(d2));
```