### PR TITLE
[Scheduler] Add new scheduler to Sync Rules

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2019-07-11T10:37:31.244Z\n"
-"PO-Revision-Date: 2019-07-11T10:37:31.244Z\n"
+"POT-Creation-Date: 2019-07-13T16:48:14.885Z\n"
+"PO-Revision-Date: 2019-07-13T16:48:14.885Z\n"
 
 msgid "<No value>"
 msgstr ""
@@ -211,6 +211,12 @@ msgstr ""
 msgid "Instance Selection"
 msgstr ""
 
+msgid "Scheduling"
+msgstr ""
+
+msgid "Configure the scheduling frequency for the synchronization rule"
+msgstr ""
+
 msgid "Summary"
 msgstr ""
 
@@ -246,7 +252,31 @@ msgstr ""
 msgid "Target instances [{{total}}]"
 msgstr ""
 
+msgid "Scheduling enabled"
+msgstr ""
+
+msgid "Frequency"
+msgstr ""
+
+msgid "Enabled"
+msgstr ""
+
+msgid "Select frequency"
+msgstr ""
+
+msgid "Cron expression"
+msgstr ""
+
+msgid "Cron expression must be valid"
+msgstr ""
+
 msgid "Destination instances"
+msgstr ""
+
+msgid "Scheduled"
+msgstr ""
+
+msgid "Last executed"
 msgstr ""
 
 msgid "Deleting Sync Rules"
@@ -266,7 +296,13 @@ msgstr ""
 msgid "Failed to execute rule {{name}}"
 msgstr ""
 
+msgid "Successfully updated sync rule"
+msgstr ""
+
 msgid "Execute"
+msgstr ""
+
+msgid "Toggle scheduling"
 msgstr ""
 
 msgid "Destination Instance"
@@ -385,5 +421,11 @@ msgstr ""
 msgid "This URL and username combination already exists"
 msgstr ""
 
-msgid "You need to select at least one element"
+msgid "You need to select at least one {{element}}"
+msgstr ""
+
+msgid "Cron expression {{expression}} must be valid"
+msgstr ""
+
+msgid "To enable a rule you need to enter a valid {{expression}}"
 msgstr ""

--- a/src/components/rules-creation-page/SyncRulesWizard.jsx
+++ b/src/components/rules-creation-page/SyncRulesWizard.jsx
@@ -9,6 +9,7 @@ import GeneralInfoStep from "./steps/GeneralInfoStep";
 import SyncRule from "../../models/syncRule";
 import MetadataStep from "./steps/MetadataSelectionStep";
 import InstanceSelectionStep from "./steps/InstanceSelectionStep";
+import SchedulerStep from "./steps/SchedulerStep";
 import SaveStep from "./steps/SaveStep";
 import { getValidationMessages } from "../../utils/validations";
 
