### PR TITLE
Improve performance on metadata synchronization

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ install:
 script:
   - PORT=8081 REACT_APP_DHIS2_BASE_URL=http://dev2.eyeseetea.com:8083 REACT_APP_CYPRESS=true yarn start &
   - yarn wait-on http-get://localhost:8081
-  - CYPRESS_EXTERNAL_API=http://dev2.eyeseetea.com:8083 CYPRESS_ROOT_URL=http://localhost:8081 yarn cy:e2e:run --record --key $CYPRESS_KEY
+  - CYPRESS_EXTERNAL_API=http://dev2.eyeseetea.com:8083 CYPRESS_ROOT_URL=http://localhost:8081 yarn cy:e2e:run --key $CYPRESS_KEY
   - kill $(jobs -p) || true
 notifications:
   slack:

--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2019-05-15T22:07:45.948Z\n"
-"PO-Revision-Date: 2019-05-15T22:07:45.948Z\n"
+"POT-Creation-Date: 2019-05-23T15:30:23.997Z\n"
+"PO-Revision-Date: 2019-05-23T15:30:23.997Z\n"
 
 msgid "Instance Configurator"
 msgstr ""
@@ -141,9 +141,6 @@ msgid "Status"
 msgstr ""
 
 msgid "Metadata Types"
-msgstr ""
-
-msgid "API Link"
 msgstr ""
 
 msgid "View summary"

--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2019-05-23T15:30:23.997Z\n"
-"PO-Revision-Date: 2019-05-23T15:30:23.997Z\n"
+"POT-Creation-Date: 2019-05-27T11:31:49.068Z\n"
+"PO-Revision-Date: 2019-05-27T11:31:49.068Z\n"
 
 msgid "Instance Configurator"
 msgstr ""
@@ -228,6 +228,12 @@ msgid "Messages"
 msgstr ""
 
 msgid "JSON Response"
+msgstr ""
+
+msgid "Fetching metadata from origin instance"
+msgstr ""
+
+msgid "Retrieving information from remote instances"
 msgstr ""
 
 msgid "Not a valid DHIS2 instance"

--- a/src/components/notifications-table/NotificationsTable.jsx
+++ b/src/components/notifications-table/NotificationsTable.jsx
@@ -10,7 +10,6 @@ import PageHeader from "../shared/PageHeader";
 
 import SyncReport from "../../models/syncReport";
 import SyncSummary from "../sync-summary/SyncSummary";
