### PR TITLE
Sync Summary Details

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2019-04-05T05:45:57.297Z\n"
-"PO-Revision-Date: 2019-04-05T05:45:57.297Z\n"
+"POT-Creation-Date: 2019-04-05T13:42:14.932Z\n"
+"PO-Revision-Date: 2019-04-05T13:42:14.932Z\n"
 
 msgid "Metadata Synchronization"
 msgstr ""
@@ -195,6 +195,18 @@ msgid "Message"
 msgstr ""
 
 msgid "Synchronization Results"
+msgstr ""
+
+msgid "Status"
+msgstr ""
+
+msgid "Summary"
+msgstr ""
+
+msgid "Messages"
+msgstr ""
+
+msgid "JSON Response"
 msgstr ""
 
 msgid "Field {{field}} cannot be blank"

--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2019-04-02T10:50:26.607Z\n"
-"PO-Revision-Date: 2019-04-02T10:50:26.607Z\n"
+"POT-Creation-Date: 2019-04-05T05:45:57.297Z\n"
+"PO-Revision-Date: 2019-04-05T05:45:57.297Z\n"
 
 msgid "Metadata Synchronization"
 msgstr ""
@@ -165,6 +165,33 @@ msgid "Synchronize Metadata"
 msgstr ""
 
 msgid "Synchronize"
+msgstr ""
+
+msgid "Type"
+msgstr ""
+
+msgid "Created"
+msgstr ""
+
+msgid "Deleted"
+msgstr ""
+
+msgid "Ignored"
+msgstr ""
+
+msgid "Updated"
+msgstr ""
+
+msgid "Total"
+msgstr ""
+
+msgid "Identifier"
+msgstr ""
+
+msgid "Property"
+msgstr ""
+
+msgid "Message"
 msgstr ""
 
 msgid "Synchronization Results"

--- a/src/components/shared/Dropdown.jsx
+++ b/src/components/shared/Dropdown.jsx
@@ -73,5 +73,5 @@ Dropdown.propTypes = {
     items: PropTypes.array.isRequired,
     value: PropTypes.string.isRequired,
     onChange: PropTypes.func.isRequired,
-    placeholder: PropTypes.string.isRequired,
+    label: PropTypes.string.isRequired,
 };

--- a/src/components/sync-configurator/BaseSyncConfigurator.jsx
+++ b/src/components/sync-configurator/BaseSyncConfigurator.jsx
@@ -173,4 +173,4 @@ class BaseSyncConfigurator extends React.Component {
     }
 }
 
-export default withRouter(withSnackbar(withStyles(styles)(BaseSyncConfigurator)));
+export default withSnackbar(withRouter(withStyles(styles)(BaseSyncConfigurator)));

--- a/src/components/sync-summary/SyncSummary.jsx
+++ b/src/components/sync-summary/SyncSummary.jsx
@@ -2,13 +2,38 @@ import React from "react";
 import i18n from "@dhis2/d2-i18n";
 import PropTypes from "prop-types";
 import { ConfirmationDialog } from "d2-ui-components";
+import ReactJson from "react-json-view";
+
+import { withStyles } from "@material-ui/core";
+import Table from "@material-ui/core/Table";
+import TableHead from "@material-ui/core/TableHead";
+import TableRow from "@material-ui/core/TableRow";
+import TableCell from "@material-ui/core/TableCell";
+import TableBody from "@material-ui/core/TableBody";
 import DialogContent from "@material-ui/core/DialogContent";
 import ExpansionPanel from "@material-ui/core/ExpansionPanel";
 import ExpansionPanelSummary from "@material-ui/core/ExpansionPanelSummary";
 import Typography from "@material-ui/core/Typography";
 import ExpansionPanelDetails from "@material-ui/core/ExpansionPanelDetails";
 import ExpandMoreIcon from "@material-ui/icons/ExpandMore";