@@ -41,6 +42,14 @@ class SyncRulesWizard extends React.Component {
             component: InstanceSelectionStep,
             validationKeys: ["targetInstances"],
             description: undefined,
+            help: undefined,
+        },
+        {
+            key: "scheduler",
+            label: i18n.t("Scheduling"),
+            component: SchedulerStep,
+            validationKeys: ["frequency", "enabled"],
+            description: i18n.t("Configure the scheduling frequency for the synchronization rule"),
             help: undefined,
         },
         {

--- a/src/components/rules-creation-page/steps/GeneralInfoStep.jsx
+++ b/src/components/rules-creation-page/steps/GeneralInfoStep.jsx
@@ -5,7 +5,15 @@ import { TextField } from "@dhis2/d2-ui-core";
 import i18n from "@dhis2/d2-i18n";
 
 const GeneralInfoStep = props => {
-    const { syncRule } = props;
+    const { syncRule, onChange } = props;
+
+    const updateFields = (field, value) => {
+        if (field === "name") {
+            onChange(syncRule.updateName(value));
+        } else if (field === "description") {
+            onChange(syncRule.updateDescription(value));
+        }
+    };
 
     const fields = [
         {
@@ -41,15 +49,12 @@ const GeneralInfoStep = props => {
         },
     ];
 
-    const updateFields = (field, value) => {
-        props.syncRule[field] = value;
-    };
-
     return <FormBuilder fields={fields} onUpdateField={updateFields} />;
 };
 
 GeneralInfoStep.propTypes = {
     syncRule: PropTypes.object.isRequired,
+    onChange: PropTypes.func.isRequired,
 };
 
 GeneralInfoStep.defaultProps = {};

--- a/src/components/rules-creation-page/steps/SchedulerStep.jsx
+++ b/src/components/rules-creation-page/steps/SchedulerStep.jsx
@@ -1,0 +1,100 @@
+import React from "react";
+import _ from "lodash";
+import PropTypes from "prop-types";
+import i18n from "@dhis2/d2-i18n";
+import { FormControlLabel, Switch } from "@material-ui/core";
+import { FormBuilder } from "@dhis2/d2-ui-forms";
+import { TextField, DropDown } from "@dhis2/d2-ui-core";
+import isValidCronExpression from "../../../utils/validCronExpression";
+
+const defaultExpression = "CUSTOM";
+const cronExpressions = [
+    { text: "EVERY_HOUR", value: "0 0 * ? * *" },
+    { text: "EVERY_DAY_MIDNIGHT", value: "0 0 1 ? * *" },
+    { text: "EVERY_DAY_THREE_AM", value: "0 0 3 ? * *" },
+    { text: "EVERY_WEEKDAY_NOON", value: "0 0 12 ? * MON-FRI" },
+    { text: "EVERY_WEEK", value: "0 0 3 ? * MON" },
+];
+
+const Toggle = ({ label, onChange, value }) => (
+    <FormControlLabel
+        control={
+            <Switch
+                onChange={e => onChange(_.set(_.clone(e), "target.value", e.target.checked))}
+                checked={value}
+                color="primary"
+            />
+        }
+        label={label}
+    />
+);
+
+const SchedulerStep = ({ syncRule, onChange }) => {
+    const selectedCron = cronExpressions.find(cron => cron.value === syncRule.frequency) || {};
+
+    const updateFields = (field, value) => {
+        if (field === "enabled") {
+            onChange(syncRule.updateEnabled(value));
+        } else if (field === "frequency" || field === "frequencyDropdown") {
+            onChange(syncRule.updateFrequency(value || ""));
+        }
+    };
+
+    const fields = [
+        {
+            name: "enabled",
+            value: syncRule.enabled,
+            component: Toggle,
+            props: {
+                label: i18n.t("Enabled"),
+                style: { width: "100%" },
+            },
+            validators: [],
+        },
+        {
+            name: "frequencyDropdown",
+            value: selectedCron.value || "",
+            component: DropDown,
+            props: {
+                hintText: i18n.t("Select frequency"),
+                menuItems: cronExpressions.map(({ text, value: id }) => ({
+                    id,
+                    displayName: i18n.t(text),
+                })),
+                includeEmpty: true,
+                emptyLabel: i18n.t(defaultExpression),
+                style: { width: "100%" },
+            },
+            validators: [],
+        },
+        {
+            name: "frequency",
+            value: syncRule.frequency,
+            component: TextField,
+            props: {
+                floatingLabelText: i18n.t("Cron expression"),
+                style: { width: "100%" },
+                changeEvent: "onBlur",
+            },
+            validators: [
+                {
+                    message: i18n.t("Cron expression must be valid"),
+                    validator(value) {
+                        return !value || isValidCronExpression(value);
+                    },
+                },
+            ],
+        },
+    ];
+
+    return <FormBuilder fields={fields} onUpdateField={updateFields} />;
+};
+
+SchedulerStep.propTypes = {
+    syncRule: PropTypes.object.isRequired,
+    onChange: PropTypes.func.isRequired,
+};
+
+SchedulerStep.defaultProps = {};
+
+export default SchedulerStep;

--- a/src/components/rules-list-page/SyncRulesPage.jsx
+++ b/src/components/rules-list-page/SyncRulesPage.jsx
@@ -14,6 +14,7 @@ import { startSynchronization } from "../../logic/synchronization";
 import SyncReport from "../../models/syncReport";
 import SyncSummary from "../sync-summary/SyncSummary";
 import Dropdown from "../dropdown/Dropdown";
+import { getValidationMessages } from "../../utils/validations";
 
 const styles = () => ({
     tableContainer: { marginTop: -10 },
@@ -66,11 +67,16 @@ class SyncRulesPage extends React.Component {
                     .map(e => e.name)
                     .join(", "),
         },
+        { name: "frequency", text: i18n.t("Frequency"), sortable: true },
+        { name: "enabled", text: i18n.t("Scheduled"), sortable: true },
     ];
 
     detailsFields = [
         { name: "name", text: i18n.t("Name") },
         { name: "description", text: i18n.t("Description") },
+        { name: "frequency", text: i18n.t("Frequency"), sortable: true },
+        { name: "enabled", text: i18n.t("Scheduled"), sortable: true },
+        { name: "lastExecuted", text: i18n.t("Last executed"), sortable: true },
         {
             name: "targetInstances",
             text: i18n.t("Destination instances"),
@@ -150,6 +156,22 @@ class SyncRulesPage extends React.Component {
         loading.reset();
     };
 
+    toggleEnable = async data => {
+        const { d2, snackbar } = this.props;
+        const oldSyncRule = SyncRule.build(data);
+        const syncRule = oldSyncRule.updateEnabled(!oldSyncRule.enabled);
+
+        const errors = await getValidationMessages(d2, syncRule);
+        if (errors.length > 0) {
+            snackbar.error(errors.join("\n"), {
+                autoHideDuration: null,
+            });
+        } else {
+            await syncRule.save(d2);
+            snackbar.success(i18n.t("Successfully updated sync rule"));
+        }
+    };
+
     actions = [
         {
             name: "details",
@@ -175,6 +197,13 @@ class SyncRulesPage extends React.Component {
             multiple: false,
             onClick: this.executeRule,
             icon: "settings_input_antenna",
+        },
+        {
+            name: "toggleEnable",
+            text: i18n.t("Toggle scheduling"),
+            multiple: false,
+            onClick: this.toggleEnable,
+            icon: "timer",
         },
     ];
 

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@ import i18n from "@dhis2/d2-i18n";
 import "font-awesome/css/font-awesome.min.css";
 
 import App from "./components/app/App";
+import apiTranslations from "./utils/apiTranslations";
 import "./locales";
 
 function isLangRTL(code) {
@@ -27,6 +28,9 @@ function configI18n(userSettings) {
     document.documentElement.setAttribute("dir", isLangRTL(uiLocale) ? "rtl" : "ltr");
 
     i18n.changeLanguage(uiLocale);
+
+    const translations = apiTranslations[uiLocale] || apiTranslations.en;
+    i18n.addResources(uiLocale, "metadata-synchronization", translations);
 }
 
 async function getBaseUrl() {

--- a/src/models/syncRule.ts
+++ b/src/models/syncRule.ts
@@ -20,7 +20,6 @@ export default class SyncRule {
                 "id",
                 "name",
                 "description",
-                "originInstance",
                 "builder",
                 "enabled",
                 "frequency",
@@ -58,7 +57,6 @@ export default class SyncRule {
             id: "",
             name: "",
             description: "",
-            originInstance: "",
             builder: {
                 targetInstances: [],
                 metadataIds: [],

--- a/src/types/synchronization.d.ts
+++ b/src/types/synchronization.d.ts
@@ -58,4 +58,7 @@ export interface SynchronizationRule {
     description?: string;
     originInstance: string;
     builder: SynchronizationBuilder;
+    enabled: string;
+    lastExecuted?: Date;
+    frequency?: string;
 }

--- a/src/types/synchronization.d.ts
+++ b/src/types/synchronization.d.ts
@@ -56,7 +56,6 @@ export interface SynchronizationRule {
     id?: string;
     name: string;
     description?: string;
-    originInstance: string;
     builder: SynchronizationBuilder;
     enabled: string;
     lastExecuted?: Date;

--- a/src/utils/apiTranslations.js
+++ b/src/utils/apiTranslations.js
@@ -1,0 +1,13 @@
+const apiTranslations = {
+    en: {
+        // Cron expressions
+        CUSTOM: "Custom",
+        EVERY_DAY_MIDNIGHT: "Every day at midnight",
+        EVERY_DAY_THREE_AM: "Every day at 3 AM",
+        EVERY_HOUR: "Every hour",
+        EVERY_WEEK: "Every week",
+        EVERY_WEEKDAY_NOON: "Every day at noon",
+    },
+};
+
+export default apiTranslations;

--- a/src/utils/validCronExpression.js
+++ b/src/utils/validCronExpression.js
@@ -1,0 +1,85 @@
+const WEEKDAYS = ["MON", "TUE", "WED", "THU", "FRI", "SAT", "SUN"];
+const MONTHS = ["JAN", "FEB", "MAR", "APR", "MAY", "JUN", "JUL", "AUG", "SEP", "OCT", "NOV", "DEC"];
+
+const isValidFields = fields => fields && fields.length === 6;
+const isValidNumber = (number, x, y) => number >= x && number <= y;
+const isWildcard = field => field === "*";
+const isUndefined = field => field === "?";
+
+const isValidNumberRange = (range, x, y) => {
+    const boundaries = range.split("-");
+    if (!boundaries || boundaries.length !== 2) return false;
+
+    return (
+        isValidNumber(boundaries[0], x, y) &&
+        isValidNumber(boundaries[1], x, y) &&
+        boundaries[0] <= boundaries[1]
+    );
+};
+
+const isValidFraction = (fraction, x, y) => {
+    const components = fraction.split("/");
+    if (!components || components.length !== 2) return false;
+
+    return (
+        (isWildcard(components[0]) || isValidNumber(components[0], x, y)) &&
+        isValidNumber(components[1], x, y)
+    );
+};
+
+const isAlphabeticWeekday = field => {
+    const weekdays = field.split("-");
+    const [firstDay, secondDay] = weekdays.map(c => WEEKDAYS.indexOf(c));
+    return (
+        (firstDay !== -1 && secondDay === undefined) ||
+        (firstDay !== -1 && secondDay !== -1 && firstDay <= secondDay)
+    );
+};
+
+const isAlphabeticMonth = field => {
+    const months = field.split("-");
+    const [firstMonth, secondMonth] = months.map(m => MONTHS.indexOf(m));
+    return (
+        (firstMonth !== -1 && secondMonth === undefined) ||
+        (firstMonth !== -1 && secondMonth !== -1 && firstMonth <= secondMonth)
+    );
+};
+
+const isValidWithinRange = (field, x, y) =>
+    isWildcard(field) ||
+    isValidNumber(field, x, y) ||
+    isValidNumberRange(field, x, y) ||
+    isValidFraction(field, x, y);
+
+const isValidSecondField = field => isValidWithinRange(field, 0, 59);
+const isValidMinuteField = field => isValidWithinRange(field, 0, 59);
+const isValidHourField = field => isValidWithinRange(field, 0, 23);
+const isValidDayField = field => isValidWithinRange(field, 0, 31) || isUndefined(field);
+const isValidMonthField = field => isValidWithinRange(field, 1, 12) || isAlphabeticMonth(field);
+const isValidWeekdayField = field =>
+    isValidWithinRange(field, 1, 7) || isAlphabeticWeekday(field) || isUndefined(field);
+
+// isValidation of CronExpression, following the Spring Scheduling pattern:
+// - Documentation: https://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/scheduling/support/CronSequenceGenerator.html
+// - Source code: https://git.io/vpoqG
+const isValidCronExpression = exp => {
+    if (!exp) {
+        return false;
+    }
+
+    const fields = exp.trim().split(" ");
+    if (!isValidFields(fields)) {
+        return false;
+    }
+
+    return (
+        isValidSecondField(fields[0]) &&
+        isValidMinuteField(fields[1]) &&
+        isValidHourField(fields[2]) &&
+        isValidDayField(fields[3]) &&
+        isValidMonthField(fields[4]) &&
+        isValidWeekdayField(fields[5])
+    );
+};
+
+export default isValidCronExpression;

--- a/src/utils/validations.js
+++ b/src/utils/validations.js
@@ -5,14 +5,18 @@ const translations = {
     cannot_be_blank: namespace => i18n.t("Field {{field}} cannot be blank", namespace),
     url_username_combo_already_exists: () =>
         i18n.t("This URL and username combination already exists"),
-    cannot_be_empty: () => i18n.t("You need to select at least one element"),
+    cannot_be_empty: namespace => i18n.t("You need to select at least one {{element}}", namespace),
+    cron_expression_must_be_valid: namespace =>
+        i18n.t("Cron expression {{expression}} must be valid", namespace),
+    cannot_enable_without_valid: namespace =>
+        i18n.t("To enable a rule you need to enter a valid {{expression}}", namespace),
 };
 
-export async function getValidationMessages(d2, model, validationKeys) {
+export async function getValidationMessages(d2, model, validationKeys = null) {
     const validationObj = await model.validate(d2);
 
     return _(validationObj)
-        .at(validationKeys)
+        .at(validationKeys || _.keys(validationObj))
         .flatten()
         .compact()
         .map(error => {


### PR DESCRIPTION
### :pushpin: References

* **Issue:** Closes #112 

* This PR adds the basic functionality to stop blocking Phase 2 development

* UI/UX improvements should be implemented in upcoming PRs (example #131)

### :memo: Implementation

- Add new scheduling step to Sync Rules Wizard

- Fix general info step to be fully immutable

- Add validation before saving on Wizard

- Add new columns to Sync Rules Page to reflect scheduling

- Add cron expressions validation from @dhis2/scheduler-app

### :art: Screenshots

![image](https://user-images.githubusercontent.com/2181866/61174386-89b16c00-a59f-11e9-8532-8fcc6b317eac.png)

![image](https://user-images.githubusercontent.com/2181866/61174390-9209a700-a59f-11e9-9488-5ff15276a32a.png)

![image](https://user-images.githubusercontent.com/2181866/61174391-959d2e00-a59f-11e9-8d1d-b526c8fcd5fa.png)

![image](https://user-images.githubusercontent.com/2181866/61174394-9f269600-a59f-11e9-8954-62f89bd7cf26.png)

![image](https://user-images.githubusercontent.com/2181866/61174399-a9489480-a59f-11e9-9b37-cf5f04d9d2a0.png)

### :fire: Is there anything the reviewer should know to test it?

- Since we are using the dataStore as database and we are unable to store booleans, we do the string conversion on the model.

### :bookmark_tabs: Others
