### PR TITLE
Deleted objects

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2019-07-23T10:59:57.868Z\n"
-"PO-Revision-Date: 2019-07-23T10:59:57.868Z\n"
+"POT-Creation-Date: 2019-08-05T07:57:08.531Z\n"
+"PO-Revision-Date: 2019-08-05T07:57:08.531Z\n"
 
 msgid "Metadata Synchronization"
 msgstr ""
@@ -173,6 +173,9 @@ msgid "Validation Rules"
 msgstr ""
 
 msgid "Synchronization Rules"
+msgstr ""
+
+msgid "Deleted objects"
 msgstr ""
 
 msgid "Name"
@@ -404,6 +407,18 @@ msgstr ""
 msgid "Data Elements Synchronization"
 msgstr ""
 
+msgid "Code"
+msgstr ""
+
+msgid "Deleted date"
+msgstr ""
+
+msgid "Deleted by"
+msgstr ""
+
+msgid "Deleted Objects Synchronization"
+msgstr ""
+
 msgid "Please select at least one element from the table to synchronize"
 msgstr ""
 
@@ -419,10 +434,13 @@ msgstr ""
 msgid "Validation Rules Synchronization"
 msgstr ""
 
-msgid "Fetching metadata from origin instance"
+msgid "Retrieving information from remote instances"
 msgstr ""
 
-msgid "Retrieving information from remote instances"
+msgid "Deleting objects in instance {{instance}}"
+msgstr ""
+
+msgid "Fetching metadata from origin instance"
 msgstr ""
 
 msgid "Importing data in instance {{instance}}"
@@ -447,9 +465,6 @@ msgid "Level"
 msgstr ""
 
 msgid "Short name"
-msgstr ""
-
-msgid "Code"
 msgstr ""
 
 msgid "ID"

