### PR TITLE
[Scheduler] User friendly cron expressions

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2019-07-13T20:28:18.139Z\n"
-"PO-Revision-Date: 2019-07-13T20:28:18.139Z\n"
+"POT-Creation-Date: 2019-07-16T12:49:27.351Z\n"
+"PO-Revision-Date: 2019-07-16T12:49:27.351Z\n"
 
 msgid "Metadata Synchronization"
 msgstr ""
@@ -262,9 +262,6 @@ msgid "Frequency"
 msgstr ""
 
 msgid "Enabled"
-msgstr ""
-
-msgid "Select frequency"
 msgstr ""
 
 msgid "Cron expression"

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@material-ui/icons": "^4.2.1",
     "@material-ui/styles": "^4.2.0",
     "axios": "^0.19.0",
+    "cronstrue": "^1.81.0",
     "cryptr": "^4.0.2",
     "d2": "^31.1.1",
     "d2-manifest": "^1.0.0",

--- a/src/components/rules-creation-page/steps/SaveStep.jsx
+++ b/src/components/rules-creation-page/steps/SaveStep.jsx
@@ -9,6 +9,7 @@ import { ConfirmationDialog, withSnackbar } from "d2-ui-components";
 import { getInstances } from "./InstanceSelectionStep";
 import { getMetadata } from "../../../utils/synchronization";
 import { getValidationMessages } from "../../../utils/validations";