-import { createMetadataExportUrl } from "../../utils/synchronization";
 
 const styles = () => ({
     tableContainer: { marginTop: -10 },

--- a/src/components/notifications-table/NotificationsTable.jsx
+++ b/src/components/notifications-table/NotificationsTable.jsx
@@ -33,7 +33,6 @@ class NotificationsTable extends React.Component {
 
     static model = {
         modelValidations: {
-            href: { type: "URL" },
             timestamp: { type: "DATE" },
             metadata: { type: "COLLECTION" },
         },
@@ -98,31 +97,8 @@ class NotificationsTable extends React.Component {
         );
     };
 
-    // TODO: We should fix d2-ui-components instead
-    getValueForUrl = value => {
-        return (
-            <a
-                rel="noopener noreferrer"
-                style={{ wordBreak: "break-all" }}
-                href={value}
-                target="_blank"
-            >
-                {value}
-            </a>
-        );
-    };
-
     getMetadataTypes = notification => {
         return this.getValueForCollection(notification.selectedTypes.map(type => ({ name: type })));
-    };
-
-    getAPILink = notification => {
-        const ids = _(notification.metadata)
-            .values()
-            .flatten()
-            .map(e => e.id)
-            .value();
-        return this.getValueForUrl(createMetadataExportUrl(this.props.d2, ids));
     };
 
     columns = [
@@ -141,11 +117,6 @@ class NotificationsTable extends React.Component {
             name: "metadata",
             text: i18n.t("Metadata Types"),
             getValue: notification => this.getMetadataTypes(notification),
-        },
-        {
-            name: "href",
-            text: i18n.t("API Link"),
-            getValue: notification => this.getAPILink(notification),
         },
     ];
 

--- a/src/components/sync-dialog/SyncDialog.jsx
+++ b/src/components/sync-dialog/SyncDialog.jsx
@@ -41,12 +41,13 @@ class SyncDialog extends React.Component {
 
     handleSynchronization = async () => {
         const { handleClose, loading, metadata, d2 } = this.props;
+        const { targetInstances } = this.state;
         loading.show(true, i18n.t("Synchronizing metadata"));
 
         try {
             const builder = {
                 metadata: metadata,
-                targetInstances: this.state.targetInstances,
+                targetInstances: targetInstances,
             };
             for await (const { message, syncReport, done } of startSynchronization(d2, builder)) {
                 if (message) loading.show(true, message);

--- a/src/components/sync-dialog/SyncDialog.jsx
+++ b/src/components/sync-dialog/SyncDialog.jsx
@@ -51,7 +51,7 @@ class SyncDialog extends React.Component {
             };
             for await (const { message, syncReport, done } of startSynchronization(d2, builder)) {
                 if (message) loading.show(true, message);
-                if (syncReport) await syncReport.save();
+                if (syncReport) await syncReport.save(d2);
                 if (done) handleClose(syncReport);
             }
         } catch (error) {

--- a/src/logic/synchronization.ts
+++ b/src/logic/synchronization.ts
@@ -126,7 +126,7 @@ export async function startSynchronization(
         .map(newBuilder => exportMetadata(d2, newBuilder));
     const exportResults: MetadataPackage[] = await Promise.all(exportPromises);
     const metadataPackage = _.deepMerge({}, ...exportResults);
-    console.debug("Metadata package from origin instance done");
+    console.debug("Metadata package from origin instance done", metadataPackage);
 
     // Phase 2: Create parent synchronization task
     const targetInstances: Instance[] = await Promise.all(

--- a/src/logic/synchronization.ts
+++ b/src/logic/synchronization.ts
@@ -89,7 +89,7 @@ async function importMetadata(
                 const { uid, errorReports = [] } = detail;
 
                 messages.push(
-                    ..._.take(errorReports, 2).map((error: any) => ({
+                    ..._.take(errorReports, 1).map((error: any) => ({
                         uid,
                         type: getClassName(error.mainKlass),
                         property: error.errorProperty,

--- a/src/models/d2Model.ts
+++ b/src/models/d2Model.ts
@@ -116,7 +116,7 @@ export class OrganisationUnitModel extends D2Model {
         "organisationUnitGroups.organisationUnitGroupSets.userGroupAccesses",
     ];
     protected static includeRules = [
-        "attribute",
+        "attributes",
         "organisationUnitGroups",
         "organisationUnitGroups.attributes",
         "organisationUnitGroups.organisationUnitGroupSets",

--- a/src/models/dataStore.ts
+++ b/src/models/dataStore.ts
@@ -33,7 +33,7 @@ export async function getData(d2: D2, dataStoreKey: string): Promise<any> {
 
 export async function getDataById(d2: D2, dataStoreKey: string, id: string): Promise<any> {
     const rawData = await getDataStore(d2, dataStoreKey);
-    return _.find(rawData, instance => instance.id === id);
+    return _.find(rawData, (element: any): boolean => element.id === id);
 }
 
 export async function getPaginatedData(
@@ -83,7 +83,9 @@ export async function saveData(d2: D2, dataStoreKey: string, data: any): Promise
 export async function deleteData(d2: D2, dataStoreKey: string, data: any): Promise<Response> {
     try {
         const dataArray = await getDataStore(d2, dataStoreKey);
-        const newDataArray = dataArray.filter((dataEl: { id: string }) => dataEl.id !== data.id);
+        const newDataArray = dataArray.filter(
+            (dataEl: { id: string }): boolean => dataEl.id !== data.id
+        );
         await saveDataStore(d2, dataStoreKey, newDataArray);
         return { status: true };
     } catch (e) {

--- a/src/models/dataStore.ts
+++ b/src/models/dataStore.ts
@@ -41,7 +41,7 @@ export async function getData(d2: D2, dataStoreKey: string): Promise<any> {
 
 export async function getDataById(d2: D2, dataStoreKey: string, id: string): Promise<any> {
     const rawData = await getDataStore(d2, dataStoreKey, []);
-    return _.find(rawData, (element: any): boolean => element.id === id);
+    return _.find(rawData, element => element.id === id);
 }
 
 export async function getPaginatedData(

--- a/src/models/instance.ts
+++ b/src/models/instance.ts
@@ -246,7 +246,7 @@ export default class Instance {
                     ),
                 };
             } else {
-                console.log({ error });
+                console.debug({ error });
                 return { status: false, error };
             }
         }

--- a/src/models/syncReport.ts
+++ b/src/models/syncReport.ts
@@ -51,12 +51,15 @@ export default class SyncReport {
     }
 
     public async save(d2: D2): Promise<Response> {
+        console.debug("Start saving SyncReport to dataStore");
         const exists = this.syncReport.id;
         const element = exists ? this.syncReport : { ...this.syncReport, id: generateUid() };
 
         if (exists) await this.remove(d2);
 
-        return saveData(d2, notificationsDataStoreKey, element);
+        const result = await saveData(d2, notificationsDataStoreKey, element);
+        console.debug("Finish saving SyncReport to dataStore", element);
+        return result;
     }
 
     public async remove(d2: D2): Promise<Response> {

--- a/src/models/syncReport.ts
+++ b/src/models/syncReport.ts
@@ -29,7 +29,6 @@ export default class SyncReport {
             user: "",
             status: "READY" as SynchronizationReportStatus,
             results: [],
-            metadata: {},
             selectedTypes: [],
         });
     }

--- a/src/types/synchronization.d.ts
+++ b/src/types/synchronization.d.ts
@@ -38,7 +38,6 @@ export interface SynchronizationReport {
     user: string;
     status: SynchronizationReportStatus;
     results: SynchronizationResult[];
-    metadata: MetadataPackage;
     selectedTypes: string[];
 }
 

--- a/src/types/synchronization.d.ts
+++ b/src/types/synchronization.d.ts
@@ -1,4 +1,5 @@
 import { MetadataImportResponse, MetadataImportStats } from "./d2";
+import SyncReport from "../models/syncReport";
 
 export interface SynchronizationBuilder {
     targetInstances: string[];
@@ -43,4 +44,10 @@ export interface SynchronizationReport {
 
 export interface NestedRules {
     [metadataType: string]: string[][];
+}
+
+export interface SynchronizationState {
+    message?: string;
+    syncReport?: SyncReport;
+    done?: boolean;
 }

--- a/src/utils/synchronization.ts
+++ b/src/utils/synchronization.ts
@@ -38,11 +38,6 @@ export function cleanReferences(
     return _.intersection(_.keys(references), rules);
 }
 
-export function createMetadataExportUrl(d2: D2, elements: string[]): string {
-    const requestUrl = d2.Api.getApi().baseUrl + "/metadata.json";
-    return requestUrl + `?fields=:all&defaults=EXCLUDE&filter=id:in:[${elements.join(",")}]`;
-}
-
 export async function getMetadata(d2: D2, elements: string[]): Promise<MetadataPackage> {
     const promises = [];
     for (let i = 0; i < elements.length; i += 100) {


### PR DESCRIPTION
### :pushpin: References

* **Issue:** Closes #86 

### :memo: Implementation

- Transform synchronization into a state machine with generator
- Update loading page with messages
- Add a visited id dictionary and move recursive function to a inner method
- Add missing TS definitions for arrow methods

### 🔢 Performace

- Previous algorithm took linear time
- Current algorithm takes logarithmic time
- For detailed comparison see https://github.com/EyeSeeTea/metadata-synchronization/issues/86#issuecomment-495881754

### :art: Screenshots

![image](https://user-images.githubusercontent.com/2181866/58325735-fc695b00-7e2a-11e9-87ac-924155cd5c6e.png)

![image](https://user-images.githubusercontent.com/2181866/58325743-068b5980-7e2b-11e9-9b71-253dbb199ab3.png)

![image](https://user-images.githubusercontent.com/2181866/58325786-291d7280-7e2b-11e9-863b-912b146c433a.png)

![image](https://user-images.githubusercontent.com/2181866/58325752-0d19d100-7e2b-11e9-8231-d3b21cd0109a.png)

![image](https://user-images.githubusercontent.com/2181866/58325763-15720c00-7e2b-11e9-82b2-72c1f55ecf53.png)


### :fire: Is there anything the reviewer should know to test it?


### :bookmark_tabs: Others
