### PR TITLE
Add OU Level Filter and improve OU Group Filter

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2019-04-05T13:42:14.932Z\n"
-"PO-Revision-Date: 2019-04-05T13:42:14.932Z\n"
+"POT-Creation-Date: 2019-04-08T05:39:48.858Z\n"
+"PO-Revision-Date: 2019-04-08T05:39:48.858Z\n"
 
 msgid "Metadata Synchronization"
 msgstr ""
@@ -149,7 +149,10 @@ msgstr ""
 msgid "Indicators Synchronization"
 msgstr ""
 
-msgid "Organisation Unit Group"
+msgid "Organisation Group"
+msgstr ""
+
+msgid "Organisation Level"
 msgstr ""
 
 msgid "Organisation Units Synchronization"

--- a/src/components/shared/Dropdown.jsx
+++ b/src/components/shared/Dropdown.jsx
@@ -71,7 +71,10 @@ export default function Dropdown({ items, value, onChange, label }) {
 
 Dropdown.propTypes = {
     items: PropTypes.array.isRequired,
-    value: PropTypes.string.isRequired,
     onChange: PropTypes.func.isRequired,
     label: PropTypes.string.isRequired,
+    value:  PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.number
+    ]).isRequired,
 };

--- a/src/components/sync-configurator/OrganisationUnitSync.jsx
+++ b/src/components/sync-configurator/OrganisationUnitSync.jsx
@@ -1,9 +1,11 @@
 import React from "react";
-import BaseSyncConfigurator from "./BaseSyncConfigurator";
 import PropTypes from "prop-types";
 import i18n from "@dhis2/d2-i18n";
-import { OrganisationUnitModel } from "../../models/d2Model";
+
 import Dropdown from "../shared/Dropdown";
