### PR TITLE
Add separate button to test connection as well as contextual action

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2019-03-22T11:28:52.570Z\n"
-"PO-Revision-Date: 2019-03-22T11:28:52.570Z\n"
+"POT-Creation-Date: 2019-03-26T16:05:15.265Z\n"
+"PO-Revision-Date: 2019-03-26T16:05:15.265Z\n"
 
 msgid "Metadata Synchronization"
 msgstr ""
@@ -38,6 +38,9 @@ msgstr ""
 msgid "Ok"
 msgstr ""
 
+msgid "Connected sucessfully to instance"
+msgstr ""
+
 msgid "Deleted {{name}}"
 msgstr ""
 
@@ -63,6 +66,9 @@ msgid "Edit"
 msgstr ""
 
 msgid "Delete"
+msgstr ""
+
+msgid "Test connection"
 msgstr ""
 
 msgid "Delete Instance?"
@@ -93,6 +99,12 @@ msgid "Password (*)"
 msgstr ""
 
 msgid "Please fix the issues before saving"
+msgstr ""
+
+msgid "Please fix the issues before testing the connection"
+msgstr ""
+
+msgid "Test Connection"
 msgstr ""
 
 msgid "New Instance"

--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2019-03-26T16:05:15.265Z\n"
-"PO-Revision-Date: 2019-03-26T16:05:15.265Z\n"
+"POT-Creation-Date: 2019-03-26T16:31:58.101Z\n"
+"PO-Revision-Date: 2019-03-26T16:31:58.101Z\n"
 
 msgid "Metadata Synchronization"
 msgstr ""
@@ -68,7 +68,7 @@ msgstr ""
 msgid "Delete"
 msgstr ""
 
-msgid "Test connection"
+msgid "Test Connection"
 msgstr ""
 
 msgid "Delete Instance?"
@@ -102,9 +102,6 @@ msgid "Please fix the issues before saving"
 msgstr ""
 
 msgid "Please fix the issues before testing the connection"
-msgstr ""
-
-msgid "Test Connection"
 msgstr ""
 
 msgid "New Instance"

--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2019-03-26T16:31:58.101Z\n"
-"PO-Revision-Date: 2019-03-26T16:31:58.101Z\n"
+"POT-Creation-Date: 2019-03-27T10:26:43.130Z\n"
+"PO-Revision-Date: 2019-03-27T10:26:43.130Z\n"
 
 msgid "Metadata Synchronization"
 msgstr ""
@@ -98,10 +98,13 @@ msgstr ""
 msgid "Password (*)"
 msgstr ""
 
-msgid "Please fix the issues before saving"
+msgid "Please fix the issues before testing the connection"
 msgstr ""
 
-msgid "Please fix the issues before testing the connection"
+msgid "Connected successfully to instance"
+msgstr ""
+
+msgid "Please fix the issues before saving"
 msgstr ""
 
 msgid "New Instance"

--- a/src/components/app/Root.jsx
+++ b/src/components/app/Root.jsx
@@ -29,7 +29,9 @@ class Root extends React.Component {
 
                 <Route
                     path="/instance-configurator"
-                    render={props => <InstanceConfigurator d2={d2} {...props} />}
+                    render={props => (
+                        <InstanceConfigurator d2={d2} appConfig={appConfig} {...props} />
+                    )}
                 />
 
                 <Route

--- a/src/components/instance-configurator/InstanceConfigurator.jsx
+++ b/src/components/instance-configurator/InstanceConfigurator.jsx
@@ -117,6 +117,7 @@ class InstanceConfigurator extends React.Component {
             text: i18n.t("Test connection"),
             multiple: false,
             onClick: this.onTestConnection,
+            icon: "settings_input_antenna",
         },
     ];
 

--- a/src/components/instance-configurator/InstanceConfigurator.jsx
+++ b/src/components/instance-configurator/InstanceConfigurator.jsx
@@ -24,6 +24,7 @@ class InstanceConfigurator extends React.Component {
         d2: PropTypes.object.isRequired,
         snackbar: PropTypes.object.isRequired,
         history: PropTypes.object.isRequired,
+        appConfig: PropTypes.object.isRequired,
     };
 
     onCreate = () => {
@@ -35,6 +36,19 @@ class InstanceConfigurator extends React.Component {
             pathname: "/instance-configurator/edit",
             instance,
         });
+    };
+
+    onTestConnection = async instanceData => {
+        const { encryptionKey } = this.props.appConfig;
+        const instance = Instance.getOrCreate(instanceData, encryptionKey);
+        const connectionErrors = await instance.check();
+        if (!connectionErrors.status) {
+            this.props.snackbar.error(connectionErrors.error.message, {
+                autoHideDuration: null,
+            });
+        } else {
+            this.props.snackbar.success(i18n.t("Connected sucessfully to instance"));
+        }
     };
 
     onDelete = instanceData => {
@@ -97,6 +111,12 @@ class InstanceConfigurator extends React.Component {
             text: i18n.t("Delete"),
             multiple: false,
             onClick: this.onDelete,
+        },
+        {
+            name: "testConnection",
+            text: i18n.t("Test connection"),
+            multiple: false,
+            onClick: this.onTestConnection,
         },
     ];
 

