### PR TITLE
Implement basic instance selection dialog

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2019-03-27T16:44:29.790Z\n"
-"PO-Revision-Date: 2019-03-27T16:44:29.790Z\n"
+"POT-Creation-Date: 2019-03-27T18:46:10.807Z\n"
+"PO-Revision-Date: 2019-03-27T18:46:10.807Z\n"
 
 msgid "Metadata Synchronization"
 msgstr ""
@@ -171,6 +171,15 @@ msgid "ID"
 msgstr ""
 
 msgid "API link"
+msgstr ""
+
+msgid "Synchronizing metadata"
+msgstr ""
+
+msgid "Synchronize Organisation Units"
+msgstr ""
+
+msgid "Synchronize"
 msgstr ""
 
 msgid "Field {{field}} cannot be blank"

--- a/src/components/app/App.jsx
+++ b/src/components/app/App.jsx
@@ -12,7 +12,7 @@ import i18n from "@dhis2/d2-i18n";
 import "./App.css";
 import Root from "./Root";
 import Share from "../share/Share";
-import {muiTheme} from "../../themes/dhis2.theme";
+import { muiTheme } from "../../themes/dhis2.theme";
 import muiThemeLegacy from "../../themes/dhis2-legacy.theme";
 
 const generateClassName = createGenerateClassName({

--- a/src/components/app/App.jsx
+++ b/src/components/app/App.jsx
@@ -9,10 +9,11 @@ import { SnackbarProvider, LoadingProvider } from "d2-ui-components";
 import _ from "lodash";
 import i18n from "@dhis2/d2-i18n";
 
-import { muiTheme } from "../../dhis2.theme";
 import "./App.css";
 import Root from "./Root";
 import Share from "../share/Share";
+import {muiTheme} from "../../themes/dhis2.theme";
+import muiThemeLegacy from "../../themes/dhis2-legacy.theme";
 
 const generateClassName = createGenerateClassName({
     dangerouslyUseGlobalCSS: false,
@@ -47,7 +48,7 @@ class App extends Component {
             <React.Fragment>
                 <JssProvider generateClassName={generateClassName}>
                     <MuiThemeProvider theme={muiTheme}>
-                        <OldMuiThemeProvider>
+                        <OldMuiThemeProvider muiTheme={muiThemeLegacy}>
                             <LoadingProvider>
                                 {showHeader && (
                                     <HeaderBar appName={i18n.t("Metadata Synchronization")} />

--- a/src/components/app/App.jsx
+++ b/src/components/app/App.jsx
@@ -48,21 +48,19 @@ class App extends Component {
                 <JssProvider generateClassName={generateClassName}>
                     <MuiThemeProvider theme={muiTheme}>
                         <OldMuiThemeProvider>
-                            <React.Fragment>
-                                <LoadingProvider>
-                                    {showHeader && (
-                                        <HeaderBar appName={i18n.t("Metadata Synchronization")} />
-                                    )}
+                            <LoadingProvider>
+                                {showHeader && (
+                                    <HeaderBar appName={i18n.t("Metadata Synchronization")} />
+                                )}
 
-                                    <div id="app" className="content">
-                                        <SnackbarProvider>
-                                            <Root d2={d2} appConfig={appConfig} />
-                                        </SnackbarProvider>
-                                    </div>
+                                <div id="app" className="content">
+                                    <SnackbarProvider>
+                                        <Root d2={d2} appConfig={appConfig} />
+                                    </SnackbarProvider>
+                                </div>
 
-                                    <Share visible={showShareButton} />
-                                </LoadingProvider>
-                            </React.Fragment>
+                                <Share visible={showShareButton} />
+                            </LoadingProvider>
                         </OldMuiThemeProvider>
                     </MuiThemeProvider>
                 </JssProvider>

--- a/src/components/app/App.jsx
+++ b/src/components/app/App.jsx
@@ -5,7 +5,7 @@ import { MuiThemeProvider } from "@material-ui/core/styles";
 import JssProvider from "react-jss/lib/JssProvider";
 import { createGenerateClassName } from "@material-ui/core/styles";
 import OldMuiThemeProvider from "material-ui/styles/MuiThemeProvider";
-import { SnackbarProvider } from "d2-ui-components";
+import { SnackbarProvider, LoadingProvider } from "d2-ui-components";
 import _ from "lodash";
 import i18n from "@dhis2/d2-i18n";
 
@@ -49,17 +49,19 @@ class App extends Component {
                     <MuiThemeProvider theme={muiTheme}>
                         <OldMuiThemeProvider>
                             <React.Fragment>
-                                {showHeader && (
-                                    <HeaderBar appName={i18n.t("Metadata Synchronization")} />
-                                )}
+                                <LoadingProvider>
+                                    {showHeader && (
+                                        <HeaderBar appName={i18n.t("Metadata Synchronization")} />
+                                    )}
 
-                                <div id="app" className="content">
-                                    <SnackbarProvider>
-                                        <Root d2={d2} appConfig={appConfig} />
-                                    </SnackbarProvider>
-                                </div>
+                                    <div id="app" className="content">
+                                        <SnackbarProvider>
+                                            <Root d2={d2} appConfig={appConfig} />
+                                        </SnackbarProvider>
+                                    </div>
 
-                                <Share visible={showShareButton} />
+                                    <Share visible={showShareButton} />
+                                </LoadingProvider>
                             </React.Fragment>
                         </OldMuiThemeProvider>
                     </MuiThemeProvider>

--- a/src/components/sync-dialog/SyncDialog.jsx
+++ b/src/components/sync-dialog/SyncDialog.jsx
@@ -1,0 +1,89 @@
+import React from "react";
+import i18n from "@dhis2/d2-i18n";
+import PropTypes from "prop-types";
+import { ConfirmationDialog, MultiSelector } from "d2-ui-components";
+import DialogContent from "@material-ui/core/DialogContent";
+import { withLoading } from "d2-ui-components";
+
+import Instance from "../../models/instance";
+import { startSynchronization } from "../../logic/synchronization";
+
+class SyncDialog extends React.Component {
+    state = {
+        instanceOptions: [],
+        targetInstances: [],
+    };
+
+    static propTypes = {
+        d2: PropTypes.object.isRequired,
+        isOpen: PropTypes.bool.isRequired,
+        metadata: PropTypes.object.isRequired,
+        handleClose: PropTypes.func.isRequired,
+        loading: PropTypes.object.isRequired,
+    };
+
+    async componentDidMount() {
+        const instances = await Instance.list(
+            this.props.d2,
+            { search: "" },
+            { page: 1, pageSize: 1, sorting: [] }
+        );
+        const instanceOptions = instances.objects.map(instance => ({
+            value: instance.id,
+            text: `${instance.name} (${instance.url}) [${instance.username}]`,
+        }));
+        this.setState({ instanceOptions });
+    }
+
+    onChangeInstances = targetInstances => {
+        this.setState({ targetInstances });
+    };
+
+    handleSynchronization = async () => {
+        this.props.loading.show(true, i18n.t("Synchronizing metadata"));
+        // TODO: Obtain import results and add warnings/errors to the logger
+        try {
+            await startSynchronization(this.props.d2, {
+                metadata: this.props.metadata,
+                targetInstances: this.state.targetInstances,
+            });
+            this.props.handleClose(true);
+        } catch (e) {
+            this.props.handleClose();
+        }
+        this.props.loading.reset();
+    };
+
+    handleCancel = () => {
+        this.props.handleClose();
+    };
+
+    render() {
+        const { d2, isOpen } = this.props;
+
+        return (
+            <React.Fragment>
+                <ConfirmationDialog
+                    isOpen={isOpen}
+                    title={i18n.t("Synchronize Organisation Units")}
+                    onSave={this.handleSynchronization}
+                    onCancel={this.handleCancel}
+                    saveText={i18n.t("Synchronize")}
+                    maxWidth={"lg"}
+                    fullWidth={true}
+                >
+                    <DialogContent>
+                        <MultiSelector
+                            d2={d2}
+                            height={300}
+                            onChange={this.onChangeInstances}
+                            options={this.state.instanceOptions}
+                        />
+                    </DialogContent>
+                </ConfirmationDialog>
+            </React.Fragment>
+        );
+    }
+}
+
+export default withLoading(SyncDialog);

--- a/src/components/sync-dialog/SyncDialog.jsx
+++ b/src/components/sync-dialog/SyncDialog.jsx
@@ -26,11 +26,11 @@ class SyncDialog extends React.Component {
         const instances = await Instance.list(
             this.props.d2,
             { search: "" },
-            { page: 1, pageSize: 1, sorting: [] }
+            { page: 1, pageSize: 100, sorting: [] }
         );
         const instanceOptions = instances.objects.map(instance => ({
             value: instance.id,
-            text: `${instance.name} (${instance.url}) [${instance.username}]`,
+            text: `${instance.name} (${instance.url} with user ${instance.username})`,
         }));
         this.setState({ instanceOptions });
     }

--- a/src/logic/synchronization.ts
+++ b/src/logic/synchronization.ts
@@ -62,13 +62,16 @@ async function exportMetadata(d2: D2, builder: ExportBuilder): Promise<Synchroni
 
 async function importMetadata(
     d2: D2,
-    instance: Instance,
+    instanceId: string,
     metadataPackage: SynchronizationResult
 ): Promise<void> {
     // TODO: Obtain import results and add warnings/errors to the logger
+    const instance = await Instance.get(d2, instanceId);
     const importResult = await postMetadata(instance, metadataPackage);
 
     // DEBUG: Print response from import
+    console.log("[DEBUG] Destination instance", instance);
+    console.log("[DEBUG] Metadata package", metadataPackage);
     console.log("[DEBUG] HTTP Status", importResult.status);
     console.log("[DEBUG] Import Stats", importResult.data.status, importResult.data.stats);
     // END OF DEBUG SECTION
@@ -92,13 +95,9 @@ export async function startSynchronization(d2: D2, builder: SynchronizationBuild
     const exportResults: SynchronizationResult[] = await Promise.all(exportPromises);
     const metadataPackage = _.deepMerge({}, ...exportResults);
 
-    // DEBUG: Print metadata package for now to console.log
-    console.log("[DEBUG] Metadata package", metadataPackage);
-    // END OF DEBUG SECTION
-
     // Phase 2: Import metadata into destination instances
-    const importPromises = builder.targetInstances.map(instance =>
-        importMetadata(d2, instance, metadataPackage)
+    const importPromises = builder.targetInstances.map(instanceId =>
+        importMetadata(d2, instanceId, metadataPackage)
     );
     const importResults: any[] = await Promise.all(importPromises);
     return await _.deepMerge({}, ...importResults);

--- a/src/models/dataStore.ts
+++ b/src/models/dataStore.ts
@@ -31,6 +31,11 @@ export async function getData(d2: D2, dataStoreKey: string): Promise<any> {
     return await getDataStore(d2, dataStoreKey);
 }
 
+export async function getDataById(d2: D2, dataStoreKey: string, id: string): Promise<any> {
+    const rawData = await getDataStore(d2, dataStoreKey);
+    return _.find(rawData, instance => instance.id === id);
+}
+
 export async function getPaginatedData(
     d2: D2,
     dataStoreKey: string,

--- a/src/models/instance.ts
+++ b/src/models/instance.ts
@@ -1,7 +1,7 @@
 import _ from "lodash";
 import { D2, Response } from "../types/d2";
 import { TableFilters, TableList, TablePagination } from "../types/d2-ui-components";
-import { deleteData, getPaginatedData, saveData, getData } from "./dataStore";
+import { deleteData, getPaginatedData, saveData, getData, getDataById } from "./dataStore";
 import { generateUid } from "d2/uid";
 import Cryptr from "cryptr";
 import i18n from "@dhis2/d2-i18n";
@@ -37,7 +37,7 @@ export default class Instance {
 
     public static getOrCreate(data: Data, encryptionKey: string): Instance {
         let instance;
-        if (!!data) {
+        if (data) {
             const cryptedInstace = new Instance(data);
             instance = cryptedInstace.decryptPassword(encryptionKey);
         } else {
@@ -54,10 +54,14 @@ export default class Instance {
         return getPaginatedData(d2, instancesDataStoreKey, filters, pagination);
     }
 
+    public static async get(d2: D2, id: string): Promise<Instance> {
+        return (await getDataById(d2, instancesDataStoreKey, id)) as Instance;
+    }
+
     public async save(d2: D2, encryptionKey: string): Promise<Response> {
         const instance = this.encryptPassword(encryptionKey);
         let toSave;
-        if (!!instance.data.id) {
+        if (instance.data.id) {
             toSave = instance.data;
             await instance.remove(d2);
         } else {
@@ -138,7 +142,7 @@ export default class Instance {
             (inst: Data) => [inst.url, inst.username].join("-") === combination
         );
         let invalid;
-        if (!!id) {
+        if (id) {
             invalid = invalidCombinations.some((inst: Data) => inst.id !== id);
         } else {
             invalid = !_.isEmpty(invalidCombinations);

--- a/src/themes/dhis2-legacy.theme.js
+++ b/src/themes/dhis2-legacy.theme.js
@@ -1,11 +1,21 @@
-import { cyan500, cyan700, cyan100, orange500, grey100, darkBlack, white, grey500, grey400 } from 'material-ui/styles/colors';
-import { fade } from 'material-ui/utils/colorManipulator';
-import Spacing from 'material-ui/styles/spacing';
-import getMuiTheme from 'material-ui/styles/getMuiTheme';
+import {
+    cyan500,
+    cyan700,
+    cyan100,
+    orange500,
+    grey100,
+    darkBlack,
+    white,
+    grey500,
+    grey400,
+} from "material-ui/styles/colors";
+import { fade } from "material-ui/utils/colorManipulator";
+import Spacing from "material-ui/styles/spacing";
+import getMuiTheme from "material-ui/styles/getMuiTheme";
 
 const theme = {
     spacing: Spacing,
-    fontFamily: 'Roboto, sans-serif',
+    fontFamily: "Roboto, sans-serif",
     palette: {
         primary1Color: cyan500,
         primary2Color: cyan700,
@@ -24,12 +34,12 @@ const theme = {
 function createAppTheme(style) {
     return {
         sideBar: {
-            backgroundColor: '#F3F3F3',
-            backgroundColorItem: 'transparent',
+            backgroundColor: "#F3F3F3",
+            backgroundColorItem: "transparent",
             backgroundColorItemActive: style.palette.accent2Color,
             textColor: style.palette.textColor,
-            textColorActive: '#276696',
-            borderStyle: '1px solid #e1e1e1',
+            textColorActive: "#276696",
+            borderStyle: "1px solid #e1e1e1",
         },
         forms: {
             minWidth: 350,
@@ -39,9 +49,9 @@ function createAppTheme(style) {
             secondaryColor: style.palette.accent4Color,
         },
         tabs: {
-            backgroundColor: '#E4E4E4',
+            backgroundColor: "#E4E4E4",
             inkBarColor: style.palette.accent1Color,
-            textColor: '#666666',
+            textColor: "#666666",
         },
     };
 }

--- a/src/themes/dhis2-legacy.theme.js
+++ b/src/themes/dhis2-legacy.theme.js
@@ -1,0 +1,52 @@
+import { cyan500, cyan700, cyan100, orange500, grey100, darkBlack, white, grey500, grey400 } from 'material-ui/styles/colors';
+import { fade } from 'material-ui/utils/colorManipulator';
+import Spacing from 'material-ui/styles/spacing';
+import getMuiTheme from 'material-ui/styles/getMuiTheme';
+
+const theme = {
+    spacing: Spacing,
+    fontFamily: 'Roboto, sans-serif',
+    palette: {
+        primary1Color: cyan500,
+        primary2Color: cyan700,
+        primary3Color: cyan100,
+        accent1Color: orange500,
+        accent2Color: grey100,
+        accent3Color: grey500,
+        textColor: darkBlack,
+        alternateTextColor: white,
+        canvasColor: white,
+        borderColor: grey400,
+        disabledColor: fade(darkBlack, 0.3),
+    },
+};
+
+function createAppTheme(style) {
+    return {
+        sideBar: {
+            backgroundColor: '#F3F3F3',
+            backgroundColorItem: 'transparent',
+            backgroundColorItemActive: style.palette.accent2Color,
+            textColor: style.palette.textColor,
+            textColorActive: '#276696',
+            borderStyle: '1px solid #e1e1e1',
+        },
+        forms: {
+            minWidth: 350,
+            maxWidth: 900,
+        },
+        formFields: {
+            secondaryColor: style.palette.accent4Color,
+        },
+        tabs: {
+            backgroundColor: '#E4E4E4',
+            inkBarColor: style.palette.accent1Color,
+            textColor: '#666666',
+        },
+    };
+}
+
+const muiTheme = getMuiTheme(theme);
+const appTheme = createAppTheme(muiTheme);
+
+export default Object.assign({}, muiTheme, appTheme);

--- a/src/themes/dhis2.theme.js
+++ b/src/themes/dhis2.theme.js
@@ -1,4 +1,4 @@
-import { createMuiTheme } from "@material-ui/core/styles/index";
+import { createMuiTheme } from "@material-ui/core/styles";
 
 // Color palette from https://projects.invisionapp.com/share/A7LT4TJYETS#/screens/302550228_Color
 export const colors = {

--- a/src/themes/dhis2.theme.js
+++ b/src/themes/dhis2.theme.js
@@ -1,4 +1,4 @@
-import { createMuiTheme } from "@material-ui/core/styles";
+import { createMuiTheme } from "@material-ui/core/styles/index";
 
 // Color palette from https://projects.invisionapp.com/share/A7LT4TJYETS#/screens/302550228_Color
 export const colors = {

--- a/src/types/synchronization.d.ts
+++ b/src/types/synchronization.d.ts
@@ -1,7 +1,5 @@
-import Instance from "../models/instance";
-
 export interface SynchronizationBuilder {
-    targetInstances: Instance[];
+    targetInstances: string[];
     metadata: {
         [metadataType: string]: string[];
     };

--- a/src/utils/testing.js
+++ b/src/utils/testing.js
@@ -9,6 +9,7 @@ import { MuiThemeProvider } from "@material-ui/core/styles";
 import { SnackbarProvider } from "d2-ui-components";
 
 import { muiTheme } from "../themes/dhis2.theme";
+import muiThemeLegacy from "../themes/dhis2-legacy.theme";
 
 // DHIS2 expects a browser environment, add some required keys to the global node namespace
 Object.assign(global, {
@@ -19,7 +20,7 @@ Object.assign(global, {
 export function mount(component) {
     const wrappedComponent = enzymeMount(
         <MuiThemeProvider theme={muiTheme}>
-            <OldMuiThemeProvider>
+            <OldMuiThemeProvider muiTheme={muiThemeLegacy}>
                 <SnackbarProvider>{component}</SnackbarProvider>
             </OldMuiThemeProvider>
         </MuiThemeProvider>

--- a/src/utils/testing.js
+++ b/src/utils/testing.js
@@ -8,7 +8,7 @@ import OldMuiThemeProvider from "material-ui/styles/MuiThemeProvider";
 import { MuiThemeProvider } from "@material-ui/core/styles";
 import { SnackbarProvider } from "d2-ui-components";
 
-import { muiTheme } from "../dhis2.theme";
+import { muiTheme } from "../themes/dhis2.theme";
 
 // DHIS2 expects a browser environment, add some required keys to the global node namespace
 Object.assign(global, {


### PR DESCRIPTION
### :pushpin: References

* **Issue:** Closes #40 

### :memo: Implementation

- Add LoadingProvider to the root app.

- Add a new SyncDialog that handles the synchronization state.

- Allow getting data by id from dataStore.

### 💻 Pending tasks

- Add a summary to the SyncDialog of the metadata objects (we need to decide how to output or if we leave this for Milestone 2).

- Verify extreme cases, no instances selected, no metadata selected and add message through snackbar.

### :art: Screenshots

![image](https://user-images.githubusercontent.com/2181866/55104441-a6966200-50ca-11e9-9e1c-d5b7152f0e1d.png)

![image](https://user-images.githubusercontent.com/2181866/55104477-b01fca00-50ca-11e9-9284-192ef1a9de2e.png)

![image](https://user-images.githubusercontent.com/2181866/55104999-c5492880-50cb-11e9-8626-d72cca6de900.png)

![image](https://user-images.githubusercontent.com/2181866/55105004-cb3f0980-50cb-11e9-95be-a7770f28dfc0.png)

### :fire: Is there anything the reviewer should know to test it?

- https://github.com/EyeSeeTea/d2-ui-components/pull/20

- https://github.com/EyeSeeTea/d2-ui-components/pull/23

### :bookmark_tabs: Others

- Do not merge until d2-ui-components is published and package.json is updated.

- The branch depends on other branches that are not ready to merge either.
