### PR TITLE
Add a property to override the fields in list()

### DIFF
--- a/src/models/d2Model.ts
+++ b/src/models/d2Model.ts
@@ -37,6 +37,7 @@ export abstract class D2Model {
     ): Promise<TableList> {
         const {
             search = null,
+            fields: overriddenFields = null,
             lastUpdatedDate = null,
             groupFilter = null,
             customFilters = [],
@@ -47,7 +48,7 @@ export abstract class D2Model {
 
         const details = this.details.map(e => e.name);
         const columns = this.columns.map(e => e.name);
-        const fields = _.union(details, columns, customFields);
+        const fields = overriddenFields ? overriddenFields : _.union(details, columns, customFields);
 
         const [field, direction] = sorting;
         const order = `${field}:i${direction}`;

--- a/src/types/d2-ui-components.d.ts
+++ b/src/types/d2-ui-components.d.ts
@@ -11,6 +11,7 @@ export interface TableList {
 
 export interface TableFilters {
     search?: string;
+    fields?: string[];
     lastUpdatedDate?: Moment;
     groupFilter?: string;
     customFilters?: string[];


### PR DESCRIPTION
### 📌 References

- This can be tested with https://github.com/EyeSeeTea/d2-ui-components/pull/34

### :memo: Implementation

- If fields are explicitly required as a filter do not internally compute the fields to use.

- This way if we only need to get "ids" we can do smaller requests to DHIS2 directly by overriding the fields array.