+import isValidCronExpression from "../../../utils/validCronExpression";
 
 const LiEntry = ({ label, value, children }) => {
     return (
@@ -108,10 +109,12 @@ const SaveStep = ({ d2, syncRule, classes, onCancel, snackbar }) => {
 
                 <LiEntry label={i18n.t("Scheduling enabled")} value={syncRule.enabled.toString()} />
 
-                <LiEntry
-                    label={i18n.t("Frequency")}
-                    value={`${cronstrue.toString(syncRule.frequency)} (${syncRule.frequency})`}
-                />
+                {isValidCronExpression(syncRule.frequency) && (
+                    <LiEntry
+                        label={i18n.t("Frequency")}
+                        value={`${cronstrue.toString(syncRule.frequency)} (${syncRule.frequency})`}
+                    />
+                )}
             </ul>
 
             <Button onClick={openCancelDialog} variant="contained">

--- a/src/components/rules-creation-page/steps/SaveStep.jsx
+++ b/src/components/rules-creation-page/steps/SaveStep.jsx
@@ -1,10 +1,10 @@
 import React, { useEffect, useState } from "react";
 import _ from "lodash";
 import PropTypes from "prop-types";
-import { Button, LinearProgress, withStyles } from "@material-ui/core";
-import { ConfirmationDialog, withSnackbar } from "d2-ui-components";
 import i18n from "@dhis2/d2-i18n";
 import cronstrue from "cronstrue";
+import { Button, LinearProgress, withStyles } from "@material-ui/core";
+import { ConfirmationDialog, withSnackbar } from "d2-ui-components";
 
 import { getInstances } from "./InstanceSelectionStep";
 import { getMetadata } from "../../../utils/synchronization";

--- a/src/components/rules-creation-page/steps/SaveStep.jsx
+++ b/src/components/rules-creation-page/steps/SaveStep.jsx
@@ -4,6 +4,7 @@ import PropTypes from "prop-types";
 import { Button, LinearProgress, withStyles } from "@material-ui/core";
 import { ConfirmationDialog, withSnackbar } from "d2-ui-components";
 import i18n from "@dhis2/d2-i18n";
+import cronstrue from "cronstrue";
 
 import { getInstances } from "./InstanceSelectionStep";
 import { getMetadata } from "../../../utils/synchronization";
@@ -107,7 +108,10 @@ const SaveStep = ({ d2, syncRule, classes, onCancel, snackbar }) => {
 
                 <LiEntry label={i18n.t("Scheduling enabled")} value={syncRule.enabled.toString()} />
 
-                <LiEntry label={i18n.t("Frequency")} value={syncRule.frequency} />
+                <LiEntry
+                    label={i18n.t("Frequency")}
+                    value={`${cronstrue.toString(syncRule.frequency)} (${syncRule.frequency})`}
+                />
             </ul>
 
             <Button onClick={openCancelDialog} variant="contained">

--- a/src/components/rules-creation-page/steps/SchedulerStep.jsx
+++ b/src/components/rules-creation-page/steps/SchedulerStep.jsx
@@ -2,10 +2,10 @@ import React from "react";
 import _ from "lodash";
 import PropTypes from "prop-types";
 import i18n from "@dhis2/d2-i18n";
+import cronstrue from "cronstrue";
 import { FormControlLabel, Switch } from "@material-ui/core";
 import { FormBuilder } from "@dhis2/d2-ui-forms";
-import { TextField, DropDown } from "@dhis2/d2-ui-core";
-import cronstrue from "cronstrue";
+import { DropDown, TextField } from "@dhis2/d2-ui-core";
 import isValidCronExpression from "../../../utils/validCronExpression";
 
 const defaultExpression = "CUSTOM";

--- a/src/components/rules-creation-page/steps/SchedulerStep.jsx
+++ b/src/components/rules-creation-page/steps/SchedulerStep.jsx
@@ -5,6 +5,7 @@ import i18n from "@dhis2/d2-i18n";
 import { FormControlLabel, Switch } from "@material-ui/core";
 import { FormBuilder } from "@dhis2/d2-ui-forms";
 import { TextField, DropDown } from "@dhis2/d2-ui-core";
+import cronstrue from "cronstrue";
 import isValidCronExpression from "../../../utils/validCronExpression";
 
 const defaultExpression = "CUSTOM";
@@ -56,7 +57,11 @@ const SchedulerStep = ({ syncRule, onChange }) => {
             value: selectedCron.value || "",
             component: DropDown,
             props: {
-                hintText: i18n.t("Select frequency"),
+                hintText: i18n.t(
+                    isValidCronExpression(syncRule.frequency)
+                        ? cronstrue.toString(syncRule.frequency)
+                        : "Select frequency"
+                ),
                 menuItems: cronExpressions.map(({ text, value: id }) => ({
                     id,
                     displayName: i18n.t(text),

--- a/src/components/rules-list-page/SyncRulesPage.jsx
+++ b/src/components/rules-list-page/SyncRulesPage.jsx
@@ -15,6 +15,9 @@ import SyncReport from "../../models/syncReport";
 import SyncSummary from "../sync-summary/SyncSummary";
 import Dropdown from "../dropdown/Dropdown";
 import { getValidationMessages } from "../../utils/validations";
+import { Tooltip } from "@material-ui/core";
+import cronstrue from "cronstrue";
+import isValidCronExpression from "../../utils/validCronExpression";
 
 const styles = () => ({
     tableContainer: { marginTop: -10 },
@@ -67,20 +70,34 @@ class SyncRulesPage extends React.Component {
                     .map(e => e.name)
                     .join(", "),
         },
-        { name: "frequency", text: i18n.t("Frequency"), sortable: true },
+        {
+            name: "frequency",
+            text: i18n.t("Frequency"),
+            sortable: true,
+            getValue: ({ frequency }) =>
+                isValidCronExpression(frequency)
+                    ? `${cronstrue.toString(frequency)} (${frequency})`
+                    : "",
+        },
         { name: "enabled", text: i18n.t("Scheduled"), sortable: true },
     ];
 
     detailsFields = [
         { name: "name", text: i18n.t("Name") },
         { name: "description", text: i18n.t("Description") },
-        { name: "frequency", text: i18n.t("Frequency"), sortable: true },
-        { name: "enabled", text: i18n.t("Scheduled"), sortable: true },
-        { name: "lastExecuted", text: i18n.t("Last executed"), sortable: true },
+        {
+            name: "frequency",
+            text: i18n.t("Frequency"),
+            getValue: ({ frequency }) =>
+                isValidCronExpression(frequency)
+                    ? `${cronstrue.toString(frequency)} (${frequency})`
+                    : "",
+        },
+        { name: "enabled", text: i18n.t("Scheduled") },
+        { name: "lastExecuted", text: i18n.t("Last executed") },
         {
             name: "targetInstances",
             text: i18n.t("Destination instances"),
-            sortable: true,
             getValue: ruleData => getValueForCollection(this.getTargetInstances(ruleData)),
         },
     ];

--- a/src/components/rules-list-page/SyncRulesPage.jsx
+++ b/src/components/rules-list-page/SyncRulesPage.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import _ from "lodash";
 import i18n from "@dhis2/d2-i18n";
+import cronstrue from "cronstrue";
 import { ConfirmationDialog, ObjectsTable, withLoading, withSnackbar } from "d2-ui-components";
 import { withRouter } from "react-router-dom";
 import { withStyles } from "@material-ui/core/styles";
@@ -15,7 +16,6 @@ import SyncReport from "../../models/syncReport";
 import SyncSummary from "../sync-summary/SyncSummary";
 import Dropdown from "../dropdown/Dropdown";
 import { getValidationMessages } from "../../utils/validations";
-import cronstrue from "cronstrue";
 import isValidCronExpression from "../../utils/validCronExpression";
 
 const styles = () => ({

--- a/src/components/rules-list-page/SyncRulesPage.jsx
+++ b/src/components/rules-list-page/SyncRulesPage.jsx
@@ -15,7 +15,6 @@ import SyncReport from "../../models/syncReport";
 import SyncSummary from "../sync-summary/SyncSummary";
 import Dropdown from "../dropdown/Dropdown";
 import { getValidationMessages } from "../../utils/validations";
-import { Tooltip } from "@material-ui/core";
 import cronstrue from "cronstrue";
 import isValidCronExpression from "../../utils/validCronExpression";
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3722,6 +3722,11 @@ create-hmac@^1.1.0, create-hmac@^1.1.2, create-hmac@^1.1.4:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
+cronstrue@^1.81.0:
+  version "1.81.0"
+  resolved "https://registry.yarnpkg.com/cronstrue/-/cronstrue-1.81.0.tgz#d618ae55ddc77e5de4bdd349c657bcb052c0ff44"
+  integrity sha512-4UUXedlzxRB4mHTOc9FECZuRv4ri4KE0/y7aclNvIme9doqFQ5Sswl6SU5R6LWSiwQ4GhNg1kqGKSQ8xPd1zrQ==
+
 cross-spawn@6.0.5, cross-spawn@^6.0.0, cross-spawn@^6.0.5:
   version "6.0.5"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"


### PR DESCRIPTION
### :pushpin: References

### :memo: Implementation

- In the sync rules wizard, when inserting a valid cron expression, we previsualize the result. If it's incorrect we have the default "Select frequency" placeholder.

- We should probably update the options we suggest in the dropdown to match the same auto generated string (but I guess we should think before which cron expressions are useful to the clients ie: Every day at 11PM from Monday to Friday)

### :art: Screenshots

![image](https://user-images.githubusercontent.com/2181866/61232535-cbbce800-a72e-11e9-8bb3-249c3fe527e1.png)

![image](https://user-images.githubusercontent.com/2181866/61232652-1e969f80-a72f-11e9-9096-d4d45325fd20.png)

![image](https://user-images.githubusercontent.com/2181866/61232735-4ab22080-a72f-11e9-98b1-31bff77dde5c.png)

![image](https://user-images.githubusercontent.com/2181866/61232783-63bad180-a72f-11e9-84aa-8acd21cc0ef4.png)

![image](https://user-images.githubusercontent.com/2181866/61232798-69b0b280-a72f-11e9-82c1-c1d0064db3ac.png)

### :fire: Is there anything the reviewer should know to test it?

- The library supports multiple locales, not sure if we want to enable that feature yet (they support more languages than us and could lead to mixed translations UI)

- Added as string interpolation, also tested adding tooltips but not sure what's the best approach.

![image](https://user-images.githubusercontent.com/2181866/61232858-91077f80-a72f-11e9-8b8f-9e69d528b27a.png)

### :bookmark_tabs: Others
