### PR TITLE
[History] Visualize if a sync was executed by a rule

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,19 +5,10 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2019-07-09T09:31:55.299Z\n"
-"PO-Revision-Date: 2019-07-09T09:31:55.299Z\n"
+"POT-Creation-Date: 2019-07-11T10:37:31.244Z\n"
+"PO-Revision-Date: 2019-07-11T10:37:31.244Z\n"
 
 msgid "<No value>"
-msgstr ""
-
-msgid "User"
-msgstr ""
-
-msgid "Timestamp"
-msgstr ""
-
-msgid "Status"
 msgstr ""
 
 msgid "Ready"
@@ -52,7 +43,19 @@ msgstr ""
 msgid "View summary"
 msgstr ""
 
+msgid "User"
+msgstr ""
+
+msgid "Timestamp"
+msgstr ""
+
+msgid "Status"
+msgstr ""
+
 msgid "Metadata Types"
+msgstr ""
+
+msgid "Sync Rule"
 msgstr ""
 
 msgid "Synchronization status"

--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2019-07-11T10:37:31.244Z\n"
-"PO-Revision-Date: 2019-07-11T10:37:31.244Z\n"
+"POT-Creation-Date: 2019-07-12T18:04:47.457Z\n"
+"PO-Revision-Date: 2019-07-12T18:04:47.457Z\n"
 
 msgid "<No value>"
 msgstr ""
@@ -41,6 +41,9 @@ msgid "Delete"
 msgstr ""
 
 msgid "View summary"
+msgstr ""
+
+msgid "Edit {{name}}"
 msgstr ""
 
 msgid "User"

