### PR TITLE
 Refactor Instance model encryption

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2019-04-26T09:34:00.788Z\n"
-"PO-Revision-Date: 2019-04-26T09:34:00.788Z\n"
+"POT-Creation-Date: 2019-05-03T09:54:18.970Z\n"
+"PO-Revision-Date: 2019-05-03T09:54:18.970Z\n"
 
 msgid "Instance Configurator"
 msgstr ""
@@ -29,7 +29,7 @@ msgstr ""
 msgid "Notifications"
 msgstr ""
 
-msgid "Connected sucessfully to instance"
+msgid "Connected successfully to instance"
 msgstr ""
 
 msgid "Deleted {{name}}"
@@ -93,9 +93,6 @@ msgid "Password (*)"
 msgstr ""
 
 msgid "Please fix the issues before testing the connection"
-msgstr ""
-
-msgid "Connected successfully to instance"
 msgstr ""
 
 msgid "Please fix the issues before saving"

--- a/src/components/app/App.jsx
+++ b/src/components/app/App.jsx
@@ -54,7 +54,7 @@ class App extends Component {
 
                                     <div id="app" className="content">
                                         <SnackbarProvider>
-                                            <Root d2={d2} appConfig={appConfig} />
+                                            <Root d2={d2} />
                                         </SnackbarProvider>
                                     </div>
 

--- a/src/components/app/Root.jsx
+++ b/src/components/app/Root.jsx
@@ -12,26 +12,21 @@ import ValidationRuleSync from "../sync-configurator/ValidationRuleSync";
 class Root extends React.Component {
     static propTypes = {
         d2: PropTypes.object.isRequired,
-        appConfig: PropTypes.object.isRequired,
     };
 
     render() {
-        const { d2, appConfig } = this.props;
+        const { d2 } = this.props;
 
         return (
             <Switch>
                 <Route
                     path={"/instance-configurator/:formFor(new|edit)/:id?"}
-                    render={props => (
-                        <InstanceFormBuilder d2={d2} appConfig={appConfig} {...props} />
-                    )}
+                    render={props => <InstanceFormBuilder d2={d2} {...props} />}
                 />
 
                 <Route
                     path="/instance-configurator"
-                    render={props => (
-                        <InstanceConfigurator d2={d2} appConfig={appConfig} {...props} />
-                    )}
+                    render={props => <InstanceConfigurator d2={d2} {...props} />}
                 />
 
                 <Route

--- a/src/components/app/Root.jsx
+++ b/src/components/app/Root.jsx
@@ -36,26 +36,22 @@ class Root extends React.Component {
 
                 <Route
                     path="/sync/organisationUnits"
-                    render={props => (
-                        <OrganisationUnitSync d2={d2} appConfig={appConfig} {...props} />
-                    )}
+                    render={props => <OrganisationUnitSync d2={d2} {...props} />}
                 />
 
                 <Route
                     path="/sync/dataElements"
-                    render={props => <DataElementSync d2={d2} appConfig={appConfig} {...props} />}
+                    render={props => <DataElementSync d2={d2} {...props} />}
                 />
 
                 <Route
                     path="/sync/indicators"
-                    render={props => <IndicatorSync d2={d2} appConfig={appConfig} {...props} />}
+                    render={props => <IndicatorSync d2={d2} {...props} />}
                 />
 
                 <Route
                     path="/sync/validationRules"
-                    render={props => (
-                        <ValidationRuleSync d2={d2} appConfig={appConfig} {...props} />
-                    )}
+                    render={props => <ValidationRuleSync d2={d2} {...props} />}
                 />
 
                 <Route render={() => <LandingPage d2={d2} />} />

--- a/src/components/instance-configurator/InstanceConfigurator.jsx
+++ b/src/components/instance-configurator/InstanceConfigurator.jsx
@@ -23,7 +23,6 @@ class InstanceConfigurator extends React.Component {
         d2: PropTypes.object.isRequired,
         snackbar: PropTypes.object.isRequired,
         history: PropTypes.object.isRequired,
-        appConfig: PropTypes.object.isRequired,
     };
 
     onCreate = () => {
@@ -38,15 +37,14 @@ class InstanceConfigurator extends React.Component {
     };
 
     onTestConnection = async instanceData => {
-        const { encryptionKey } = this.props.appConfig;
-        const instance = Instance.getOrCreate(instanceData, encryptionKey);
+        const instance = await Instance.parse(instanceData);
         const connectionErrors = await instance.check();
         if (!connectionErrors.status) {
             this.props.snackbar.error(connectionErrors.error.message, {
                 autoHideDuration: null,
             });
         } else {
-            this.props.snackbar.success(i18n.t("Connected sucessfully to instance"));
+            this.props.snackbar.success(i18n.t("Connected successfully to instance"));
         }
     };
 

--- a/src/components/instance-form-builder/GeneralInfoForm.jsx
+++ b/src/components/instance-form-builder/GeneralInfoForm.jsx
@@ -41,7 +41,6 @@ class GeneralInfoForm extends React.Component {
         instance: PropTypes.object.isRequired,
         snackbar: PropTypes.object.isRequired,
         cancelAction: PropTypes.func.isRequired,
-        appConfig: PropTypes.object.isRequired,
     };
 
     setFormReference = formReference => {
@@ -198,7 +197,7 @@ class GeneralInfoForm extends React.Component {
     };
 
     saveAction = async () => {
-        const { d2, instance, appConfig } = this.props;
+        const { d2, instance } = this.props;
         const fields = this.generateFields();
         const formErrors = isFormValid(fields, this.formReference);
         if (formErrors.length > 0) {
@@ -213,9 +212,8 @@ class GeneralInfoForm extends React.Component {
                 autoHideDuration: null,
             });
         } else {
-            const encryptionKey = _(appConfig).get("encryptionKey");
             this.setState({ isSaving: true });
-            await instance.save(d2, encryptionKey);
+            await instance.save(d2);
             this.setState({ isSaving: false });
             this.props.history.push("/instance-configurator");
         }

--- a/src/components/instance-form-builder/InstanceFormBuilder.jsx
+++ b/src/components/instance-form-builder/InstanceFormBuilder.jsx
@@ -14,7 +14,6 @@ class InstanceFormBuilder extends React.Component {
         d2: PropTypes.object.isRequired,
         history: PropTypes.object.isRequired,
         location: PropTypes.object.isRequired,
-        appConfig: PropTypes.object.isRequired,
     };
 
     isEdit = this.props.match.params.formFor === "edit";
@@ -22,12 +21,9 @@ class InstanceFormBuilder extends React.Component {
     constructor(props) {
         super(props);
 
-        const {
-            location,
-            appConfig: { encryptionKey },
-        } = props;
+        const { location } = props;
 
-        const instance = Instance.getOrCreate(location.instance, encryptionKey);
+        const instance = Instance.parse(location.instance);
 
         this.state = {
             instance,
@@ -38,14 +34,12 @@ class InstanceFormBuilder extends React.Component {
     componentDidMount = async () => {
         const {
             match: { params },
-            appConfig: { encryptionKey },
             d2,
         } = this.props;
         const { instance } = this.state;
         if (this.isEdit && !instance.data.id) {
-            const encryptedInstance = await Instance.get(d2, params.id);
-            const instanceToEdit = encryptedInstance.decryptPassword(encryptionKey);
-            this.setState({ instance: instanceToEdit });
+            const instance = await Instance.get(d2, params.id);
+            this.setState({ instance });
         }
     };
 
@@ -68,7 +62,7 @@ class InstanceFormBuilder extends React.Component {
 
     render() {
         const { dialogOpen } = this.state;
-        const { d2, appConfig } = this.props;
+        const { d2 } = this.props;
 
         const title = !this.isEdit ? i18n.t("New Instance") : i18n.t("Edit Instance");
 
@@ -95,7 +89,6 @@ class InstanceFormBuilder extends React.Component {
 
                 <GeneralInfoForm
                     d2={d2}
-                    appConfig={appConfig}
                     instance={this.state.instance}
                     onChange={this.onChange}
                     cancelAction={this.cancelSave}

--- a/src/components/sync-configurator/BaseSyncConfigurator.jsx
+++ b/src/components/sync-configurator/BaseSyncConfigurator.jsx
@@ -218,7 +218,6 @@ class BaseSyncConfigurator extends React.Component {
                     metadata={metadata}
                     isOpen={syncDialogOpen}
                     handleClose={this.closeDialog}
-                    encryptionKey={this.props.appConfig.encryptionKey}
                 />
                 <SyncSummary
                     response={importResponse}

--- a/src/components/sync-dialog/SyncDialog.jsx
+++ b/src/components/sync-dialog/SyncDialog.jsx
@@ -44,14 +44,10 @@ class SyncDialog extends React.Component {
         this.props.loading.show(true, i18n.t("Synchronizing metadata"));
 
         try {
-            const metadataPackage = await startSynchronization(
-                this.props.d2,
-                {
-                    metadata: this.props.metadata,
-                    targetInstances: this.state.targetInstances,
-                },
-                this.props.encryptionKey
-            );
+            const metadataPackage = await startSynchronization(this.props.d2, {
+                metadata: this.props.metadata,
+                targetInstances: this.state.targetInstances,
+            });
             this.props.handleClose(metadataPackage);
         } catch (error) {
             console.error(error);

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,10 @@
 import React from "react";
 import ReactDOM from "react-dom";
-import { init, config, getUserSettings, getManifest } from "d2";
-import "font-awesome/css/font-awesome.min.css";
 import _ from "lodash";
+import axios from "axios";
+import { init, config, getUserSettings, getManifest } from "d2";
 import { HashRouter } from "react-router-dom";
+import "font-awesome/css/font-awesome.min.css";
 
 import App from "./components/app/App";
 import i18n from "./locales";
@@ -65,9 +66,7 @@ async function main() {
         loadHeaderBarTranslations(d2);
         const userSettings = await getUserSettings();
         configI18n(userSettings);
-        const appConfig = await fetch("app-config.json", {
-            credentials: "same-origin",
-        }).then(res => res.json());
+        const appConfig = await axios.get("app-config.json").then(res => res.data);
         ReactDOM.render(
             <HashRouter>
                 <App d2={d2} appConfig={appConfig} />

--- a/src/logic/synchronization.ts
+++ b/src/logic/synchronization.ts
@@ -66,12 +66,10 @@ async function exportMetadata(d2: D2, builder: ExportBuilder): Promise<MetadataP
 async function importMetadata(
     d2: D2,
     instanceId: string,
-    metadataPackage: MetadataPackage,
-    encryptionKey: string
+    metadataPackage: MetadataPackage
 ): Promise<SynchronizationResult> {
     const instance = await Instance.get(d2, instanceId);
-    const decryptedInstance = instance.decryptPassword(encryptionKey);
-    const importResult = await postMetadata(decryptedInstance, metadataPackage);
+    const importResult = await postMetadata(instance, metadataPackage);
 
     const typeStats: any[] = [];
     const messages: any[] = [];
@@ -109,8 +107,7 @@ async function importMetadata(
 
 export async function startSynchronization(
     d2: D2,
-    builder: SynchronizationBuilder,
-    encryptionKey: string
+    builder: SynchronizationBuilder
 ): Promise<SynchronizationResult[]> {
     // Phase 1: Export and package metadata from origin instance
     const exportPromises = _.keys(builder.metadata)
@@ -129,7 +126,7 @@ export async function startSynchronization(
 
     // Phase 2: Import metadata into destination instances
     const importPromises = builder.targetInstances.map(instanceId =>
-        importMetadata(d2, instanceId, metadataPackage, encryptionKey)
+        importMetadata(d2, instanceId, metadataPackage)
     );
 
     return Promise.all(importPromises);

--- a/src/models/d2Model.ts
+++ b/src/models/d2Model.ts
@@ -48,7 +48,9 @@ export abstract class D2Model {
 
         const details = this.details.map(e => e.name);
         const columns = this.columns.map(e => e.name);
-        const fields = overriddenFields ? overriddenFields : _.union(details, columns, customFields);
+        const fields = overriddenFields
+            ? overriddenFields
+            : _.union(details, columns, customFields);
 
         const [field, direction] = sorting;
         const order = `${field}:i${direction}`;


### PR DESCRIPTION
### :pushpin: References

* **Issue:** Closes #54 
* **Issue:** Closes #34 

### :memo: Implementation

- Instead of getOrCreate add a new parse method that from a given data creates an Instance.

- Re-use the parse method for current get operation

- Simplify code where possible and fix minor strings

- Move to axios all fetch calls

### :fire: Is there anything the reviewer should know to test it?

- Encryption is only done during save to dataStore

- Decryption is only done during get from dataStore

- All internal app calls use an object with plain text password

### :bookmark_tabs: Others

- Instance.getEncryptionKey() could be memoized but I'm not sure how it works with async calls.