--- a/src/components/instance-configurator/InstanceConfigurator.jsx
+++ b/src/components/instance-configurator/InstanceConfigurator.jsx
@@ -114,7 +114,7 @@ class InstanceConfigurator extends React.Component {
         },
         {
             name: "testConnection",
-            text: i18n.t("Test connection"),
+            text: i18n.t("Test Connection"),
             multiple: false,
             onClick: this.onTestConnection,
             icon: "settings_input_antenna",

--- a/src/components/instance-form-builder/GeneralInfoForm.jsx
+++ b/src/components/instance-form-builder/GeneralInfoForm.jsx
@@ -22,8 +22,12 @@ const styles = () => ({
         paddingBottom: 30,
     },
     buttonContainer: {
-        flexDirection: "row",
+        display: "flex",
+        justifyContent: "space-between",
         paddingTop: 30,
+    },
+    testButton: {
+        marginTop: 10,
     },
 });
 
@@ -180,13 +184,9 @@ class GeneralInfoForm extends React.Component {
             }
             const fieldKeys = fields.map(field => field.name);
             const errorMessages = await getValidationMessages(d2, instance, fieldKeys);
-            const connectionErrors = await instance.check();
 
-            const allErrors = connectionErrors.status
-                ? errorMessages
-                : [...errorMessages, connectionErrors.error];
-            if (!_(allErrors).isEmpty()) {
-                this.props.snackbar.error(allErrors.join("\n"), {
+            if (!_(errorMessages).isEmpty()) {
+                this.props.snackbar.error(errorMessages.join("\n"), {
                     autoHideDuration: null,
                 });
             } else {
@@ -194,6 +194,25 @@ class GeneralInfoForm extends React.Component {
                 await instance.save(d2);
                 this.setState({ isSaving: false });
                 this.props.history.push("/instance-configurator");
+            }
+        };
+
+        const testConnection = async () => {
+            const formErrors = isFormValid(fields, this.formReference);
+            if (formErrors.length > 0) {
+                this.props.snackbar.error(
+                    i18n.t("Please fix the issues before testing the connection")
+                );
+                return;
+            }
+            const { instance } = this.props;
+            const connectionErrors = await instance.check();
+            if (!connectionErrors.status) {
+                this.props.snackbar.error(connectionErrors.error.message, {
+                    autoHideDuration: null,
+                });
+            } else {
+                this.props.snackbar.success(i18n.t("Connected sucessfully to instance"));
             }
         };
 
@@ -206,8 +225,19 @@ class GeneralInfoForm extends React.Component {
                         ref={this.setFormReference}
                     />
                     <div className={classes.buttonContainer}>
-                        <SaveButton onClick={saveAction} isSaving={this.state.isSaving} />
-                        <RaisedButton label={i18n.t("Cancel")} onClick={this.props.cancelAction} />
+                        <div>
+                            <SaveButton onClick={saveAction} isSaving={this.state.isSaving} />
+                            <RaisedButton
+                                label={i18n.t("Cancel")}
+                                onClick={this.props.cancelAction}
+                            />
+                        </div>
+                        <div className={classes.testButton}>
+                            <RaisedButton
+                                label={i18n.t("Test Connection")}
+                                onClick={testConnection}
+                            />
+                        </div>
                     </div>
                 </CardContent>
             </Card>

--- a/src/models/instance.ts
+++ b/src/models/instance.ts
@@ -165,6 +165,7 @@ export default class Instance {
 
     public async check(): Promise<Response> {
         const { url, username, password } = this.data;
+        console.log({ url, username, password });
         const headers = new Headers({
             Authorization: "Basic " + btoa(username + ":" + password),
         });

--- a/src/models/instance.ts
+++ b/src/models/instance.ts
@@ -188,7 +188,6 @@ export default class Instance {
 
     public async check(): Promise<Response> {
         const { url, username, password } = this.data;
-        console.log({ url, username, password });
         const headers = new Headers({
             Authorization: "Basic " + btoa(username + ":" + password),
         });


### PR DESCRIPTION
### :pushpin: References
* **Issue:** Closes #33 

### :memo: Implementation
Connection validation is no longer performed on save. There is now a separate button on the form to validate the connection as well as a new contextual action on the instancesList. 

### :art: Screenshots
![image](https://user-images.githubusercontent.com/15323369/55015125-91e39c80-4fec-11e9-903f-8857ef0dca5b.png)
![image](https://user-images.githubusercontent.com/15323369/55015143-98721400-4fec-11e9-8e64-a1c06d20a187.png)
![image](https://user-images.githubusercontent.com/15323369/55015181-a6279980-4fec-11e9-8785-3f2caf66211e.png)

### :fire: Is there anything the reviewer should know to test it?
This branch is based off the `encrypt-password-7` in order to integrate encryption into the connection validation. Same warnings as that branch, `app-config.json` file must be created and older instances created before this PR will break the app when trying to `Edit` or `Test Connection` from the contextual options