--- a/src/components/history-list-page/HistoryPage.jsx
+++ b/src/components/history-list-page/HistoryPage.jsx
@@ -137,11 +137,12 @@ class HistoryPage extends React.Component {
     getSyncRuleEditLink = id => {
         const { syncRules } = this.state;
         const syncRule = syncRules.find(e => e.id === id);
+        if (!syncRule) return null;
 
-        return syncRule ? (
-            <Link to={`/synchronization-rules/edit/${syncRule.id}`}>Edit {syncRule.name}</Link>
-        ) : (
-            ""
+        return (
+            <Link to={`/synchronization-rules/edit/${syncRule.id}`}>
+                {i18n.t("Edit {{name}}", { name: syncRule.name })}
+            </Link>
         );
     };
 
@@ -167,7 +168,7 @@ class HistoryPage extends React.Component {
 
     getSyncRuleName = id => {
         const { syncRules } = this.state;
-        const syncRule = syncRules.find(e => e.id === id) || {};
+        const syncRule = syncRules.find(rule => rule.id === id) || {};
         return syncRule.name;
     };
 

--- a/src/components/rules-creation-page/steps/InstanceSelectionStep.jsx
+++ b/src/components/rules-creation-page/steps/InstanceSelectionStep.jsx
@@ -4,7 +4,7 @@ import { MultiSelector } from "d2-ui-components";
 import Instance from "../../../models/instance";
 
 export const getInstances = async d2 => {
-    const { objects } = await Instance.list(d2, null, { paging: false });
+    const { objects } = await Instance.list(d2, {}, { paging: false });
     return objects.map(instance => ({
         value: instance.id,
         text: `${instance.name} (${instance.url} with user ${instance.username})`,

--- a/src/components/rules-creation-page/steps/InstanceSelectionStep.jsx
+++ b/src/components/rules-creation-page/steps/InstanceSelectionStep.jsx
@@ -4,12 +4,8 @@ import { MultiSelector } from "d2-ui-components";
 import Instance from "../../../models/instance";
 
 export const getInstances = async d2 => {
-    const instances = await Instance.list(
-        d2,
-        { search: "" },
-        { page: 1, pageSize: 100, sorting: [] }
-    );
-    return instances.objects.map(instance => ({
+    const { objects } = await Instance.list(d2, null, { paging: false });
+    return objects.map(instance => ({
         value: instance.id,
         text: `${instance.name} (${instance.url} with user ${instance.username})`,
     }));

--- a/src/components/rules-list-page/SyncRulesPage.jsx
+++ b/src/components/rules-list-page/SyncRulesPage.jsx
@@ -129,11 +129,14 @@ class SyncRulesPage extends React.Component {
         this.props.history.push(`/synchronization-rules/edit/${rule.id}`);
     };
 
-    executeRule = async ({ builder, name }) => {
+    executeRule = async ({ builder, name, id }) => {
         const { d2, loading } = this.props;
         loading.show(true, i18n.t("Synchronizing metadata"));
         try {
-            for await (const { message, syncReport, done } of startSynchronization(d2, builder)) {
+            for await (const { message, syncReport, done } of startSynchronization(d2, {
+                ...builder,
+                syncRule: id,
+            })) {
                 if (message) loading.show(true, message);
                 if (syncReport) await syncReport.save(d2);
                 if (done && syncReport) {

--- a/src/logic/synchronization.ts
+++ b/src/logic/synchronization.ts
@@ -117,7 +117,7 @@ export async function* startSynchronization(
     d2: D2,
     builder: SynchronizationBuilder
 ): AsyncIterableIterator<SynchronizationState> {
-    const { targetInstances: targetInstanceIds, metadataIds } = builder;
+    const { targetInstances: targetInstanceIds, metadataIds, syncRule } = builder;
 
     // Phase 1: Export and package metadata from origin instance
     console.debug("Start synchronization process");
@@ -148,6 +148,7 @@ export async function* startSynchronization(
         user: d2.currentUser.username,
         types: _.keys(metadata),
         status: "RUNNING" as SynchronizationReportStatus,
+        syncRule,
     });
     syncReport.addSyncResult(
         ...targetInstances.map(instance => ({

--- a/src/models/syncReport.ts
+++ b/src/models/syncReport.ts
@@ -29,7 +29,7 @@ export default class SyncReport {
         this.syncReport = {
             id: generateUid(),
             date: new Date(),
-            ..._.pick(syncReport, ["id", "date", "user", "status", "types"]),
+            ..._.pick(syncReport, ["id", "date", "user", "status", "types", "syncRule"]),
         };
     }
 

--- a/src/models/syncRule.ts
+++ b/src/models/syncRule.ts
@@ -70,7 +70,7 @@ export default class SyncRule {
         filters: SyncRuleTableFilters,
         pagination: TablePagination
     ): Promise<TableList> {
-        const { targetInstanceFilter } = filters;
+        const { targetInstanceFilter = null } = filters || {};
         const data = await getPaginatedData(d2, dataStoreKey, filters, pagination);
         return targetInstanceFilter
             ? {

--- a/src/types/synchronization.d.ts
+++ b/src/types/synchronization.d.ts
@@ -4,6 +4,7 @@ import SyncReport from "../models/syncReport";
 export interface SynchronizationBuilder {
     targetInstances: string[];
     metadataIds: string[];
+    syncRule?: string;
 }
 
 export interface ExportBuilder {
@@ -38,6 +39,7 @@ export interface SynchronizationReport {
     user: string;
     status: SynchronizationReportStatus;
     types: string[];
+    syncRule?: string;
 }
 
 export interface NestedRules {


### PR DESCRIPTION
### :pushpin: References

* **Issue:** Closes #113 

### :memo: Implementation

- Add support for ```paging=false``` in dataStore getPaginatedData()
- Add syncRule id to a syncReport if the sync was executed as part of a rule
- Show the syncRule in the Notifications page

### :art: Screenshots

![image](https://user-images.githubusercontent.com/2181866/60883465-8f7b1a80-a24a-11e9-83d4-2782788e359a.png)

![image](https://user-images.githubusercontent.com/2181866/60883472-96099200-a24a-11e9-8f88-c798257077af.png)

### :fire: Is there anything the reviewer should know to test it?


### :bookmark_tabs: Others

- https://github.com/EyeSeeTea/d2-ui-components/pull/50