### PR TITLE
Allow synchronization of OrganisationUnitGroupSets

### DIFF
--- a/src/components/synchronization-page/OrganisationUnitPage.jsx
+++ b/src/components/synchronization-page/OrganisationUnitPage.jsx
@@ -1,7 +1,11 @@
 import React from "react";
 import PropTypes from "prop-types";
 import i18n from "@dhis2/d2-i18n";
-import { OrganisationUnitModel, OrganisationUnitGroupModel } from "../../models/d2Model";
+import {
+    OrganisationUnitModel,
+    OrganisationUnitGroupModel,
+    OrganisationUnitGroupSetModel,
+} from "../../models/d2Model";
 import GenericSynchronizationPage from "./GenericSynchronizationPage";
 
 export default class OrganisationUnitPage extends React.Component {
@@ -17,7 +21,11 @@ export default class OrganisationUnitPage extends React.Component {
         return (
             <GenericSynchronizationPage
                 d2={d2}
-                models={[OrganisationUnitModel, OrganisationUnitGroupModel]}
+                models={[
+                    OrganisationUnitModel,
+                    OrganisationUnitGroupModel,
+                    OrganisationUnitGroupSetModel,
+                ]}
                 title={title}
             />
         );

--- a/src/models/d2Model.ts
+++ b/src/models/d2Model.ts
@@ -172,6 +172,24 @@ export class OrganisationUnitGroupModel extends D2Model {
     ];
 }
 
+export class OrganisationUnitGroupSetModel extends D2Model {
+    protected static metadataType = "organisationUnitGroupSet";
+
+    protected static excludeRules = [
+        "user",
+        "userAccesses",
+        "userGroupAccesses",
+        "organisationUnitGroups.organisationUnitGroupSets",
+        "organisationUnitGroups.organisationUnits.organisationUnitGroups",
+    ];
+    protected static includeRules = [
+        "attributes",
+        "organisationUnitGroups",
+        "organisationUnitGroups.organisationUnits",
+        "organisationUnitGroups.organisationUnits.attributes",
+    ];
+}
+
 export class DataElementModel extends D2Model {
     protected static metadataType = "dataElement";
     protected static groupFilterName = "dataElementGroups";

--- a/src/models/d2ModelFactory.ts
+++ b/src/models/d2ModelFactory.ts
@@ -5,6 +5,7 @@ import {
     IndicatorModel,
     OrganisationUnitModel,
     OrganisationUnitGroupModel,
+    OrganisationUnitGroupSetModel,
     ValidationRuleModel,
 } from "./d2Model";
 import { D2 } from "../types/d2";
@@ -12,6 +13,7 @@ import { D2 } from "../types/d2";
 const classes: { [modelName: string]: typeof D2Model } = {
     OrganisationUnitModel,
     OrganisationUnitGroupModel,
+    OrganisationUnitGroupSetModel,
     DataElementModel,
     IndicatorModel,
     ValidationRuleModel,


### PR DESCRIPTION
### :pushpin: References

### :memo: Implementation

- Re-use our powerful core logic for dependency fetching
- Re-use the new abstracted Metadata Table from Sync Rules

### :art: Screenshots

![image](https://user-images.githubusercontent.com/2181866/60469269-65c75f80-9c5c-11e9-975c-19da1c1d59e0.png)

### :fire: Is there anything the reviewer should know to test it?

- This is more difficult to test but the resulting metadata package seems to be correct

### :bookmark_tabs: Others