+import BaseSyncConfigurator from "./BaseSyncConfigurator";
+import { OrganisationUnitModel } from "../../models/d2Model";
+import { d2ModelFactory } from "../../models/d2ModelFactory";
 
 export default class OrganisationUnitSync extends React.Component {
     static propTypes = {
@@ -15,6 +17,10 @@ export default class OrganisationUnitSync extends React.Component {
             value: "",
             items: [],
         },
+        orgUnitLevelFilter: {
+            value: "",
+            items: [],
+        },
     };
 
     componentDidMount() {
@@ -22,36 +28,74 @@ export default class OrganisationUnitSync extends React.Component {
     }
 
     getDropdownData = async () => {
-        const orgUnitGroups = await OrganisationUnitModel.getOrgUnitGroups(this.props.d2);
-        const { value } = this.state.orgUnitGroupFilter;
-        this.setState({ orgUnitGroupFilter: { value, items: orgUnitGroups } });
+        const { d2 } = this.props;
+
+        const orgUnitGroupsClass = d2ModelFactory(d2, "organisationUnitGroups");
+        const orgUnitGroupList = await orgUnitGroupsClass.listMethod(
+            d2,
+            { customFields: ["id", "name"] },
+            { paging: false }
+        );
+        const orgUnitGroups = orgUnitGroupList.objects;
+        const orgUnitGroupFilter = { ...this.state.orgUnitGroupFilter, items: orgUnitGroups };
+
+        const orgUnitLevelsClass = d2ModelFactory(d2, "organisationUnitLevels");
+        const orgUnitLevelsList = await orgUnitLevelsClass.listMethod(
+            d2,
+            { customFields: ["level", "name"] },
+            { paging: false, sorting: ["level", "asc"] }
+        );
+        const orgUnitLevels = orgUnitLevelsList.objects.map(e => ({
+            id: e.level,
+            name: `${e.level}. ${e.name}`,
+        }));
+        const orgUnitLevelFilter = { ...this.state.orgUnitGroupFilter, items: orgUnitLevels };
+
+        this.setState({ orgUnitGroupFilter, orgUnitLevelFilter });
     };
 
-    handleFilterChange = event => {
+    handleGroupFilterChange = event => {
         const { items } = this.state.orgUnitGroupFilter;
         this.setState({ orgUnitGroupFilter: { value: event.target.value, items } });
     };
 
+    handleLevelFilterChange = event => {
+        const { items } = this.state.orgUnitLevelFilter;
+        this.setState({ orgUnitLevelFilter: { value: event.target.value, items } });
+    };
+
     renderExtraFilters = () => {
-        const { items, value } = this.state.orgUnitGroupFilter;
-        return (
+        const { orgUnitGroupFilter, orgUnitLevelFilter } = this.state;
+        return [
             <Dropdown
-                items={items}
-                onChange={this.handleFilterChange}
-                value={value}
-                label={i18n.t("Organisation Unit Group")}
-            />
-        );
+                items={orgUnitGroupFilter.items}
+                onChange={this.handleGroupFilterChange}
+                value={orgUnitGroupFilter.value}
+                label={i18n.t("Organisation Group")}
+            />,
+
+            <Dropdown
+                items={orgUnitLevelFilter.items}
+                onChange={this.handleLevelFilterChange}
+                value={orgUnitLevelFilter.value}
+                label={i18n.t("Organisation Level")}
+            />,
+        ];
     };
 
     render() {
+        const { orgUnitGroupFilter, orgUnitLevelFilter } = this.state;
         const title = i18n.t("Organisation Units Synchronization");
+
         return (
             <BaseSyncConfigurator
                 model={OrganisationUnitModel}
                 title={title}
                 renderExtraFilters={this.renderExtraFilters}
-                extraFiltersState={{ orgUnitGroup: this.state.orgUnitGroupFilter.value }}
+                extraFiltersState={{
+                    orgUnitGroup: orgUnitGroupFilter.value,
+                    orgUnitLevel: orgUnitLevelFilter.value,
+                }}
                 {...this.props}
             />
         );

--- a/src/components/sync-configurator/OrganisationUnitSync.jsx
+++ b/src/components/sync-configurator/OrganisationUnitSync.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import i18n from "@dhis2/d2-i18n";
+import memoize from "nano-memoize";
 
 import Dropdown from "../shared/Dropdown";
 import BaseSyncConfigurator from "./BaseSyncConfigurator";
@@ -22,6 +23,11 @@ export default class OrganisationUnitSync extends React.Component {
             items: [],
         },
     };
+
+    getExtraFilterState = memoize((orgUnitGroupFilterValue, orgUnitLevelFilterValue) => ({
+        orgUnitGroup: orgUnitGroupFilterValue,
+        orgUnitLevel: orgUnitLevelFilterValue,
+    }));
 
     componentDidMount() {
         this.getDropdownData();
@@ -88,16 +94,17 @@ export default class OrganisationUnitSync extends React.Component {
     render() {
         const { orgUnitGroupFilter, orgUnitLevelFilter } = this.state;
         const title = i18n.t("Organisation Units Synchronization");
+        const extraFiltersState = this.getExtraFilterState(
+            orgUnitGroupFilter.value,
+            orgUnitLevelFilter.value
+        );
 
         return (
             <BaseSyncConfigurator
                 model={OrganisationUnitModel}
                 title={title}
                 renderExtraFilters={this.renderExtraFilters}
-                extraFiltersState={{
-                    orgUnitGroup: orgUnitGroupFilter.value,
-                    orgUnitLevel: orgUnitLevelFilter.value,
-                }}
+                extraFiltersState={extraFiltersState}
                 {...this.props}
             />
         );

--- a/src/components/sync-configurator/OrganisationUnitSync.jsx
+++ b/src/components/sync-configurator/OrganisationUnitSync.jsx
@@ -68,6 +68,7 @@ export default class OrganisationUnitSync extends React.Component {
         const { orgUnitGroupFilter, orgUnitLevelFilter } = this.state;
         return [
             <Dropdown
+                key={"group-filter"}
                 items={orgUnitGroupFilter.items}
                 onChange={this.handleGroupFilterChange}
                 value={orgUnitGroupFilter.value}
@@ -75,6 +76,7 @@ export default class OrganisationUnitSync extends React.Component {
             />,
 
             <Dropdown
+                key={"level-filter"}
                 items={orgUnitLevelFilter.items}
                 onChange={this.handleLevelFilterChange}
                 value={orgUnitLevelFilter.value}

--- a/src/models/d2Model.ts
+++ b/src/models/d2Model.ts
@@ -6,7 +6,13 @@ import {
     organisationUnitsColumns,
     organisationUnitsDetails,
 } from "../utils/d2";
-import { TableFilters, TableLabel, TableList, TablePagination } from "../types/d2-ui-components";
+import {
+    OrganisationUnitTableFilters,
+    TableFilters,
+    TableLabel,
+    TableList,
+    TablePagination,
+} from "../types/d2-ui-components";
 import { D2, ModelDefinition } from "../types/d2";
 
 export abstract class D2Model {
@@ -26,22 +32,24 @@ export abstract class D2Model {
         filters: TableFilters,
         pagination: TablePagination
     ): Promise<TableList> {
-        const { search = null, lastUpdatedDate = null, d2Filters = [] } = filters || {};
-        const { page = 1, pageSize = 20, sorting = this.initialSorting } = pagination || {};
+        const { search = null, lastUpdatedDate = null, customFilters = [], customFields = [] } =
+            filters || {};
+        const { page = 1, pageSize = 20, sorting = this.initialSorting, paging = true } =
+            pagination || {};
 
         const details = this.details.map(e => e.name);
         const columns = this.columns.map(e => e.name);
-        const fields = _.union(details, columns);
+        const fields = _.union(details, columns, customFields);
 
         const [field, direction] = sorting;
         const order = `${field}:i${direction}`;
         const filter = _.compact([
             search ? `displayName:ilike:${search}` : null,
             lastUpdatedDate ? `lastUpdated:ge:${lastUpdatedDate.toISOString()}` : null,
-            ...d2Filters,
+            ...customFilters,
         ]);
 
-        const listParams = cleanParams({ fields, filter, page, pageSize, order });
+        const listParams = cleanParams({ fields, filter, page, pageSize, order, paging });
         const collection = await this.getD2Model(d2).list(listParams);
         return { pager: collection.pager, objects: collection.toArray() };
     }
@@ -102,21 +110,18 @@ export class OrganisationUnitModel extends D2Model {
     protected static columns = organisationUnitsColumns;
     protected static details = organisationUnitsDetails;
 
-    public static async getOrgUnitGroups(d2: D2) {
-        const fields = ["id", "displayName"];
-        const groups = await d2.models.organisationUnitGroup.list({ fields });
-        return _.map(groups.toArray(), g => ({ id: g.id, name: g.displayName }));
-    }
-
     public static async listMethod(
         d2: D2,
-        filters: TableFilters,
+        filters: OrganisationUnitTableFilters,
         pagination: TablePagination
     ): Promise<TableList> {
-        const { orgUnitGroup = null } = filters || {};
+        const { orgUnitGroup = null, orgUnitLevel = null } = filters || {};
         const newFilters = {
             ...filters,
-            d2Filters: [orgUnitGroup ? `organisationUnitGroups.id:eq:${orgUnitGroup}` : null],
+            customFilters: [
+                orgUnitGroup ? `organisationUnitGroups.id:eq:${orgUnitGroup}` : null,
+                orgUnitLevel ? `level:eq:${orgUnitLevel}` : null,
+            ],
         };
         return await super.listMethod(d2, newFilters, pagination);
     }

--- a/src/models/d2Model.ts
+++ b/src/models/d2Model.ts
@@ -118,10 +118,10 @@ export class OrganisationUnitModel extends D2Model {
         const { orgUnitGroup = null, orgUnitLevel = null } = filters || {};
         const newFilters = {
             ...filters,
-            customFilters: [
+            customFilters: _.compact([
                 orgUnitGroup ? `organisationUnitGroups.id:eq:${orgUnitGroup}` : null,
                 orgUnitLevel ? `level:eq:${orgUnitLevel}` : null,
-            ],
+            ]),
         };
         return await super.listMethod(d2, newFilters, pagination);
     }

--- a/src/types/d2-ui-components.d.ts
+++ b/src/types/d2-ui-components.d.ts
@@ -10,16 +10,22 @@ export interface TableList {
 }
 
 export interface TableFilters {
-    search: string;
+    search?: string;
     lastUpdatedDate?: Moment;
+    customFilters?: (string | null)[];
+    customFields?: string[];
+}
+
+export interface OrganisationUnitTableFilters extends TableFilters {
     orgUnitGroup?: string;
-    d2Filters: (string | null)[];
+    orgUnitLevel?: string;
 }
 
 export interface TablePagination {
-    page: number;
-    pageSize: number;
-    sorting: string[];
+    page?: number;
+    pageSize?: number;
+    sorting?: string[];
+    paging?: boolean;
 }
 
 export interface TableLabel {

--- a/src/types/d2-ui-components.d.ts
+++ b/src/types/d2-ui-components.d.ts
@@ -12,7 +12,7 @@ export interface TableList {
 export interface TableFilters {
     search?: string;
     lastUpdatedDate?: Moment;
-    customFilters?: (string | null)[];
+    customFilters?: string[];
     customFields?: string[];
 }
 


### PR DESCRIPTION
### :pushpin: References

* **Issue:** Closes #59 

### :memo: Implementation

- Improve OU Group filter by adding indirect access to d2Model

- Add OU Level filter re-using the new OU Group filter logic

- Improve the listMethod to customize on-demand the fields/filters/paging required

### :art: Screenshots

![image](https://user-images.githubusercontent.com/2181866/55630691-9101f600-57b6-11e9-966f-29dd667b0fb4.png)

![image](https://user-images.githubusercontent.com/2181866/55630705-9b23f480-57b6-11e9-8a63-2abd84757283.png)

![image](https://user-images.githubusercontent.com/2181866/55630723-a4ad5c80-57b6-11e9-8440-92a8af3312bc.png)

![image](https://user-images.githubusercontent.com/2181866/55630739-ad9e2e00-57b6-11e9-8c73-ab8451e6beeb.png)

### :fire: Is there anything the reviewer should know to test it?

- We had a bug where only 50 OU Groups appeared in the dropdown because paging was not set to false.