-import ReactJson from "react-json-view";
+
+const styles = theme => ({
+    expansionPanelHeading1: {
+        fontSize: theme.typography.pxToRem(15),
+        flexBasis: "55%",
+        flexShrink: 0,
+    },
+    expansionPanelHeading2: {
+        fontSize: theme.typography.pxToRem(15),
+        color: theme.palette.text.secondary,
+    },
+    expansionPanelDetails: {
+        padding: "4px 24px 4px",
+    },
+    expansionPanel: {
+        paddingBottom: "10px",
+    },
+});
 
 class SyncSummary extends React.Component {
     static propTypes = {
@@ -21,8 +46,62 @@ class SyncSummary extends React.Component {
         this.props.handleClose();
     };
 
+    static buildSummaryTable(stats) {
+        return (
+            <Table padding={"dense"}>
+                <TableHead>
+                    <TableRow>
+                        <TableCell>{i18n.t("Type")}</TableCell>
+                        <TableCell>{i18n.t("Created")}</TableCell>
+                        <TableCell>{i18n.t("Deleted")}</TableCell>
+                        <TableCell>{i18n.t("Ignored")}</TableCell>
+                        <TableCell>{i18n.t("Updated")}</TableCell>
+                        <TableCell>{i18n.t("Total")}</TableCell>
+                    </TableRow>
+                </TableHead>
+                <TableBody>
+                    {stats.map(({ type, created, deleted, ignored, updated, total }, i) => (
+                        <TableRow key={`row-${i}`}>
+                            <TableCell>{type}</TableCell>
+                            <TableCell>{created}</TableCell>
+                            <TableCell>{deleted}</TableCell>
+                            <TableCell>{ignored}</TableCell>
+                            <TableCell>{updated}</TableCell>
+                            <TableCell>{total}</TableCell>
+                        </TableRow>
+                    ))}
+                </TableBody>
+            </Table>
+        );
+    }
+
+    static buildMessageTable(messages) {
+        return (
+            <Table padding={"dense"}>
+                <TableHead>
+                    <TableRow>
+                        <TableCell>{i18n.t("Identifier")}</TableCell>
+                        <TableCell>{i18n.t("Type")}</TableCell>
+                        <TableCell>{i18n.t("Property")}</TableCell>
+                        <TableCell>{i18n.t("Message")}</TableCell>
+                    </TableRow>
+                </TableHead>
+                <TableBody>
+                    {messages.map(({ uid, type, property, message }, i) => (
+                        <TableRow key={`row-${i}`}>
+                            <TableCell>{uid}</TableCell>
+                            <TableCell>{type}</TableCell>
+                            <TableCell>{property}</TableCell>
+                            <TableCell>{message}</TableCell>
+                        </TableRow>
+                    ))}
+                </TableBody>
+            </Table>
+        );
+    }
+
     render() {
-        const { isOpen, response } = this.props;
+        const { isOpen, response, classes } = this.props;
 
         return (
             <React.Fragment>
@@ -35,10 +114,60 @@ class SyncSummary extends React.Component {
                     fullWidth={true}
                 >
                     <DialogContent>
-                        <ExpansionPanel defaultExpanded>
+                        {response.map((responseElement, i) => (
+                            <ExpansionPanel
+                                defaultExpanded={response.length === 1}
+                                className={classes.expansionPanel}
+                                key={`row-${i}`}
+                            >
+                                <ExpansionPanelSummary expandIcon={<ExpandMoreIcon />}>
+                                    <Typography className={classes.expansionPanelHeading1}>
+                                        {`${responseElement.instance.name} (${
+                                            responseElement.instance.url
+                                        })`}
+                                    </Typography>
+                                    <Typography className={classes.expansionPanelHeading2}>
+                                        {`Status: ${responseElement.status}`}
+                                    </Typography>
+                                </ExpansionPanelSummary>
+
+                                <ExpansionPanelDetails className={classes.expansionPanelDetails}>
+                                    <Typography variant={"overline"}>Summary</Typography>
+                                </ExpansionPanelDetails>
+
+                                <ExpansionPanelDetails className={classes.expansionPanelDetails}>
+                                    {SyncSummary.buildSummaryTable([
+                                        ...responseElement.report.typeStats,
+                                        { type: "Total", ...responseElement.stats },
+                                    ])}
+                                </ExpansionPanelDetails>
+
+                                {responseElement.report.messages.length > 0 && (
+                                    <div>
+                                        <ExpansionPanelDetails
+                                            className={classes.expansionPanelDetails}
+                                        >
+                                            <Typography variant={"overline"}>Messages</Typography>
+                                        </ExpansionPanelDetails>
+                                        <ExpansionPanelDetails
+                                            className={classes.expansionPanelDetails}
+                                        >
+                                            {SyncSummary.buildMessageTable(
+                                                responseElement.report.messages
+                                            )}
+                                        </ExpansionPanelDetails>
+                                    </div>
+                                )}
+                            </ExpansionPanel>
+                        ))}
+
+                        <ExpansionPanel defaultExpanded={response.length === 0}>
                             <ExpansionPanelSummary expandIcon={<ExpandMoreIcon />}>
-                                <Typography>JSON Response</Typography>
+                                <Typography className={classes.expansionPanelHeading1}>
+                                    JSON Response
+                                </Typography>
                             </ExpansionPanelSummary>
+
                             <ExpansionPanelDetails>
                                 <ReactJson src={response} collapsed={2} enableClipboard={false} />
                             </ExpansionPanelDetails>
@@ -50,4 +179,4 @@ class SyncSummary extends React.Component {
     }
 }
 
-export default SyncSummary;
+export default withStyles(styles)(SyncSummary);

--- a/src/components/sync-summary/SyncSummary.jsx
+++ b/src/components/sync-summary/SyncSummary.jsx
@@ -161,7 +161,7 @@ class SyncSummary extends React.Component {
                             </ExpansionPanel>
                         ))}
 
-                        <ExpansionPanel defaultExpanded={response.length === 0}>
+                        <ExpansionPanel>
                             <ExpansionPanelSummary expandIcon={<ExpandMoreIcon />}>
                                 <Typography className={classes.expansionPanelHeading1}>
                                     JSON Response

--- a/src/components/sync-summary/SyncSummary.jsx
+++ b/src/components/sync-summary/SyncSummary.jsx
@@ -4,17 +4,19 @@ import PropTypes from "prop-types";
 import { ConfirmationDialog } from "d2-ui-components";
 import ReactJson from "react-json-view";
 
-import { withStyles } from "@material-ui/core";
-import Table from "@material-ui/core/Table";
-import TableHead from "@material-ui/core/TableHead";
-import TableRow from "@material-ui/core/TableRow";
-import TableCell from "@material-ui/core/TableCell";
-import TableBody from "@material-ui/core/TableBody";
-import DialogContent from "@material-ui/core/DialogContent";
-import ExpansionPanel from "@material-ui/core/ExpansionPanel";
-import ExpansionPanelSummary from "@material-ui/core/ExpansionPanelSummary";
-import Typography from "@material-ui/core/Typography";
-import ExpansionPanelDetails from "@material-ui/core/ExpansionPanelDetails";
+import {
+    withStyles,
+    Table,
+    TableHead,
+    TableRow,
+    TableCell,
+    TableBody,
+    DialogContent,
+    ExpansionPanel,
+    ExpansionPanelSummary,
+    ExpansionPanelDetails,
+    Typography,
+} from "@material-ui/core";
 import ExpandMoreIcon from "@material-ui/icons/ExpandMore";
 
 const styles = theme => ({
@@ -127,18 +129,18 @@ class SyncSummary extends React.Component {
                                         })`}
                                     </Typography>
                                     <Typography className={classes.expansionPanelHeading2}>
-                                        {`Status: ${responseElement.status}`}
+                                        {`${i18n.t("Status")}: ${responseElement.status}`}
                                     </Typography>
                                 </ExpansionPanelSummary>
 
                                 <ExpansionPanelDetails className={classes.expansionPanelDetails}>
-                                    <Typography variant={"overline"}>Summary</Typography>
+                                    <Typography variant="overline">{i18n.t("Summary")}</Typography>
                                 </ExpansionPanelDetails>
 
                                 <ExpansionPanelDetails className={classes.expansionPanelDetails}>
                                     {SyncSummary.buildSummaryTable([
                                         ...responseElement.report.typeStats,
-                                        { type: "Total", ...responseElement.stats },
+                                        { type: i18n.t("Total"), ...responseElement.stats },
                                     ])}
                                 </ExpansionPanelDetails>
 
@@ -147,7 +149,9 @@ class SyncSummary extends React.Component {
                                         <ExpansionPanelDetails
                                             className={classes.expansionPanelDetails}
                                         >
-                                            <Typography variant={"overline"}>Messages</Typography>
+                                            <Typography variant="overline">
+                                                {i18n.t("Messages")}
+                                            </Typography>
                                         </ExpansionPanelDetails>
                                         <ExpansionPanelDetails
                                             className={classes.expansionPanelDetails}
@@ -164,7 +168,7 @@ class SyncSummary extends React.Component {
                         <ExpansionPanel>
                             <ExpansionPanelSummary expandIcon={<ExpandMoreIcon />}>
                                 <Typography className={classes.expansionPanelHeading1}>
-                                    JSON Response
+                                    {i18n.t("JSON Response")}
                                 </Typography>
                             </ExpansionPanelSummary>
 

--- a/src/logic/synchronization.ts
+++ b/src/logic/synchronization.ts
@@ -19,7 +19,7 @@ import {
     getMetadata,
     postMetadata,
 } from "../utils/synchronization";
-import {getClassName} from "../utils/d2";
+import { getClassName } from "../utils/d2";
 
 async function exportMetadata(d2: D2, builder: ExportBuilder): Promise<MetadataPackage> {
     const { type, ids, excludeRules, includeRules } = builder;
@@ -78,7 +78,7 @@ async function importMetadata(
 
     if (importResult.data.typeReports) {
         importResult.data.typeReports.forEach((report: any) => {
-            const {klass, stats, objectReports = []} = report;
+            const { klass, stats, objectReports = [] } = report;
 
             typeStats.push({
                 ...stats,
@@ -86,14 +86,16 @@ async function importMetadata(
             });
 
             objectReports.forEach((detail: any) => {
-                const {uid, errorReports = []} = detail;
+                const { uid, errorReports = [] } = detail;
 
-                messages.push(...errorReports.map((error: any) => ({
-                    uid,
-                    type: getClassName(error.mainKlass),
-                    property: error.errorProperty,
-                    message: error.message,
-                })));
+                messages.push(
+                    ...errorReports.map((error: any) => ({
+                        uid,
+                        type: getClassName(error.mainKlass),
+                        property: error.errorProperty,
+                        message: error.message,
+                    }))
+                );
             });
         });
     }
@@ -101,7 +103,7 @@ async function importMetadata(
     return {
         ...importResult.data,
         instance: _.pick(instance, ["id", "name", "url"]),
-        report: { typeStats, messages }
+        report: { typeStats, messages },
     };
 }
 

--- a/src/logic/synchronization.ts
+++ b/src/logic/synchronization.ts
@@ -19,6 +19,7 @@ import {
     getMetadata,
     postMetadata,
 } from "../utils/synchronization";
+import {getClassName} from "../utils/d2";
 
 async function exportMetadata(d2: D2, builder: ExportBuilder): Promise<MetadataPackage> {
     const { type, ids, excludeRules, includeRules } = builder;
@@ -72,11 +73,35 @@ async function importMetadata(
     const decryptedInstance = instance.decryptPassword(encryptionKey);
     const importResult = await postMetadata(decryptedInstance, metadataPackage);
 
-    // TODO: Update the logger
+    const typeStats: any[] = [];
+    const messages: any[] = [];
+
+    if (importResult.data.typeReports) {
+        importResult.data.typeReports.forEach((report: any) => {
+            const {klass, stats, objectReports = []} = report;
+
+            typeStats.push({
+                ...stats,
+                type: getClassName(klass),
+            });
+
+            objectReports.forEach((detail: any) => {
+                const {uid, errorReports = []} = detail;
+
+                messages.push(...errorReports.map((error: any) => ({
+                    uid,
+                    type: getClassName(error.mainKlass),
+                    property: error.errorProperty,
+                    message: error.message,
+                })));
+            });
+        });
+    }
 
     return {
         ...importResult.data,
         instance: _.pick(instance, ["id", "name", "url"]),
+        report: { typeStats, messages }
     };
 }
 

--- a/src/types/synchronization.d.ts
+++ b/src/types/synchronization.d.ts
@@ -24,6 +24,10 @@ export interface SynchronizationResult extends MetadataImportResponse {
         name: string;
         url: string;
     };
+    report: {
+        typeStats: any[];
+        messages: any[];
+    };
 }
 
 export interface NestedRules {

--- a/src/utils/d2.ts
+++ b/src/utils/d2.ts
@@ -60,5 +60,5 @@ export function cleanModelName(d2: D2, id: string, caller: string): string | nul
 }
 
 export function getClassName(className: string): string {
-    return className.substr(className.lastIndexOf('.') + 1);
+    return className.substr(className.lastIndexOf(".") + 1);
 }

--- a/src/utils/d2.ts
+++ b/src/utils/d2.ts
@@ -59,6 +59,8 @@ export function cleanModelName(d2: D2, id: string, caller: string): string | nul
     }
 }
 
-export function getClassName(className: string): string {
-    return className.substr(className.lastIndexOf(".") + 1);
+export function getClassName(className: string): string | undefined {
+    return _(className)
+        .split(".")
+        .last();
 }

--- a/src/utils/d2.ts
+++ b/src/utils/d2.ts
@@ -58,3 +58,7 @@ export function cleanModelName(d2: D2, id: string, caller: string): string | nul
         return null;
     }
 }
+
+export function getClassName(className: string): string {
+    return className.substr(className.lastIndexOf('.') + 1);
+}

--- a/src/utils/synchronization.ts
+++ b/src/utils/synchronization.ts
@@ -71,6 +71,8 @@ export async function postMetadata(instance: Instance, metadata: any): Promise<a
     } catch (error) {
         if (error.response) {
             return error.response;
+        } else if (error.request) {
+            return { data: { status: "NETWORK ERROR" }};
         } else {
             throw error;
         }

--- a/src/utils/synchronization.ts
+++ b/src/utils/synchronization.ts
@@ -72,7 +72,7 @@ export async function postMetadata(instance: Instance, metadata: any): Promise<a
         if (error.response) {
             return error.response;
         } else if (error.request) {
-            return { data: { status: "NETWORK ERROR" }};
+            return { data: { status: "NETWORK ERROR" } };
         } else {
             throw error;
         }


### PR DESCRIPTION
### :pushpin: References

* **Issue:** Closes #42 

### :memo: Implementation

- Added the main logic from the import-export-app for reporting.

- Improved the import-export-app UI into material-ui tables.

- Collapsed all when more than one instance involved.

- Solved "Warning contextType"

- Solved "Network error causing to finish sync"

- Solved "Dropdown label was not defined"

### :art: Screenshots

![image](https://user-images.githubusercontent.com/2181866/55606701-259a3300-577a-11e9-97fd-cb0284b85eee.png)

![image](https://user-images.githubusercontent.com/2181866/55606735-3f3b7a80-577a-11e9-842c-8f590e034f3c.png)

![image](https://user-images.githubusercontent.com/2181866/55606767-5b3f1c00-577a-11e9-9fd4-9064f4a23353.png)

![image](https://user-images.githubusercontent.com/2181866/55606748-495d7900-577a-11e9-8b1f-988918cc7c46.png)

![image](https://user-images.githubusercontent.com/2181866/55606756-511d1d80-577a-11e9-8fc2-0a9870193c9e.png)

### :fire: Is there anything the reviewer should know to test it?

- The two tables generated might be combined later into a parametric single method.

- History page (logger) should be moved from #42 into its own card