### PR TITLE
Use same protocol for jquery load

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -20,7 +20,7 @@
     -->
     <title>Metadata Synchronization</title>
 
-    <script src="http://code.jquery.com/jquery-latest.min.js"></script>
+    <script src="//code.jquery.com/jquery-latest.min.js"></script>
     <script src="%PUBLIC_URL%/feedback-tool/feedback.min.js"></script>
     <script src="%PUBLIC_URL%/feedback-tool/feedback-github.min.js"></script>
     <script src="%PUBLIC_URL%/feedback-tool/feedback-dhis2.min.js"></script>


### PR DESCRIPTION
### :pushpin: References

Error: "Cannot read property feedbackDhis2 of undefined"

### :memo: Implementation

- `index.html` loaded jquery with `http://`, let's use `//` (same protocol)

https://developer.mozilla.org/en-US/docs/Web/Security/Mixed_content/How_to_fix_website_with_mixed_content

Note that this will be a problem if we need syncs to/from dhis2 instances on http from the app in a https instance.