--- a/src/components/app/App.jsx
+++ b/src/components/app/App.jsx
@@ -54,19 +54,21 @@ class App extends Component {
                     <MuiThemeProvider theme={muiTheme}>
                         <OldMuiThemeProvider muiTheme={muiThemeLegacy}>
                             <LoadingProvider>
-                                <React.Fragment>
-                                    {showHeader && (
-                                        <HeaderBar appName={i18n.t("Metadata Synchronization")} />
-                                    )}
+                                <SnackbarProvider>
+                                    <React.Fragment>
+                                        {showHeader && (
+                                            <HeaderBar
+                                                appName={i18n.t("Metadata Synchronization")}
+                                            />
+                                        )}
 
-                                    <div id="app" className="content">
-                                        <SnackbarProvider>
+                                        <div id="app" className="content">
                                             <Root d2={d2} />
-                                        </SnackbarProvider>
-                                    </div>
+                                        </div>
 
-                                    <Share visible={showShareButton} />
-                                </React.Fragment>
+                                        <Share visible={showShareButton} />
+                                    </React.Fragment>
+                                </SnackbarProvider>
                             </LoadingProvider>
                         </OldMuiThemeProvider>
                     </MuiThemeProvider>

--- a/src/components/app/App.jsx
+++ b/src/components/app/App.jsx
@@ -55,19 +55,15 @@ class App extends Component {
                         <OldMuiThemeProvider muiTheme={muiThemeLegacy}>
                             <LoadingProvider>
                                 <SnackbarProvider>
-                                    <React.Fragment>
-                                        {showHeader && (
-                                            <HeaderBar
-                                                appName={i18n.t("Metadata Synchronization")}
-                                            />
-                                        )}
+                                    {showHeader && (
+                                        <HeaderBar appName={i18n.t("Metadata Synchronization")} />
+                                    )}
 
-                                        <div id="app" className="content">
-                                            <Root d2={d2} />
-                                        </div>
+                                    <div id="app" className="content">
+                                        <Root d2={d2} />
+                                    </div>
 
-                                        <Share visible={showShareButton} />
-                                    </React.Fragment>
+                                    <Share visible={showShareButton} />
                                 </SnackbarProvider>
                             </LoadingProvider>
                         </OldMuiThemeProvider>

--- a/src/components/app/Root.jsx
+++ b/src/components/app/Root.jsx
@@ -9,6 +9,7 @@ import OrganisationUnitPage from "../synchronization-page/OrganisationUnitPage";
 import DataElementPage from "../synchronization-page/DataElementPage";
 import IndicatorPage from "../synchronization-page/IndicatorPage";
 import ValidationRulePage from "../synchronization-page/ValidationRulePage";
+import DeletedObjectsPage from "../synchronization-page/DeletedObjectsPage";
 import HistoryPage from "../history-list-page/HistoryPage";
 import SyncRulesWizard from "../rules-creation-page/SyncRulesWizard";
 import SyncRulesConfigurator from "../rules-list-page/SyncRulesPage";
@@ -51,6 +52,11 @@ class Root extends React.Component {
                 <Route
                     path="/sync/validationRules"
                     render={props => <ValidationRulePage d2={d2} {...props} />}
+                />
+
+                <Route
+                    path="/sync/deleted"
+                    render={props => <DeletedObjectsPage d2={d2} {...props} />}
                 />
 
                 <Route path="/history" render={props => <HistoryPage d2={d2} {...props} />} />

--- a/src/components/dropdown/Dropdown.jsx
+++ b/src/components/dropdown/Dropdown.jsx
@@ -74,9 +74,9 @@ export default function Dropdown({ items, value, onChange, label, hideEmpty }) {
                     }}
                 >
                     {!hideEmpty && <MenuItem value={""}>{i18n.t("<No value>")}</MenuItem>}
-                    {items.map(i => (
-                        <MenuItem key={i.id} value={i.id}>
-                            {i.name}
+                    {items.map((element, index) => (
+                        <MenuItem key={`element-${index}`} value={element.id}>
+                            {element.name}
                         </MenuItem>
                     ))}
                 </Select>

--- a/src/components/landing-page/LandingPage.jsx
+++ b/src/components/landing-page/LandingPage.jsx
@@ -43,9 +43,9 @@ const styles = () => ({
     },
 });
 
-const GRID_ITEM_BIG = 12;
-const GRID_ITEM_MEDIUM = 6;
-const GRID_ITEM_SMALL = 3;
+const GRID_ROW_1 = 12;
+const GRID_ROW_3 = 3;
+const GRID_ROW_4 = 4;
 
 class LandingPage extends React.Component {
     static propTypes = {
@@ -55,18 +55,19 @@ class LandingPage extends React.Component {
     render() {
         const { classes } = this.props;
         const items = [
-            ["instance-configurator", i18n.t("Instance Configuration"), "edit", GRID_ITEM_BIG],
-            ["sync/organisationUnits", i18n.t("Organisation Units"), "sync", GRID_ITEM_SMALL],
-            ["sync/dataElements", i18n.t("Data Elements"), "sync", GRID_ITEM_SMALL],
-            ["sync/indicators", i18n.t("Indicators"), "sync", GRID_ITEM_SMALL],
-            ["sync/validationRules", i18n.t("Validation Rules"), "sync", GRID_ITEM_SMALL],
+            ["instance-configurator", i18n.t("Instance Configuration"), "edit", GRID_ROW_1],
+            ["sync/organisationUnits", i18n.t("Organisation Units"), "sync", GRID_ROW_3],
+            ["sync/dataElements", i18n.t("Data Elements"), "sync", GRID_ROW_3],
+            ["sync/indicators", i18n.t("Indicators"), "sync", GRID_ROW_3],
+            ["sync/validationRules", i18n.t("Validation Rules"), "sync", GRID_ROW_3],
             [
                 "synchronization-rules",
                 i18n.t("Synchronization Rules"),
                 "playlist_add_check",
-                GRID_ITEM_MEDIUM,
+                GRID_ROW_4,
             ],
-            ["history", i18n.t("Synchronization History"), "history", GRID_ITEM_MEDIUM],
+            ["sync/deleted", i18n.t("Deleted objects"), "delete", GRID_ROW_4],
+            ["history", i18n.t("Synchronization History"), "history", GRID_ROW_4],
         ];
         const menuItems = items.map(([key, title, icon, xs]) => (
             <Grid item xs={xs} className={classes.item} key={key}>

--- a/src/components/metadata-table/MetadataTable.jsx
+++ b/src/components/metadata-table/MetadataTable.jsx
@@ -277,6 +277,7 @@ class MetadataTable extends React.Component {
                 customFiltersComponent={this.renderCustomFilters}
                 customFilters={filters}
                 initialSelection={initialSelection}
+                forceSelectionColumn={true}
                 {...rest}
             />
         );

--- a/src/components/rules-creation-page/steps/SaveStep.jsx
+++ b/src/components/rules-creation-page/steps/SaveStep.jsx
@@ -53,7 +53,7 @@ const SaveStep = ({ d2, syncRule, classes, onCancel, snackbar }) => {
     };
 
     useEffect(() => {
-        getMetadata(d2, syncRule.metadataIds, "id,name").then(updateMetadata);
+        getMetadata(d2.Api.getApi().baseUrl, syncRule.metadataIds, "id,name").then(updateMetadata);
         getInstances(d2).then(setInstanceOptions);
     }, [d2, syncRule]);
 

--- a/src/components/rules-creation-page/steps/SaveStep.jsx
+++ b/src/components/rules-creation-page/steps/SaveStep.jsx
@@ -6,6 +6,7 @@ import { Button, LinearProgress, withStyles } from "@material-ui/core";
 import { ConfirmationDialog, withSnackbar } from "d2-ui-components";
 
 import { getInstances } from "./InstanceSelectionStep";
+import { getBaseUrl } from "../../../utils/d2";
 import { getMetadata } from "../../../utils/synchronization";
 import { getValidationMessages } from "../../../utils/validations";
 
@@ -53,7 +54,7 @@ const SaveStep = ({ d2, syncRule, classes, onCancel, snackbar }) => {
     };
 
     useEffect(() => {
-        getMetadata(d2.Api.getApi().baseUrl, syncRule.metadataIds, "id,name").then(updateMetadata);
+        getMetadata(getBaseUrl(d2), syncRule.metadataIds, "id,name").then(updateMetadata);
         getInstances(d2).then(setInstanceOptions);
     }, [d2, syncRule]);
 

--- a/src/components/synchronization-page/DeletedObjectsPage.jsx
+++ b/src/components/synchronization-page/DeletedObjectsPage.jsx
@@ -20,6 +20,8 @@ class DeletedObjectsPage extends React.Component {
         },
     };
 
+    buttonLabel = <DeleteIcon />;
+
     models = [
         {
             getInitialSorting: () => ["deletedAt", "desc"],
@@ -53,7 +55,6 @@ class DeletedObjectsPage extends React.Component {
         const { d2 } = this.props;
 
         const title = i18n.t("Deleted Objects Synchronization");
-        const buttonLabel = <DeleteIcon />;
 
         return (
             <GenericSynchronizationPage
@@ -62,7 +63,7 @@ class DeletedObjectsPage extends React.Component {
                 models={this.models}
                 list={DeletedObject.list}
                 isDelete={true}
-                buttonLabel={buttonLabel}
+                buttonLabel={this.buttonLabel}
             />
         );
     }

--- a/src/components/synchronization-page/DeletedObjectsPage.jsx
+++ b/src/components/synchronization-page/DeletedObjectsPage.jsx
@@ -20,46 +20,49 @@ class DeletedObjectsPage extends React.Component {
         },
     };
 
-    model = {
-        getInitialSorting: () => ["deletedAt", "desc"],
-        getColumns: () => [
-            { name: "id", text: i18n.t("Identifier"), sortable: true },
-            { name: "code", text: i18n.t("Code"), sortable: true },
-            { name: "klass", text: i18n.t("Metadata type"), sortable: true },
-            { name: "deletedAt", text: i18n.t("Deleted date"), sortable: true },
-            { name: "deletedBy", text: i18n.t("Deleted by"), sortable: true },
-        ],
-        getDetails: () => [
-            { name: "id", text: i18n.t("Identifier") },
-            { name: "code", text: i18n.t("Code") },
-            { name: "klass", text: i18n.t("Metadata type") },
-            { name: "deletedAt", text: i18n.t("Deleted date") },
-            { name: "deletedBy", text: i18n.t("Deleted by") },
-        ],
-        getGroupFilterName: () => null,
-        getLevelFilterName: () => null,
-        getMetadataType: () => "deletedObjects",
-        getD2Model: () => ({
-            displayName: "Deleted Objects",
-            modelValidations: {
-                updatedAt: { type: "DATE" },
-            },
-        }),
-    };
+    models = [
+        {
+            getInitialSorting: () => ["deletedAt", "desc"],
+            getColumns: () => [
+                { name: "id", text: i18n.t("Identifier"), sortable: true },
+                { name: "code", text: i18n.t("Code"), sortable: true },
+                { name: "klass", text: i18n.t("Metadata type"), sortable: true },
+                { name: "deletedAt", text: i18n.t("Deleted date"), sortable: true },
+                { name: "deletedBy", text: i18n.t("Deleted by"), sortable: true },
+            ],
+            getDetails: () => [
+                { name: "id", text: i18n.t("Identifier") },
+                { name: "code", text: i18n.t("Code") },
+                { name: "klass", text: i18n.t("Metadata type") },
+                { name: "deletedAt", text: i18n.t("Deleted date") },
+                { name: "deletedBy", text: i18n.t("Deleted by") },
+            ],
+            getGroupFilterName: () => null,
+            getLevelFilterName: () => null,
+            getMetadataType: () => "deletedObjects",
+            getD2Model: () => ({
+                displayName: "Deleted Objects",
+                modelValidations: {
+                    updatedAt: { type: "DATE" },
+                },
+            }),
+        },
+    ];
 
     render() {
         const { d2 } = this.props;
 
         const title = i18n.t("Deleted Objects Synchronization");
+        const buttonLabel = <DeleteIcon />;
 
         return (
             <GenericSynchronizationPage
                 d2={d2}
                 title={title}
-                models={[this.model]}
+                models={this.models}
                 list={DeletedObject.list}
                 isDelete={true}
-                buttonLabel={<DeleteIcon />}
+                buttonLabel={buttonLabel}
             />
         );
     }

--- a/src/components/synchronization-page/DeletedObjectsPage.jsx
+++ b/src/components/synchronization-page/DeletedObjectsPage.jsx
@@ -1,0 +1,68 @@
+import React from "react";
+import PropTypes from "prop-types";
+import i18n from "@dhis2/d2-i18n";
+import DeleteIcon from "@material-ui/icons/Delete";
+import { withLoading } from "d2-ui-components";
+
+import GenericSynchronizationPage from "./GenericSynchronizationPage";
+import DeletedObject from "../../models/deletedObjects";
+
+class DeletedObjectsPage extends React.Component {
+    static propTypes = {
+        d2: PropTypes.object.isRequired,
+    };
+
+    state = {
+        filters: {
+            deletedAtFilter: null,
+            deletedByFilter: null,
+            metadataTypeFilter: null,
+        },
+    };
+
+    model = {
+        getInitialSorting: () => ["deletedAt", "desc"],
+        getColumns: () => [
+            { name: "id", text: i18n.t("Identifier"), sortable: true },
+            { name: "code", text: i18n.t("Code"), sortable: true },
+            { name: "klass", text: i18n.t("Metadata type"), sortable: true },
+            { name: "deletedAt", text: i18n.t("Deleted date"), sortable: true },
+            { name: "deletedBy", text: i18n.t("Deleted by"), sortable: true },
+        ],
+        getDetails: () => [
+            { name: "id", text: i18n.t("Identifier") },
+            { name: "code", text: i18n.t("Code") },
+            { name: "klass", text: i18n.t("Metadata type") },
+            { name: "deletedAt", text: i18n.t("Deleted date") },
+            { name: "deletedBy", text: i18n.t("Deleted by") },
+        ],
+        getGroupFilterName: () => null,
+        getLevelFilterName: () => null,
+        getMetadataType: () => "deletedObjects",
+        getD2Model: () => ({
+            displayName: "Deleted Objects",
+            modelValidations: {
+                updatedAt: { type: "DATE" },
+            },
+        }),
+    };
+
+    render() {
+        const { d2 } = this.props;
+
+        const title = i18n.t("Deleted Objects Synchronization");
+
+        return (
+            <GenericSynchronizationPage
+                d2={d2}
+                title={title}
+                models={[this.model]}
+                list={DeletedObject.list}
+                isDelete={true}
+                buttonLabel={<DeleteIcon />}
+            />
+        );
+    }
+}
+
+export default withLoading(DeletedObjectsPage);

--- a/src/logic/delete.ts
+++ b/src/logic/delete.ts
@@ -1,0 +1,61 @@
+import i18n from "@dhis2/d2-i18n";
+
+import Instance from "../models/instance";
+import SyncReport from "../models/syncReport";
+import { getMetadata, postMetadata, cleanImportResponse } from "../utils/synchronization";
+import { D2, MetadataImportStatus } from "../types/d2";
+import {
+    SynchronizationBuilder,
+    SynchronizationState,
+    SynchronizationReportStatus,
+} from "../types/synchronization";
+
+export async function* startDelete(
+    d2: D2,
+    builder: SynchronizationBuilder
+): AsyncIterableIterator<SynchronizationState> {
+    const { targetInstances: targetInstanceIds, metadataIds } = builder;
+
+    // Phase 1: Compare for each destination instance if the ids exists
+    console.debug("Start delete process");
+    yield { message: i18n.t("Retrieving information from remote instances") };
+
+    const targetInstances: Instance[] = await Promise.all(
+        targetInstanceIds.map(id => Instance.get(d2, id))
+    );
+
+    const syncReport = SyncReport.build({
+        user: d2.currentUser.username,
+        types: ["deletedObjects"],
+        status: "RUNNING" as SynchronizationReportStatus,
+    });
+    syncReport.addSyncResult(
+        ...targetInstances.map(instance => ({
+            instance: instance.toObject(),
+            status: "PENDING" as MetadataImportStatus,
+            date: new Date(),
+        }))
+    );
+    yield { syncReport };
+
+    for (const instance of targetInstances) {
+        yield {
+            message: i18n.t("Deleting objects in instance {{instance}}", {
+                instance: instance.name,
+            }),
+        };
+        console.debug("Deleting metadata on destination instance", instance, metadataIds);
+        const itemsToDelete = await getMetadata(instance.apiUrl, metadataIds, "id", instance.auth);
+        const response = await postMetadata(instance, itemsToDelete, { importStrategy: "DELETE" });
+
+        syncReport.addSyncResult(cleanImportResponse(response, instance));
+        console.debug("Finished deleting metadata on instance", instance, itemsToDelete);
+        yield { syncReport };
+    }
+
+    // Phase 5: Update parent task status
+    syncReport.setStatus(syncReport.hasErrors() ? "FAILURE" : "DONE");
+    yield { syncReport, done: true };
+
+    return syncReport;
+}

--- a/src/logic/metadata.ts
+++ b/src/logic/metadata.ts
@@ -4,7 +4,7 @@ import axios from "axios";
 import { D2, ModelCollection, Params } from "../types/d2";
 import { TableFilters, TableList, TablePagination } from "../types/d2-ui-components";
 import { getMetadata } from "../utils/synchronization";
-import { d2BaseModelDetails } from "../utils/d2";
+import { d2BaseModelDetails, getBaseUrl } from "../utils/d2";
 
 export async function listByIds(
     d2: D2,
@@ -17,7 +17,7 @@ export async function listByIds(
     const [field, direction] = sorting;
 
     const metadata = await getMetadata(
-        d2.Api.getApi().baseUrl,
+        getBaseUrl(d2),
         ids,
         fields ? fields.join(",") : d2BaseModelDetails.map(e => e.name).join(",")
     );
@@ -54,17 +54,14 @@ export async function getDeletedObjects(
     d2: D2,
     originalParams?: Params
 ): Promise<Pick<ModelCollection, "toArray" | "pager">> {
-    const { deletedObjects, pager } = (await axios.get(
-        d2.Api.getApi().baseUrl + "/deletedObjects",
-        {
-            withCredentials: true,
-            params: {
-                fields: ":all",
-                ...originalParams,
-                paging: false, // DHIS2 deletedObjects endpoint pager does not work properly
-            },
-        }
-    )).data;
+    const { deletedObjects, pager } = (await axios.get(getBaseUrl(d2) + "/deletedObjects", {
+        withCredentials: true,
+        params: {
+            fields: ":all",
+            ...originalParams,
+            paging: false, // DHIS2 deletedObjects endpoint pager does not work properly
+        },
+    })).data;
 
     return { toArray: () => deletedObjects, pager };
 }

--- a/src/logic/metadata.ts
+++ b/src/logic/metadata.ts
@@ -1,6 +1,7 @@
 import _ from "lodash";
+import axios from "axios";
 
-import { D2 } from "../types/d2";
+import { D2, ModelCollection, Params } from "../types/d2";
 import { TableFilters, TableList, TablePagination } from "../types/d2-ui-components";
 import { getMetadata } from "../utils/synchronization";
 import { d2BaseModelDetails } from "../utils/d2";
@@ -16,7 +17,7 @@ export async function listByIds(
     const [field, direction] = sorting;
 
     const metadata = await getMetadata(
-        d2,
+        d2.Api.getApi().baseUrl,
         ids,
         fields ? fields.join(",") : d2BaseModelDetails.map(e => e.name).join(",")
     );
@@ -47,4 +48,23 @@ export async function listByIds(
     const paginatedData = _.slice(sortedData, currentlyShown, currentlyShown + pageSize);
 
     return { objects: paginatedData, pager: { page, total } };
+}
+
+export async function getDeletedObjects(
+    d2: D2,
+    originalParams?: Params
+): Promise<Pick<ModelCollection, "toArray" | "pager">> {
+    const { deletedObjects, pager } = (await axios.get(
+        d2.Api.getApi().baseUrl + "/deletedObjects",
+        {
+            withCredentials: true,
+            params: {
+                fields: ":all",
+                ...originalParams,
+                paging: false, // DHIS2 deletedObjects endpoint pager does not work properly
+            },
+        }
+    )).data;
+
+    return { toArray: () => deletedObjects, pager };
 }

--- a/src/logic/synchronization.ts
+++ b/src/logic/synchronization.ts
@@ -12,7 +12,6 @@ import {
     NestedRules,
     SynchronizationBuilder,
     SynchronizationReportStatus,
-    SynchronizationResult,
     SynchronizationState,
 } from "../types/synchronization";
 import {
@@ -22,8 +21,8 @@ import {
     getAllReferences,
     getMetadata,
     postMetadata,
+    cleanImportResponse,
 } from "../utils/synchronization";
-import { getClassName } from "../utils/d2";
 import SyncRule from "../models/syncRule";
 
 async function exportMetadata(d2: D2, originalBuilder: ExportBuilder): Promise<MetadataPackage> {
@@ -38,7 +37,8 @@ async function exportMetadata(d2: D2, originalBuilder: ExportBuilder): Promise<M
         const nestedIncludeRules: NestedRules = buildNestedRules(includeRules);
 
         // Get all the required metadata
-        const syncMetadata = await getMetadata(d2, ids);
+        const { baseUrl } = d2.Api.getApi();
+        const syncMetadata = await getMetadata(baseUrl, ids);
         const elements = syncMetadata[model.plural] || [];
 
         for (const element of elements) {
@@ -73,57 +73,17 @@ async function exportMetadata(d2: D2, originalBuilder: ExportBuilder): Promise<M
     return recursiveExport(originalBuilder);
 }
 
-async function importMetadata(
-    instance: Instance,
-    metadataPackage: MetadataPackage
-): Promise<SynchronizationResult> {
-    const importResult = await postMetadata(instance, metadataPackage);
-
-    const typeStats: any[] = [];
-    const messages: any[] = [];
-
-    if (importResult.typeReports) {
-        importResult.typeReports.forEach(report => {
-            const { klass, stats, objectReports = [] } = report;
-
-            typeStats.push({
-                ...stats,
-                type: getClassName(klass),
-            });
-
-            objectReports.forEach((detail: any) => {
-                const { uid, errorReports = [] } = detail;
-
-                messages.push(
-                    ..._.take(errorReports, 1).map((error: any) => ({
-                        uid,
-                        type: getClassName(error.mainKlass),
-                        property: error.errorProperty,
-                        message: error.message,
-                    }))
-                );
-            });
-        });
-    }
-
-    return {
-        ..._.pick(importResult, ["status", "stats"]),
-        instance: _.pick(instance, ["id", "name", "url", "username"]),
-        report: { typeStats, messages },
-        date: new Date(),
-    };
-}
-
 export async function* startSynchronization(
     d2: D2,
     builder: SynchronizationBuilder
 ): AsyncIterableIterator<SynchronizationState> {
     const { targetInstances: targetInstanceIds, metadataIds, syncRule } = builder;
+    const { baseUrl } = d2.Api.getApi();
 
     // Phase 1: Export and package metadata from origin instance
     console.debug("Start synchronization process");
     yield { message: i18n.t("Fetching metadata from origin instance") };
-    const metadata = await getMetadata(d2, metadataIds, "id");
+    const metadata = await getMetadata(baseUrl, metadataIds, "id");
     const exportPromises = _.keys(metadata)
         .map(type => {
             const myClass = d2ModelFactory(d2, type);
@@ -168,8 +128,9 @@ export async function* startSynchronization(
             }),
         };
         console.debug("Start import on destination instance", instance);
-        const result = await importMetadata(instance, metadataPackage);
-        syncReport.addSyncResult(result);
+        const response = await postMetadata(instance, metadataPackage);
+
+        syncReport.addSyncResult(cleanImportResponse(response, instance));
         console.debug("Finished importing data on instance", instance);
         yield { syncReport };
     }

--- a/src/models/dataStore.ts
+++ b/src/models/dataStore.ts
@@ -3,20 +3,23 @@ import axios from "axios";
 
 import { D2, Response } from "../types/d2";
 import { TableFilters, TableList, TablePagination } from "../types/d2-ui-components";
+import { getBaseUrl } from "../utils/d2";
 
 const dataStoreNamespace = "metadata-synchronization";
 
 export async function getDataStore(d2: D2, dataStoreKey: string, defaultValue: any): Promise<any> {
+    const baseUrl = getBaseUrl(d2);
+
     try {
         const response = await axios.get(
-            d2.Api.getApi().baseUrl + `/dataStore/${dataStoreNamespace}/${dataStoreKey}`,
+            baseUrl + `/dataStore/${dataStoreNamespace}/${dataStoreKey}`,
             { withCredentials: true }
         );
         return response.data;
     } catch (error) {
         if (error.response && error.response.status === 404) {
             await axios.post(
-                d2.Api.getApi().baseUrl + `/dataStore/${dataStoreNamespace}/${dataStoreKey}`,
+                baseUrl + `/dataStore/${dataStoreNamespace}/${dataStoreKey}`,
                 defaultValue,
                 { withCredentials: true }
             );
@@ -28,19 +31,16 @@ export async function getDataStore(d2: D2, dataStoreKey: string, defaultValue: a
 }
 
 export async function saveDataStore(d2: D2, dataStoreKey: string, value: any): Promise<void> {
+    const baseUrl = getBaseUrl(d2);
     try {
-        await axios.put(
-            d2.Api.getApi().baseUrl + `/dataStore/${dataStoreNamespace}/${dataStoreKey}`,
-            value,
-            { withCredentials: true }
-        );
+        await axios.put(baseUrl + `/dataStore/${dataStoreNamespace}/${dataStoreKey}`, value, {
+            withCredentials: true,
+        });
     } catch (error) {
         if (error.response && error.response.status === 404) {
-            await axios.post(
-                d2.Api.getApi().baseUrl + `/dataStore/${dataStoreNamespace}/${dataStoreKey}`,
-                value,
-                { withCredentials: true }
-            );
+            await axios.post(baseUrl + `/dataStore/${dataStoreNamespace}/${dataStoreKey}`, value, {
+                withCredentials: true,
+            });
         } else {
             throw error;
         }
@@ -49,10 +49,9 @@ export async function saveDataStore(d2: D2, dataStoreKey: string, value: any): P
 
 export async function deleteDataStore(d2: D2, dataStoreKey: string): Promise<void> {
     try {
-        await axios.delete(
-            d2.Api.getApi().baseUrl + `/dataStore/${dataStoreNamespace}/${dataStoreKey}`,
-            { withCredentials: true }
-        );
+        await axios.delete(getBaseUrl(d2) + `/dataStore/${dataStoreNamespace}/${dataStoreKey}`, {
+            withCredentials: true,
+        });
     } catch (error) {
         if (!error.response || error.response.status !== 404) {
             throw error;

--- a/src/models/deletedObjects.ts
+++ b/src/models/deletedObjects.ts
@@ -3,6 +3,7 @@ import axios from "axios";
 
 import { D2 } from "../types/d2";
 import { TableList, TablePagination, TableFilters } from "../types/d2-ui-components";
+import { getBaseUrl } from "../utils/d2";
 
 type DeletedObjectData = {
     uid: string;
@@ -35,7 +36,7 @@ export default class DeletedObject {
         return this.data.deletedBy;
     }
 
-    public static build(data: any | undefined): DeletedObject {
+    public static build(data: DeletedObjectData | undefined): DeletedObject {
         return new DeletedObject(
             data || {
                 uid: "",
@@ -56,16 +57,13 @@ export default class DeletedObject {
         const { page = 1, pageSize = 20, paging = true, sorting = ["id", "asc"] } =
             pagination || {};
 
-        const { deletedObjects: rawData } = (await axios.get(
-            d2.Api.getApi().baseUrl + "/deletedObjects",
-            {
-                withCredentials: true,
-                params: {
-                    fields: ":all,uid~rename(id)",
-                    paging: false,
-                },
-            }
-        )).data;
+        const { deletedObjects: rawData } = (await axios.get(getBaseUrl(d2) + "/deletedObjects", {
+            withCredentials: true,
+            params: {
+                fields: ":all,uid~rename(id)",
+                paging: false,
+            },
+        })).data;
 
         const filteredData = search
             ? _.filter(rawData, o =>

--- a/src/models/deletedObjects.ts
+++ b/src/models/deletedObjects.ts
@@ -1,0 +1,94 @@
+import _ from "lodash";
+import axios from "axios";
+
+import { D2 } from "../types/d2";
+import { TableList, TablePagination, TableFilters } from "../types/d2-ui-components";
+
+type DeletedObjectData = {
+    uid: string;
+    code: string;
+    klass: string;
+    deletedAt: Date;
+    deletedBy: string;
+};
+
+export default class DeletedObject {
+    private data: DeletedObjectData;
+
+    constructor(data: DeletedObjectData) {
+        this.data = data;
+    }
+
+    public get code(): string {
+        return this.data.code;
+    }
+
+    public get klass(): string {
+        return this.data.klass;
+    }
+
+    public get deletedAt(): Date {
+        return this.data.deletedAt;
+    }
+
+    public get deletedBy(): string {
+        return this.data.deletedBy;
+    }
+
+    public static build(data: any | undefined): DeletedObject {
+        return new DeletedObject(
+            data || {
+                uid: "",
+                code: "",
+                klass: "",
+                deletedAt: new Date(),
+                deletedBy: "",
+            }
+        );
+    }
+
+    public static async list(
+        d2: D2,
+        filters: TableFilters,
+        pagination: TablePagination
+    ): Promise<TableList> {
+        const { search = null } = filters || {};
+        const { page = 1, pageSize = 20, paging = true, sorting = ["id", "asc"] } =
+            pagination || {};
+
+        const { deletedObjects: rawData } = (await axios.get(
+            d2.Api.getApi().baseUrl + "/deletedObjects",
+            {
+                withCredentials: true,
+                params: {
+                    fields: ":all,uid~rename(id)",
+                    paging: false,
+                },
+            }
+        )).data;
+
+        const filteredData = search
+            ? _.filter(rawData, o =>
+                  _(o)
+                      .keys()
+                      .filter(k => typeof o[k] === "string")
+                      .some(k => o[k].toLowerCase().includes(search.toLowerCase()))
+              )
+            : rawData;
+
+        const [field, direction] = sorting;
+        const sortedData = _.orderBy(
+            filteredData,
+            [data => (data[field] ? data[field].toLowerCase() : "")],
+            [direction as "asc" | "desc"]
+        );
+
+        const total = sortedData.length;
+        const pageCount = paging ? Math.ceil(sortedData.length / pageSize) : 1;
+        const firstItem = paging ? (page - 1) * pageSize : 0;
+        const lastItem = paging ? firstItem + pageSize : sortedData.length;
+        const paginatedData = _.slice(sortedData, firstItem, lastItem);
+
+        return { objects: paginatedData, pager: { page, pageCount, total } };
+    }
+}

--- a/src/models/instance.ts
+++ b/src/models/instance.ts
@@ -123,7 +123,7 @@ export default class Instance {
     }
 
     public setUrl(url: string): Instance {
-        return new Instance({ ...this.data, url });
+        return new Instance({ ...this.data, url: url.replace(/\/+$/, "") });
     }
 
     public setUsername(username: string): Instance {

--- a/src/models/instance.ts
+++ b/src/models/instance.ts
@@ -1,5 +1,5 @@
 import _ from "lodash";
-import axios from "axios";
+import axios, { AxiosBasicCredentials } from "axios";
 import Cryptr from "cryptr";
 import i18n from "@dhis2/d2-i18n";
 import { generateUid } from "d2/uid";
@@ -43,6 +43,10 @@ export default class Instance {
         return this.data.url;
     }
 
+    public get apiUrl(): string {
+        return this.data.url + "/api";
+    }
+
     public get username(): string {
         return this.data.username;
     }
@@ -53,6 +57,10 @@ export default class Instance {
 
     public get description(): string {
         return this.data.description ? this.data.description : "";
+    }
+
+    public get auth(): AxiosBasicCredentials {
+        return { username: this.data.username, password: this.data.password };
     }
 
     public static setEncryptionKey(encryptionKey: string): void {

--- a/src/types/d2.d.ts
+++ b/src/types/d2.d.ts
@@ -30,22 +30,9 @@ export interface D2Api {
 }
 
 export interface Pager {
-    nextPage: string;
-    prevPage: string;
     page: number;
     pageCount: number;
     total: number;
-    query: Params;
-
-    getNextPage(): Promise<ModelCollection>;
-
-    getPreviousPage(): Promise<ModelCollection>;
-
-    goToPage(): Promise<ModelCollection>;
-
-    hasNextPage(): boolean;
-
-    hasPreviousPage(): boolean;
 }
 
 export interface ModelCollection {

--- a/src/utils/d2.ts
+++ b/src/utils/d2.ts
@@ -66,3 +66,5 @@ export function getClassName(className: string): string | undefined {
         .split(".")
         .last();
 }
+
+export const getBaseUrl = (d2: D2): string => d2.Api.getApi().baseUrl;

--- a/src/utils/synchronization.ts
+++ b/src/utils/synchronization.ts
@@ -70,7 +70,7 @@ export async function getMetadata(
 
 export async function postMetadata(
     instance: Instance,
-    metadata: any,
+    metadata: object,
     additionalParams?: MetadataImportParams
 ): Promise<MetadataImportResponse> {
     try {


### PR DESCRIPTION
### :pushpin: References

* **Issue:** Closes #100 
* **Depends on:** https://github.com/EyeSeeTea/d2-ui-components/pull/57

### :memo: Implementation

- Add a new SyncPage that hosts all the deleted objects of the instance

- Before asking to delete the objects on destination, we query destination to see if they still exists

- We have re-used as much code as possible, everything works with the same Generic Sync Page that we use for programmatic metadata synchronizations.

### :art: Screenshots

![image](https://user-images.githubusercontent.com/2181866/62608234-c9017d00-b8ff-11e9-8241-f226a9f856d4.png)

### :fire: Is there anything the reviewer should know to test it?

- Deletion is not a fully working feature of DHIS2, for example it will fail if you are deleting an organisation that has children or if you are deleting an object that has been re-created with the same id after being deleted.

### :bookmark_tabs: Others
