### PR TITLE
Add new metadata types for programs

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2019-09-17T10:45:09.309Z\n"
-"PO-Revision-Date: 2019-09-17T10:45:09.309Z\n"
+"POT-Creation-Date: 2019-10-10T16:55:48.806Z\n"
+"PO-Revision-Date: 2019-10-10T16:55:48.806Z\n"
 
 msgid "Metadata Synchronization"
 msgstr ""
@@ -378,6 +378,9 @@ msgstr ""
 msgid "Toggle scheduling"
 msgstr ""
 
+msgid "Sharing settings"
+msgstr ""
+
 msgid "Last executed date"
 msgstr ""
 
@@ -391,6 +394,48 @@ msgid "Are you sure you want to delete {{count}} rules?"
 msgid_plural "Are you sure you want to delete {{count}} rules?"
 msgstr[0] ""
 msgstr[1] ""
+
+msgid "External access"
+msgstr ""
+
+msgid "Anyone can view without login"
+msgstr ""
+
+msgid "No access"
+msgstr ""
+
+msgid "Public access"
+msgstr ""
+
+msgid "METADATA"
+msgstr ""
+
+msgid "Can edit and view"
+msgstr ""
+
+msgid "Can view only"
+msgstr ""
+
+msgid "DATA"
+msgstr ""
+
+msgid "Can capture and view"
+msgstr ""
+
+msgid "Created by"
+msgstr ""
+
+msgid "Who has access"
+msgstr ""
+
+msgid "Close"
+msgstr ""
+
+msgid "Add users and user groups"
+msgstr ""
+
+msgid "Enter names"
+msgstr ""
 
 msgid "Synchronize Metadata"
 msgstr ""

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "d2": "^31.1.1",
     "d2-manifest": "^1.0.0",
     "d2-ui-components": "^0.0.25",
+    "downshift": "^3.3.4",
     "enzyme": "^3.10.0",
     "enzyme-adapter-react-16": "^1.14.0",
     "enzyme-to-json": "^3.4.0",

--- a/src/components/app/App.jsx
+++ b/src/components/app/App.jsx
@@ -13,6 +13,7 @@ import Share from "../share/Share";
 import Instance from "../../models/instance";
 import { muiTheme } from "./themes/dhis2.theme";
 import muiThemeLegacy from "./themes/dhis2-legacy.theme";
+import { initializeAppRoles } from "../../utils/permissions";
 import "./App.css";
 
 const generateClassName = createGenerateClassName({
@@ -26,7 +27,7 @@ class App extends Component {
         appConfig: PropTypes.object.isRequired,
     };
 
-    componentDidMount() {
+    async componentDidMount() {
         const { d2, appConfig } = this.props;
         const appKey = _(this.props.appConfig).get("appKey");
 
@@ -41,6 +42,8 @@ class App extends Component {
         if (appConfig && appConfig.encryptionKey) {
             Instance.setEncryptionKey(appConfig.encryptionKey);
         }
+
+        await initializeAppRoles(d2.Api.getApi().baseUrl);
     }
 
     render() {

--- a/src/components/app/Root.jsx
+++ b/src/components/app/Root.jsx
@@ -20,58 +20,59 @@ class Root extends React.Component {
     };
 
     render() {
-        const { d2 } = this.props;
-
         return (
             <Switch>
                 <Route
                     path={"/instance-configurator/:action(new|edit)/:id?"}
-                    render={props => <InstanceFormBuilder d2={d2} {...props} />}
+                    render={props => <InstanceFormBuilder {...this.props} {...props} />}
                 />
 
                 <Route
                     path="/instance-configurator"
-                    render={props => <InstanceConfigurator d2={d2} {...props} />}
+                    render={props => <InstanceConfigurator {...this.props} {...props} />}
                 />
 
                 <Route
                     path="/sync/organisationUnits"
-                    render={props => <OrganisationUnitPage d2={d2} {...props} />}
+                    render={props => <OrganisationUnitPage {...this.props} {...props} />}
                 />
 
                 <Route
                     path="/sync/dataElements"
-                    render={props => <DataElementPage d2={d2} {...props} />}
+                    render={props => <DataElementPage {...this.props} {...props} />}
                 />
 
                 <Route
                     path="/sync/indicators"
-                    render={props => <IndicatorPage d2={d2} {...props} />}
+                    render={props => <IndicatorPage {...this.props} {...props} />}
                 />
 
                 <Route
                     path="/sync/validationRules"
-                    render={props => <ValidationRulePage d2={d2} {...props} />}
+                    render={props => <ValidationRulePage {...this.props} {...props} />}
                 />
 
                 <Route
                     path="/sync/deleted"
-                    render={props => <DeletedObjectsPage d2={d2} {...props} />}
+                    render={props => <DeletedObjectsPage {...this.props} {...props} />}
                 />
 
-                <Route path="/history/:id?" render={props => <HistoryPage d2={d2} {...props} />} />
+                <Route
+                    path="/history/:id?"
+                    render={props => <HistoryPage {...this.props} {...props} />}
+                />
 
                 <Route
                     path={"/synchronization-rules/:action(new|edit)/:id?"}
-                    render={props => <SyncRulesWizard d2={d2} {...props} />}
+                    render={props => <SyncRulesWizard {...this.props} {...props} />}
                 />
 
                 <Route
                     path="/synchronization-rules"
-                    render={props => <SyncRulesConfigurator d2={d2} {...props} />}
+                    render={props => <SyncRulesConfigurator {...this.props} {...props} />}
                 />
 
-                <Route render={() => <LandingPage d2={d2} />} />
+                <Route render={() => <LandingPage {...this.props} />} />
             </Switch>
         );
     }

--- a/src/components/instance-list-page/InstancesPage.jsx
+++ b/src/components/instance-list-page/InstancesPage.jsx
@@ -6,8 +6,8 @@ import { ConfirmationDialog, ObjectsTable, withLoading, withSnackbar } from "d2-
 import { withRouter } from "react-router-dom";
 
 import PageHeader from "../page-header/PageHeader";
-
 import Instance from "../../models/instance";
+import { isAppConfigurator } from "../../utils/permissions";
 
 class InstancesPage extends React.Component {
     static propTypes = {
@@ -26,7 +26,15 @@ class InstancesPage extends React.Component {
     state = {
         tableKey: Math.random(),
         toDelete: null,
+        appConfigurator: false,
     };
+
+    async componentDidMount() {
+        const { d2 } = this.props;
+        const appConfigurator = await isAppConfigurator(d2);
+
+        this.setState({ appConfigurator });
+    }
 
     columns = [
         { name: "name", text: i18n.t("Server name"), sortable: true },
@@ -76,12 +84,14 @@ class InstancesPage extends React.Component {
             name: "edit",
             text: i18n.t("Edit"),
             multiple: false,
+            isActive: () => this.state.appConfigurator,
             onClick: this.editInstance,
         },
         {
             name: "delete",
             text: i18n.t("Delete"),
             multiple: true,
+            isActive: () => this.state.appConfigurator,
             onClick: this.deleteInstance,
         },
         {
@@ -126,7 +136,7 @@ class InstancesPage extends React.Component {
     };
 
     render() {
-        const { tableKey, toDelete } = this.state;
+        const { tableKey, toDelete, appConfigurator } = this.state;
         const { d2 } = this.props;
 
         return (
@@ -153,7 +163,7 @@ class InstancesPage extends React.Component {
                     detailsFields={this.detailsFields}
                     pageSize={10}
                     actions={this.actions}
-                    onButtonClick={this.createInstance}
+                    onButtonClick={appConfigurator ? this.createInstance : null}
                     list={Instance.list}
                 />
             </React.Fragment>

--- a/src/components/rules-creation-page/steps/MetadataSelectionStep.jsx
+++ b/src/components/rules-creation-page/steps/MetadataSelectionStep.jsx
@@ -17,6 +17,10 @@ import {
     OrganisationUnitModel,
     ValidationRuleGroupModel,
     ValidationRuleModel,
+    ProgramIndicatorModel,
+    ProgramIndicatorGroupModel,
+    ProgramRuleModel,
+    ProgramRuleVariableModel,
 } from "../../../models/d2Model";
 
 class MetadataSelectionStep extends React.Component {
@@ -43,6 +47,10 @@ class MetadataSelectionStep extends React.Component {
         OrganisationUnitGroupSetModel,
         ValidationRuleModel,
         ValidationRuleGroupModel,
+        ProgramIndicatorModel,
+        ProgramIndicatorGroupModel,
+        ProgramRuleModel,
+        ProgramRuleVariableModel,
     ];
 
     componentDidMount() {

--- a/src/components/rules-list-page/SyncRulesPage.jsx
+++ b/src/components/rules-list-page/SyncRulesPage.jsx
@@ -19,7 +19,14 @@ import { startSynchronization } from "../../logic/synchronization";
 import SyncReport from "../../models/syncReport";
 import SyncSummary from "../sync-summary/SyncSummary";
 import Dropdown from "../dropdown/Dropdown";
+import SharingDialog from "../sharing-dialog/SharingDialog";
 import { getValidationMessages } from "../../utils/validations";
+import {
+    getUserInfo,
+    isGlobalAdmin,
+    isAppConfigurator,
+    isAppExecutor,
+} from "../../utils/permissions";
 
 class SyncRulesPage extends React.Component {
     static propTypes = {
@@ -47,6 +54,10 @@ class SyncRulesPage extends React.Component {
         lastExecutedFilter: null,
         syncReport: SyncReport.create(),
         syncSummaryOpen: false,
+        userInfo: {},
+        globalAdmin: false,
+        appConfigurator: false,
+        appExecutor: false,
     };
 
     getTargetInstances = ruleData => {
@@ -117,7 +128,12 @@ class SyncRulesPage extends React.Component {
     async componentDidMount() {
         const { d2 } = this.props;
         const { objects: allInstances } = await Instance.list(d2, null, null);
-        this.setState({ allInstances });
+        const userInfo = await getUserInfo(d2);
+        const globalAdmin = await isGlobalAdmin(d2);
+        const appConfigurator = await isAppConfigurator(d2);
+        const appExecutor = await isAppExecutor(d2);
+
+        this.setState({ allInstances, userInfo, globalAdmin, appConfigurator, appExecutor });
     }
 
     backHome = () => {
@@ -201,6 +217,46 @@ class SyncRulesPage extends React.Component {
         }
     };
 
+    openSharingSettings = object => {
+        this.setState({
+            sharingSettingsObject: {
+                object,
+                meta: { allowPublicAccess: true, allowExternalAccess: false },
+            },
+        });
+    };
+
+    closeSharingSettings = () => {
+        this.setState({ sharingSettingsObject: null });
+    };
+
+    verifyUserHasAccess = (d2, data, condition = false) => {
+        const { userInfo, globalAdmin } = this.state;
+        if (globalAdmin) return true;
+
+        const rules = Array.isArray(data) ? data : [data];
+        for (const ruleData of rules) {
+            const rule = SyncRule.build(ruleData);
+            if (!rule.isVisibleToUser(userInfo, "WRITE")) return false;
+        }
+
+        return condition;
+    };
+
+    verifyUserCanEdit = (d2, data) => {
+        const { appConfigurator } = this.state;
+        return this.verifyUserHasAccess(d2, data, appConfigurator);
+    };
+
+    verifyUserCanEditSharingSettings = (d2, data) => {
+        const { appConfigurator, appExecutor } = this.state;
+        return this.verifyUserHasAccess(d2, data, appConfigurator || appExecutor);
+    };
+
+    verifyUserCanExecute = (d2, data) => {
+        return this.state.appExecutor;
+    };
+
     actions = [
         {
             name: "details",
@@ -212,18 +268,21 @@ class SyncRulesPage extends React.Component {
             name: "edit",
             text: i18n.t("Edit"),
             multiple: false,
+            isActive: this.verifyUserCanEdit,
             onClick: this.editRule,
         },
         {
             name: "delete",
             text: i18n.t("Delete"),
             multiple: true,
+            isActive: this.verifyUserCanEdit,
             onClick: this.deleteSyncRules,
         },
         {
             name: "execute",
             text: i18n.t("Execute"),
             multiple: false,
+            isActive: this.verifyUserCanExecute,
             onClick: this.executeRule,
             icon: "settings_input_antenna",
         },
@@ -231,8 +290,17 @@ class SyncRulesPage extends React.Component {
             name: "toggleEnable",
             text: i18n.t("Toggle scheduling"),
             multiple: false,
+            isActive: this.verifyUserCanEdit,
             onClick: this.toggleEnable,
             icon: "timer",
+        },
+        {
+            name: "sharingSettings",
+            text: i18n.t("Sharing settings"),
+            multiple: false,
+            isActive: this.verifyUserCanEditSharingSettings,
+            onClick: this.openSharingSettings,
+            icon: "share",
         },
     ];
 
@@ -243,6 +311,27 @@ class SyncRulesPage extends React.Component {
     changeEnabledFilter = event => this.setState({ enabledFilter: event.target.value });
 
     changeLastExecutedFilter = moment => this.setState({ lastExecutedFilter: moment });
+
+    onSearchRequest = key =>
+        this.props.d2.Api.getApi()
+            .get("sharing/search", { key })
+            .then(searchResult => searchResult);
+
+    onSharingChanged = async (updatedAttributes, onSuccess) => {
+        const sharingSettingsObject = {
+            meta: this.state.sharingSettingsObject.meta,
+            object: {
+                ...this.state.sharingSettingsObject.object,
+                ...updatedAttributes,
+            },
+        };
+
+        const syncRule = SyncRule.build(sharingSettingsObject.object);
+        await syncRule.save(this.props.d2);
+
+        this.setState({ sharingSettingsObject });
+        if (onSuccess) onSuccess();
+    };
 
     renderCustomFilters = () => {
         const {
@@ -292,6 +381,8 @@ class SyncRulesPage extends React.Component {
             targetInstanceFilter,
             enabledFilter,
             lastExecutedFilter,
+            sharingSettingsObject,
+            appConfigurator,
         } = this.state;
         const { d2 } = this.props;
 
@@ -307,7 +398,7 @@ class SyncRulesPage extends React.Component {
                     pageSize={10}
                     actions={this.actions}
                     list={SyncRule.list}
-                    onButtonClick={this.createRule}
+                    onButtonClick={appConfigurator ? this.createRule : null}
                     customFiltersComponent={this.renderCustomFilters}
                     customFilters={{ targetInstanceFilter, enabledFilter, lastExecutedFilter }}
                 />
@@ -332,6 +423,15 @@ class SyncRulesPage extends React.Component {
                     response={syncReport}
                     isOpen={syncSummaryOpen}
                     handleClose={this.closeSummary}
+                />
+
+                <SharingDialog
+                    isOpen={!!sharingSettingsObject}
+                    isDataShareable={false}
+                    sharedObject={sharingSettingsObject}
+                    onCancel={this.closeSharingSettings}
+                    onSharingChanged={this.onSharingChanged}
+                    onSearchRequest={this.onSearchRequest}
                 />
             </React.Fragment>
         );

--- a/src/components/sharing-dialog/Access.jsx
+++ b/src/components/sharing-dialog/Access.jsx
@@ -1,0 +1,165 @@
+import React from "react";
+import PropTypes from "prop-types";
+import IconButton from "@material-ui/core/IconButton";
+import ClearIcon from "@material-ui/icons/Clear";
+import PersonIcon from "@material-ui/icons/Person";
+import GroupIcon from "@material-ui/icons/Group";
+import PublicIcon from "@material-ui/icons/Public";
+import BusinessIcon from "@material-ui/icons/Business";
+import { withStyles } from "@material-ui/core/styles";
+import i18n from "@dhis2/d2-i18n";
+
+import PermissionPicker from "./PermissionPicker";
+import { accessStringToObject, accessObjectToString } from "./utils";
+
+const icons = {
+    user: PersonIcon,
+    userGroup: GroupIcon,
+    external: PublicIcon,
+    public: BusinessIcon,
+};
+
+const SvgIcon = ({ userType }) => {
+    const Icon = icons[userType] || PersonIcon;
+
+    return <Icon color="action" />;
+};
+
+SvgIcon.propTypes = {
+    userType: PropTypes.string.isRequired,
+};
+
+const styles = {
+    accessView: {
+        fontWeight: "400",
+        display: "flex",
+        flexDirection: "row",
+        justifyContent: "space-between",
+        alignItems: "center",
+        padding: "4px 8px",
+    },
+    accessDescription: {
+        display: "flex",
+        flexDirection: "column",
+        flex: 1,
+        paddingLeft: 16,
+    },
+};
+
+const useAccessObjectFormat = props => ({
+    ...props,
+    access: accessStringToObject(props.access),
+    onChange: newAccess => props.onChange(accessObjectToString(newAccess)),
+});
+
+export const Access = withStyles(styles)(
+    ({
+        access,
+        accessType,
+        accessOptions,
+        primaryText,
+        secondaryText,
+        onChange,
+        onRemove,
+        disabled,
+        classes,
+    }) => (
+        <div className={classes.accessView}>
+            <SvgIcon userType={accessType} />
+            <div className={classes.accessDescription}>
+                <div>{primaryText}</div>
+                <div style={{ color: "#818181", paddingTop: 4 }}>{secondaryText || " "}</div>
+            </div>
+            <PermissionPicker
+                access={access}
+                accessOptions={accessOptions}
+                onChange={onChange}
+                disabled={disabled}
+            />
+            <IconButton disabled={!onRemove} onClick={onRemove}>
+                <ClearIcon color={!onRemove ? "disabled" : "action"} />
+            </IconButton>
+        </div>
+    )
+);
+
+Access.propTypes = {
+    access: PropTypes.object.isRequired,
+    accessType: PropTypes.string.isRequired,
+    accessOptions: PropTypes.object.isRequired,
+    primaryText: PropTypes.string.isRequired,
+    onChange: PropTypes.func.isRequired,
+    disabled: PropTypes.bool,
+    secondaryText: PropTypes.string,
+    onRemove: PropTypes.func,
+};
+
+Access.defaultProps = {
+    secondaryText: null,
+    onRemove: null,
+    disabled: false,
+};
+
+export const GroupAccess = basicProps => {
+    const props = useAccessObjectFormat(basicProps);
+    const newProps = {
+        accessType: props.groupType,
+        primaryText: props.groupName,
+        accessOptions: {
+            meta: { canView: true, canEdit: true, noAccess: false },
+            data: props.dataShareable && {
+                canView: true,
+                canEdit: true,
+                noAccess: true,
+            },
+        },
+    };
+
+    return <Access {...props} {...newProps} />;
+};
+
+export const ExternalAccess = props => {
+    const newProps = {
+        ...props,
+        accessType: "external",
+        primaryText: i18n.t("External access"),
+        secondaryText: props.access ? i18n.t("Anyone can view without login") : i18n.t("No access"),
+        access: {
+            meta: { canEdit: false, canView: props.access },
+            data: { canEdit: false, canView: false },
+        },
+        onChange: newAccess => props.onChange(newAccess.meta.canView),
+        accessOptions: {
+            meta: { canView: true, canEdit: false, noAccess: true },
+        },
+    };
+
+    return <Access {...props} {...newProps} />;
+};
+
+export const PublicAccess = basicProps => {
+    const props = useAccessObjectFormat(basicProps);
+    const { canEdit, canView } = props.access.meta;
+    const description = canEdit
+        ? "Anyone can find and view"
+        : canView
+        ? "Anyone can view"
+        : "No access";
+
+    const newProps = {
+        ...props,
+        accessType: "public",
+        primaryText: i18n.t("Public access"),
+        secondaryText: description,
+        accessOptions: {
+            meta: { canView: true, canEdit: true, noAccess: true },
+            data: props.dataShareable && {
+                canView: true,
+                canEdit: true,
+                noAccess: true,
+            },
+        },
+    };
+
+    return <Access {...props} {...newProps} />;
+};

--- a/src/components/sharing-dialog/AutoComplete.jsx
+++ b/src/components/sharing-dialog/AutoComplete.jsx
@@ -1,0 +1,156 @@
+import React, { Component } from "react";
+import PropTypes from "prop-types";
+import Downshift from "downshift";
+import { withStyles } from "@material-ui/core/styles";
+import TextField from "@material-ui/core/TextField";
+import Paper from "@material-ui/core/Paper";
+import MenuItem from "@material-ui/core/MenuItem";
+import Popper from "@material-ui/core/Popper";
+
+const Input = ({ InputProps }) => {
+    return <TextField id="user-search-input" fullWidth InputProps={{ ...InputProps }} />;
+};
+
+Input.propTypes = {
+    InputProps: PropTypes.object.isRequired,
+};
+
+const Suggestion = ({ suggestion, itemProps, isHighlighted, selectedItem }) => {
+    const isSelected = selectedItem && selectedItem.id === suggestion.id;
+
+    return (
+        <MenuItem
+            {...itemProps}
+            key={suggestion.label}
+            selected={isHighlighted}
+            component="div"
+            style={{
+                fontWeight: isSelected ? 500 : 400,
+            }}
+        >
+            {suggestion.displayName}
+        </MenuItem>
+    );
+};
+
+Suggestion.propTypes = {
+    isHighlighted: PropTypes.bool.isRequired,
+    itemProps: PropTypes.object,
+    selectedItem: PropTypes.object,
+    suggestion: PropTypes.shape({ displayName: PropTypes.string }).isRequired,
+};
+
+const styles = theme => ({
+    root: {
+        flexGrow: 1,
+        height: 60,
+    },
+    popper: {
+        zIndex: 2000,
+        maxHeight: "420px",
+        overflowY: "hidden",
+        boxShadow: "0px 0px 1px 1px rgba(0,0,0,0.2)",
+    },
+    container: {
+        flexGrow: 1,
+        position: "relative",
+    },
+    inputRoot: {
+        flexWrap: "wrap",
+    },
+});
+
+let popperNode;
+
+class AutoComplete extends Component {
+    render() {
+        const { classes, placeholderText, suggestions, searchText } = this.props;
+
+        return (
+            <div className={classes.root}>
+                <Downshift
+                    id="user-autocomplete"
+                    onInputValueChange={this.props.onInputChanged}
+                    onChange={this.props.onItemSelected}
+                    itemToString={item => (item ? item.name : "")}
+                    inputValue={searchText}
+                >
+                    {({
+                        getInputProps,
+                        getItemProps,
+                        getMenuProps,
+                        highlightedIndex,
+                        isOpen,
+                        selectedItem,
+                    }) => {
+                        return (
+                            <div className={classes.container}>
+                                <Input
+                                    fullWidth
+                                    classes={classes}
+                                    InputProps={getInputProps({
+                                        placeholder: placeholderText,
+                                        inputRef: node => {
+                                            popperNode = node;
+                                        },
+                                    })}
+                                />
+                                <div {...getMenuProps()}>
+                                    {isOpen && (
+                                        <Popper
+                                            className={classes.popper}
+                                            open
+                                            anchorEl={popperNode}
+                                        >
+                                            <Paper
+                                                square
+                                                style={{
+                                                    width: popperNode
+                                                        ? popperNode.clientWidth
+                                                        : null,
+                                                }}
+                                            >
+                                                {suggestions.map((suggestion, index) => {
+                                                    return (
+                                                        <Suggestion
+                                                            key={suggestion.id}
+                                                            suggestion={suggestion}
+                                                            itemProps={getItemProps({
+                                                                item: {
+                                                                    name: suggestion.displayName,
+                                                                    id: suggestion.id,
+                                                                },
+                                                            })}
+                                                            isHighlighted={
+                                                                highlightedIndex === index
+                                                            }
+                                                            selectedItem={selectedItem}
+                                                        />
+                                                    );
+                                                })}
+                                            </Paper>
+                                        </Popper>
+                                    )}
+                                </div>
+                            </div>
+                        );
+                    }}
+                </Downshift>
+            </div>
+        );
+    }
+}
+
+AutoComplete.propTypes = {
+    classes: PropTypes.object.isRequired,
+    placeholderText: PropTypes.string,
+    onInputChanged: PropTypes.func.isRequired,
+    onItemSelected: PropTypes.func.isRequired,
+    suggestions: PropTypes.array.isRequired,
+};
+
+AutoComplete.defaultProps = {
+    placeholderText: "",
+};
+
+export default withStyles(styles)(AutoComplete);

--- a/src/components/sharing-dialog/PermissionOption.jsx
+++ b/src/components/sharing-dialog/PermissionOption.jsx
@@ -1,0 +1,36 @@
+import React from "react";
+import PropTypes from "prop-types";
+import DoneIcon from "@material-ui/icons/Done";
+import MenuItem from "@material-ui/core/MenuItem";
+import ListItemIcon from "@material-ui/core/ListItemIcon";
+import ListItemText from "@material-ui/core/ListItemText";
+
+const PermissionOption = props => {
+    if (props.disabled) {
+        return null;
+    }
+
+    return (
+        <MenuItem disabled={props.disabled} onClick={props.onClick} selected={props.isSelected}>
+            {props.isSelected && (
+                <ListItemIcon>
+                    <DoneIcon />
+                </ListItemIcon>
+            )}
+            <ListItemText inset primary={props.primaryText} />
+        </MenuItem>
+    );
+};
+
+PermissionOption.propTypes = {
+    disabled: PropTypes.bool.isRequired,
+    isSelected: PropTypes.bool,
+    primaryText: PropTypes.string.isRequired,
+    onClick: PropTypes.func.isRequired,
+};
+
+PermissionOption.defaultProps = {
+    isSelected: false,
+};
+
+export default PermissionOption;

--- a/src/components/sharing-dialog/PermissionPicker.jsx
+++ b/src/components/sharing-dialog/PermissionPicker.jsx
@@ -1,0 +1,167 @@
+import PropTypes from "prop-types";
+import React, { Component, Fragment } from "react";
+import IconButton from "@material-ui/core/IconButton";
+import Divider from "@material-ui/core/Divider";
+import MenuList from "@material-ui/core/MenuList";
+import Popover from "@material-ui/core/Popover";
+import NotInterestedIcon from "@material-ui/icons/NotInterested";
+import CreateIcon from "@material-ui/icons/Create";
+import VisibilityIcon from "@material-ui/icons/Visibility";
+import { withStyles } from "@material-ui/core/styles";
+import i18n from "@dhis2/d2-i18n";
+
+import PermissionOption from "./PermissionOption";
+
+const styles = {
+    optionHeader: {
+        paddingLeft: 16,
+        paddingTop: 16,
+        fontWeight: "500",
+        color: "gray",
+    },
+};
+
+const AccessIcon = ({ metaAccess, disabled }) => {
+    const iconProps = {
+        color: disabled ? "disabled" : "action",
+    };
+    if (metaAccess.canEdit) {
+        return <CreateIcon {...iconProps} />;
+    }
+
+    return metaAccess.canView ? (
+        <VisibilityIcon {...iconProps} />
+    ) : (
+        <NotInterestedIcon {...iconProps} />
+    );
+};
+
+class PermissionPicker extends Component {
+    state = {
+        open: false,
+    };
+
+    onOptionClick = access => () => {
+        const newAccess = {
+            ...this.props.access,
+            ...access,
+        };
+
+        this.props.onChange(newAccess);
+    };
+
+    openMenu = event => {
+        event.preventDefault();
+        this.setState({
+            open: true,
+            anchor: event.currentTarget,
+        });
+    };
+
+    closeMenu = () => {
+        this.setState({
+            open: false,
+        });
+    };
+
+    render = () => {
+        const { data, meta } = this.props.access;
+        const { data: dataOptions, meta: metaOptions } = this.props.accessOptions;
+
+        return (
+            <Fragment>
+                <IconButton onClick={this.openMenu} disabled={this.props.disabled}>
+                    <AccessIcon metaAccess={meta} disabled={this.props.disabled} />
+                </IconButton>
+                <Popover
+                    open={this.state.open}
+                    anchorEl={this.state.anchor}
+                    onClose={this.closeMenu}
+                >
+                    <OptionHeader text={i18n.t("METADATA")} />
+                    <MenuList>
+                        <PermissionOption
+                            disabled={!metaOptions.canEdit}
+                            primaryText={i18n.t("Can edit and view")}
+                            isSelected={meta.canEdit}
+                            onClick={this.onOptionClick({ meta: { canView: true, canEdit: true } })}
+                        />
+                        <PermissionOption
+                            disabled={!metaOptions.canView}
+                            primaryText={i18n.t("Can view only")}
+                            isSelected={!meta.canEdit && meta.canView}
+                            onClick={this.onOptionClick({
+                                meta: { canView: true, canEdit: false },
+                            })}
+                        />
+                        <PermissionOption
+                            disabled={!metaOptions.noAccess}
+                            primaryText={i18n.t("No access")}
+                            isSelected={!meta.canEdit && !meta.canView}
+                            onClick={this.onOptionClick({
+                                meta: { canView: false, canEdit: false },
+                            })}
+                        />
+                    </MenuList>
+                    <Divider />
+
+                    {dataOptions && (
+                        <Fragment>
+                            <OptionHeader text={i18n.t("DATA")} />
+                            <MenuList>
+                                <PermissionOption
+                                    disabled={!dataOptions.canEdit}
+                                    primaryText={i18n.t("Can capture and view")}
+                                    isSelected={data.canEdit}
+                                    onClick={this.onOptionClick({
+                                        data: { canView: true, canEdit: true },
+                                    })}
+                                />
+                                <PermissionOption
+                                    disabled={!dataOptions.canView}
+                                    primaryText={i18n.t("Can view only")}
+                                    isSelected={!data.canEdit && data.canView}
+                                    onClick={this.onOptionClick({
+                                        data: { canView: true, canEdit: false },
+                                    })}
+                                />
+                                <PermissionOption
+                                    disabled={!dataOptions.noAccess}
+                                    primaryText={i18n.t("No access")}
+                                    isSelected={!data.canEdit && !data.canView}
+                                    onClick={this.onOptionClick({
+                                        data: {
+                                            canView: false,
+                                            canEdit: false,
+                                        },
+                                    })}
+                                />
+                            </MenuList>
+                        </Fragment>
+                    )}
+                </Popover>
+            </Fragment>
+        );
+    };
+}
+
+PermissionPicker.propTypes = {
+    access: PropTypes.object.isRequired,
+    accessOptions: PropTypes.object.isRequired,
+    onChange: PropTypes.func.isRequired,
+    disabled: PropTypes.bool,
+};
+
+PermissionPicker.defaultProps = {
+    disabled: false,
+};
+
+const OptionHeader = withStyles(styles)(({ text, classes }) => (
+    <div className={classes.optionHeader}>{text.toUpperCase()}</div>
+));
+
+OptionHeader.propTypes = {
+    text: PropTypes.string.isRequired,
+};
+
+export default PermissionPicker;

--- a/src/components/sharing-dialog/Sharing.jsx
+++ b/src/components/sharing-dialog/Sharing.jsx
@@ -1,0 +1,210 @@
+import PropTypes from "prop-types";
+import React from "react";
+import Divider from "@material-ui/core/Divider";
+import Typography from "@material-ui/core/Typography";
+import { withStyles } from "@material-ui/core/styles";
+import i18n from "@dhis2/d2-i18n";
+
+import UserSearch from "./UserSearch";
+import { PublicAccess, ExternalAccess, GroupAccess } from "./Access";
+
+const styles = {
+    title: {
+        fontSize: "24px",
+        fontWeight: 300,
+        color: "rgba(0, 0, 0, 0.87)",
+        padding: "16px 0px 5px",
+        margin: "0px",
+    },
+    createdBy: {
+        color: "#818181",
+    },
+    titleBodySpace: {
+        paddingTop: 30,
+    },
+    rules: {
+        height: "240px",
+        overflowY: "scroll",
+    },
+};
+
+/**
+ * Content of the sharing dialog; a set of components for changing sharing
+ * preferences.
+ */
+class Sharing extends React.Component {
+    onAccessRuleChange = id => accessRule => {
+        const changeWithId = rule => (rule.id === id ? { ...rule, access: accessRule } : rule);
+        const userAccesses = (this.props.sharedObject.object.userAccesses || []).map(changeWithId);
+        const userGroupAccesses = (this.props.sharedObject.object.userGroupAccesses || []).map(
+            changeWithId
+        );
+
+        this.props.onChange({
+            userAccesses,
+            userGroupAccesses,
+        });
+    };
+
+    onAccessRemove = accessOwnerId => () => {
+        const withoutId = accessOwner => accessOwner.id !== accessOwnerId;
+        const userAccesses = (this.props.sharedObject.object.userAccesses || []).filter(withoutId);
+        const userGroupAccesses = (this.props.sharedObject.object.userGroupAccesses || []).filter(
+            withoutId
+        );
+
+        this.props.onChange({
+            userAccesses,
+            userGroupAccesses,
+        });
+    };
+
+    onPublicAccessChange = publicAccess => {
+        this.props.onChange({
+            publicAccess,
+        });
+    };
+
+    onExternalAccessChange = externalAccess => {
+        this.props.onChange({
+            externalAccess,
+        });
+    };
+
+    setAccessListRef = ref => {
+        this.accessListRef = ref;
+    };
+
+    accessListRef = null;
+
+    addUserAccess = userAccess => {
+        const currentAccesses = this.props.sharedObject.object.userAccesses || [];
+        this.props.onChange(
+            {
+                userAccesses: [...currentAccesses, userAccess],
+            },
+            this.scrollAccessListToBottom()
+        );
+    };
+
+    addUserGroupAccess = userGroupAccess => {
+        const currentAccesses = this.props.sharedObject.object.userGroupAccesses || [];
+        this.props.onChange(
+            {
+                userGroupAccesses: [...currentAccesses, userGroupAccess],
+            },
+            this.scrollAccessListToBottom()
+        );
+    };
+
+    scrollAccessListToBottom = () => {
+        this.accessListRef.scrollTop = this.accessListRef.scrollHeight;
+    };
+
+    render() {
+        const {
+            user,
+            displayName,
+            name,
+            userAccesses,
+            userGroupAccesses,
+            publicAccess,
+            externalAccess,
+        } = this.props.sharedObject.object;
+        const { allowPublicAccess, allowExternalAccess } = this.props.sharedObject.meta;
+        const { classes } = this.props;
+
+        const accessIds = (userAccesses || [])
+            .map(access => access.id)
+            .concat((userGroupAccesses || []).map(access => access.id));
+
+        return (
+            <div>
+                <h2 className={classes.title}>{displayName || name}</h2>
+                {user && (
+                    <div className={classes.createdBy}>
+                        {`${i18n.t("Created by")}: ${user.name}`}
+                    </div>
+                )}
+                <div className={classes.titleBodySpace} />
+                <Typography variant="subtitle1">{i18n.t("Who has access")}</Typography>
+                <Divider />
+                <div className={classes.rules} ref={this.setAccessListRef}>
+                    <PublicAccess
+                        access={publicAccess}
+                        disabled={!allowPublicAccess}
+                        dataShareable={this.props.dataShareable}
+                        onChange={this.onPublicAccessChange}
+                    />
+                    <Divider />
+                    <ExternalAccess
+                        access={externalAccess}
+                        disabled={!allowExternalAccess}
+                        onChange={this.onExternalAccessChange}
+                    />
+                    <Divider />
+                    {userAccesses &&
+                        userAccesses.map(access => (
+                            <div key={access.id}>
+                                <GroupAccess
+                                    groupName={access.displayName}
+                                    groupType="user"
+                                    access={access.access}
+                                    dataShareable={this.props.dataShareable}
+                                    onRemove={this.onAccessRemove(access.id)}
+                                    onChange={this.onAccessRuleChange(access.id)}
+                                />
+                                <Divider />
+                            </div>
+                        ))}
+                    {userGroupAccesses &&
+                        userGroupAccesses.map(access => (
+                            <div key={access.id}>
+                                <GroupAccess
+                                    access={access.access}
+                                    groupName={access.displayName}
+                                    groupType="userGroup"
+                                    dataShareable={this.props.dataShareable}
+                                    onRemove={this.onAccessRemove(access.id)}
+                                    onChange={this.onAccessRuleChange(access.id)}
+                                />
+                                <Divider />
+                            </div>
+                        ))}
+                </div>
+                <UserSearch
+                    onSearch={this.props.onSearch}
+                    addUserAccess={this.addUserAccess}
+                    addUserGroupAccess={this.addUserGroupAccess}
+                    dataShareable={this.props.dataShareable}
+                    currentAccessIds={accessIds}
+                />
+            </div>
+        );
+    }
+}
+
+Sharing.propTypes = {
+    /**
+     * The object to share
+     */
+    sharedObject: PropTypes.object.isRequired,
+
+    /*
+     * If true, the object's data should have their own settings.
+     */
+    dataShareable: PropTypes.bool.isRequired,
+
+    /**
+     * Function that takes an object containing updated sharing preferences and
+     * an optional callback fired when the change was successfully posted.
+     */
+    onChange: PropTypes.func.isRequired,
+
+    /**
+     * Takes a string and a callback, and returns matching users and userGroups.
+     */
+    onSearch: PropTypes.func.isRequired,
+};
+
+export default withStyles(styles)(Sharing);

--- a/src/components/sharing-dialog/SharingDialog.jsx
+++ b/src/components/sharing-dialog/SharingDialog.jsx
@@ -1,0 +1,42 @@
+import React from "react";
+import i18n from "@dhis2/d2-i18n";
+import { ConfirmationDialog } from "d2-ui-components";
+import DialogContent from "@material-ui/core/DialogContent";
+
+import Sharing from "./Sharing";
+
+const SharingDialog = ({
+    isOpen,
+    isDataShareable,
+    sharedObject,
+    onCancel,
+    onSharingChanged,
+    onSearchRequest,
+}) => {
+    return (
+        <React.Fragment>
+            <ConfirmationDialog
+                isOpen={isOpen}
+                title={i18n.t("Sharing settings")}
+                onCancel={onCancel}
+                cancelText={i18n.t("Close")}
+                maxWidth={"lg"}
+                fullWidth={true}
+                disableEnforceFocus
+            >
+                <DialogContent>
+                    {sharedObject && (
+                        <Sharing
+                            sharedObject={sharedObject}
+                            dataShareable={isDataShareable}
+                            onChange={onSharingChanged}
+                            onSearch={onSearchRequest}
+                        />
+                    )}
+                </DialogContent>
+            </ConfirmationDialog>
+        </React.Fragment>
+    );
+};
+
+export default SharingDialog;

--- a/src/components/sharing-dialog/UserSearch.jsx
+++ b/src/components/sharing-dialog/UserSearch.jsx
@@ -1,0 +1,165 @@
+import React, { Component } from "react";
+import PropTypes from "prop-types";
+import { Subject } from "rxjs/Subject";
+import { timer } from "rxjs/observable/timer";
+import { debounce } from "rxjs/operators";
+import { withStyles } from "@material-ui/core/styles";
+import i18n from "@dhis2/d2-i18n";
+
+import { accessObjectToString } from "./utils";
+import PermissionPicker from "./PermissionPicker";
+import AutoComplete from "./AutoComplete";
+
+const styles = {
+    container: {
+        fontWeight: "400",
+        padding: 16,
+        backgroundColor: "#F5F5F5",
+        display: "flex",
+        flexDirection: "column",
+        justifyContent: "center",
+    },
+
+    innerContainer: {
+        display: "flex",
+        flexDirection: "row",
+        flex: 1,
+    },
+
+    title: {
+        color: "#818181",
+        paddingBottom: 8,
+    },
+};
+
+const searchDelay = 300;
+
+class UserSearch extends Component {
+    state = {
+        defaultAccess: {
+            meta: { canView: true, canEdit: true },
+            data: { canView: false, canEdit: false },
+        },
+        searchResult: [],
+        searchText: "",
+    };
+
+    componentDidMount() {
+        this.inputStream.pipe(debounce(() => timer(searchDelay))).subscribe(searchText => {
+            this.fetchSearchResult(searchText);
+        });
+    }
+
+    onItemSelected = selected => {
+        // Material UI triggers an 'onUpdateInput' when a search result is clicked. Therefore, we
+        // immediately pushes a new item to the search stream to prevent the stream from searching
+        // for the item again.
+        this.inputStream.next("");
+
+        const selection = this.state.searchResult.find(r => r.id === selected.id);
+
+        const type = selection.type;
+        delete selection.type;
+
+        if (type === "userAccess") {
+            this.props.addUserAccess({
+                ...selection,
+                access: accessObjectToString(this.state.defaultAccess),
+            });
+        } else {
+            this.props.addUserGroupAccess({
+                ...selection,
+                access: accessObjectToString(this.state.defaultAccess),
+            });
+        }
+        this.clearSearchText();
+    };
+
+    inputStream = new Subject();
+
+    hasNoCurrentAccess = userOrGroup => this.props.currentAccessIds.indexOf(userOrGroup.id) === -1;
+
+    fetchSearchResult = searchText => {
+        if (searchText === "") {
+            this.handleSearchResult([]);
+        } else {
+            this.props.onSearch(searchText).then(({ users, userGroups }) => {
+                const addType = type => result => ({ ...result, type });
+                const searchResult = users
+                    .map(addType("userAccess"))
+                    .filter(this.hasNoCurrentAccess)
+                    .concat(
+                        userGroups.map(addType("userGroupAccess")).filter(this.hasNoCurrentAccess)
+                    );
+
+                this.handleSearchResult(searchResult);
+            });
+        }
+    };
+
+    handleSearchResult = searchResult => {
+        this.setState({ searchResult });
+    };
+
+    onInputChanged = searchText => {
+        this.inputStream.next(searchText);
+        this.setState({ searchText });
+    };
+
+    accessOptionsChanged = accessOptions => {
+        this.setState({
+            defaultAccess: accessOptions,
+        });
+    };
+
+    clearSearchText = () => {
+        this.setState({
+            searchText: "",
+        });
+    };
+
+    render() {
+        const { classes } = this.props;
+        return (
+            <div className={classes.container}>
+                <div className={classes.title}>{i18n.t("Add users and user groups")}</div>
+                <div className={classes.innerContainer}>
+                    <AutoComplete
+                        suggestions={this.state.searchResult}
+                        placeholderText={i18n.t("Enter names")}
+                        onItemSelected={this.onItemSelected}
+                        onInputChanged={this.onInputChanged}
+                        searchText={this.state.searchText}
+                        classes={{}}
+                    />
+                    <PermissionPicker
+                        access={this.state.defaultAccess}
+                        accessOptions={{
+                            meta: {
+                                canView: true,
+                                canEdit: true,
+                                noAccess: false,
+                            },
+                            data: this.props.dataShareable && {
+                                canView: true,
+                                canEdit: true,
+                                noAccess: true,
+                            },
+                        }}
+                        onChange={this.accessOptionsChanged}
+                    />
+                </div>
+            </div>
+        );
+    }
+}
+
+UserSearch.propTypes = {
+    onSearch: PropTypes.func.isRequired,
+    addUserAccess: PropTypes.func.isRequired,
+    dataShareable: PropTypes.bool.isRequired,
+    addUserGroupAccess: PropTypes.func.isRequired,
+    currentAccessIds: PropTypes.array.isRequired,
+};
+
+export default withStyles(styles)(UserSearch);

--- a/src/components/sharing-dialog/utils.js
+++ b/src/components/sharing-dialog/utils.js
@@ -1,0 +1,56 @@
+export const cachedAccessTypeToString = (canView, canEdit) => {
+    if (canView) {
+        return canEdit ? "rw------" : "r-------";
+    }
+
+    return "--------";
+};
+
+export const transformAccessObject = (access, type) => ({
+    id: access.id,
+    name: access.name,
+    displayName: access.displayName,
+    type,
+    canView: access.access && access.access.includes("r"),
+    canEdit: access.access && access.access.includes("rw"),
+});
+
+export const accessStringToObject = access => {
+    if (!access) {
+        return {
+            data: { canView: false, canEdit: false },
+            meta: { canView: false, canEdit: false },
+        };
+    }
+
+    const metaAccess = access.substring(0, 2);
+    const dataAccess = access.substring(2, 4);
+
+    return {
+        meta: {
+            canView: metaAccess.includes("r"),
+            canEdit: metaAccess.includes("rw"),
+        },
+        data: {
+            canView: dataAccess.includes("r"),
+            canEdit: dataAccess.includes("rw"),
+        },
+    };
+};
+
+export const accessObjectToString = accessObject => {
+    const convert = ({ canEdit, canView }) => {
+        if (canEdit) {
+            return "rw";
+        }
+
+        return canView ? "r-" : "--";
+    };
+
+    let accessString = "";
+    accessString += convert(accessObject.meta);
+    accessString += convert(accessObject.data);
+    accessString += "----";
+
+    return accessString;
+};

--- a/src/components/synchronization-page/GenericSynchronizationPage.jsx
+++ b/src/components/synchronization-page/GenericSynchronizationPage.jsx
@@ -12,6 +12,7 @@ import SyncDialog from "../sync-dialog/SyncDialog";
 import SyncSummary from "../sync-summary/SyncSummary";
 import PageHeader from "../page-header/PageHeader";
 import SyncReport from "../../models/syncReport";
+import { isAppConfigurator } from "../../utils/permissions";
 
 class GenericSynchronizationPage extends React.Component {
     static propTypes = {
@@ -28,7 +29,15 @@ class GenericSynchronizationPage extends React.Component {
         importResponse: SyncReport.create(),
         syncDialogOpen: false,
         syncSummaryOpen: false,
+        appConfigurator: false,
     };
+
+    async componentDidMount() {
+        const { d2 } = this.props;
+        const appConfigurator = await isAppConfigurator(d2);
+
+        this.setState({ appConfigurator });
+    }
 
     goHome = () => {
         this.props.history.push("/");
@@ -90,7 +99,13 @@ class GenericSynchronizationPage extends React.Component {
 
     render() {
         const { d2, title, models, ...rest } = this.props;
-        const { syncDialogOpen, syncSummaryOpen, importResponse, metadataIds } = this.state;
+        const {
+            syncDialogOpen,
+            syncSummaryOpen,
+            importResponse,
+            metadataIds,
+            appConfigurator,
+        } = this.state;
 
         return (
             <React.Fragment>
@@ -102,7 +117,7 @@ class GenericSynchronizationPage extends React.Component {
                     initialModel={models[0]}
                     initialSelection={metadataIds}
                     notifyNewSelection={this.changeSelection}
-                    onButtonClick={this.startSynchronization}
+                    onButtonClick={appConfigurator ? this.startSynchronization : null}
                     buttonLabel={<SyncIcon />}
                     {...rest}
                 />

--- a/src/models/d2Model.ts
+++ b/src/models/d2Model.ts
@@ -256,6 +256,44 @@ export class IndicatorGroupSetModel extends D2Model {
     ];
 }
 
+export class ProgramIndicatorModel extends D2Model {
+    protected static metadataType = "programIndicator";
+    protected static groupFilterName = "programIndicatorGroups";
+
+    protected static excludeRules = ["programs"];
+    protected static includeRules = [
+        "attributes",
+        "legendSets",
+        "programIndicatorGroups",
+        "programIndicatorGroups.attributes",
+    ];
+}
+
+export class ProgramIndicatorGroupModel extends D2Model {
+    protected static metadataType = "programIndicatorGroup";
+
+    protected static excludeRules = ["legendSets", "programIndicators.programIndicatorGroups"];
+    protected static includeRules = [
+        "attributes",
+        "programIndicators",
+        "programIndicators.attributes",
+    ];
+}
+
+export class ProgramRuleModel extends D2Model {
+    protected static metadataType = "programRule";
+
+    protected static excludeRules = [];
+    protected static includeRules = ["attributes", "programRuleActions"];
+}
+
+export class ProgramRuleVariableModel extends D2Model {
+    protected static metadataType = "programRuleVariable";
+
+    protected static excludeRules = [];
+    protected static includeRules = ["attributes"];
+}
+
 export class ValidationRuleModel extends D2Model {
     protected static metadataType = "validationRule";
     protected static groupFilterName = "validationRuleGroups";

--- a/src/types/d2.d.ts
+++ b/src/types/d2.d.ts
@@ -85,6 +85,8 @@ export interface D2 {
         username: string;
         name: string;
         email: string;
+        getUserRoles(): Promise<any>;
+        getUserGroups(): Promise<any>;
     };
 }
 

--- a/src/types/modules.d.ts
+++ b/src/types/modules.d.ts
@@ -17,3 +17,7 @@ declare module "@dhis2/d2-i18n" {
 declare module "@dhis2/d2-i18n" {
     export function t(value: string, variable?: any): string;
 }
+
+declare module "nano-memoize" {
+    export default function memoize(method: Function): Function;
+}

--- a/src/types/synchronization.d.ts
+++ b/src/types/synchronization.d.ts
@@ -60,4 +60,14 @@ export interface SynchronizationRule {
     enabled: boolean;
     lastExecuted?: Date;
     frequency?: string;
+    publicAccess: string;
+    userAccesses: SharingSetting[];
+    userGroupAccesses: SharingSetting[];
+}
+
+export interface SharingSetting {
+    access: string;
+    displayName: string;
+    id: string;
+    name: string;
 }

--- a/src/utils/permissions.ts
+++ b/src/utils/permissions.ts
@@ -1,0 +1,108 @@
+import axios from "axios";
+import memoize from "nano-memoize";
+
+import { D2 } from "../types/d2";
+
+const AppRoles: {
+    [key: string]: {
+        name: string;
+        description: string;
+    };
+} = {
+    CONFIGURATION_ACCESS: {
+        name: "METADATA_SYNC_CONFIGURATOR",
+        description:
+            "APP - This role allows to create new instances and synchronization rules in the Metadata Sync app",
+    },
+    SYNC_RULE_EXECUTION_ACCESS: {
+        name: "METADATA_SYNC_EXECUTOR",
+        description:
+            "APP - This role allows to execute synchronization rules in the Metadata Sync app",
+    },
+};
+
+export interface UserInfo {
+    userGroups: any[];
+    id: string;
+    name: string;
+    username: string;
+}
+
+const getUserRoles = memoize(async (d2: D2) => {
+    const baseUrl = d2.Api.getApi().baseUrl;
+    const { userCredentials } = (await axios.get(baseUrl + "/me", {
+        withCredentials: true,
+        params: {
+            fields: "userCredentials[userRoles[:all]]",
+        },
+    })).data;
+    return userCredentials.userRoles;
+});
+
+export const isGlobalAdmin = async (d2: D2) => {
+    const userRoles = await getUserRoles(d2);
+    return !!userRoles.find((role: any) =>
+        role.authorities.find((authority: string) => authority === "ALL")
+    );
+};
+
+export const isAppConfigurator = async (d2: D2) => {
+    const userRoles = await getUserRoles(d2);
+    const globalAdmin = await isGlobalAdmin(d2);
+    const { name } = AppRoles.CONFIGURATION_ACCESS;
+
+    return globalAdmin || !!userRoles.find((role: any) => role.name === name);
+};
+
+export const isAppExecutor = async (d2: D2) => {
+    const userRoles = await getUserRoles(d2);
+    const globalAdmin = await isGlobalAdmin(d2);
+    const { name } = AppRoles.SYNC_RULE_EXECUTION_ACCESS;
+
+    return globalAdmin || !!userRoles.find((role: any) => role.name === name);
+};
+
+export const getUserInfo = memoize(
+    async (d2: D2): Promise<UserInfo> => {
+        const userGroups = await d2.currentUser.getUserGroups();
+
+        return {
+            userGroups: userGroups.toArray(),
+            id: d2.currentUser.id,
+            name: d2.currentUser.name,
+            username: d2.currentUser.username,
+        };
+    }
+);
+
+export const initializeAppRoles = async (baseUrl: string) => {
+    for (const role in AppRoles) {
+        const { name, description } = AppRoles[role];
+        const { userRoles } = (await axios.get(baseUrl + "/metadata", {
+            withCredentials: true,
+            params: {
+                userRoles: true,
+                filter: `name:eq:${name}`,
+                fields: "id",
+            },
+        })).data as { userRoles?: { id: string }[] };
+
+        if (!userRoles || userRoles.length === 0) {
+            await axios.post(
+                baseUrl + "/metadata.json",
+                {
+                    userRoles: [
+                        {
+                            name,
+                            description,
+                            publicAccess: "--------",
+                        },
+                    ],
+                },
+                {
+                    withCredentials: true,
+                }
+            );
+        }
+    }
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1270,6 +1270,11 @@
   resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz#2b5a3ab3f918cca48a8c754c08168e3f03eba61b"
   integrity sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==
 
+"@reach/auto-id@^0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@reach/auto-id/-/auto-id-0.2.0.tgz#97f9e48fe736aa5c6f4f32cf73c1f19d005f8550"
+  integrity sha512-lVK/svL2HuQdp7jgvlrLkFsUx50Az9chAhxpiPwBqcS83I2pVWvXp98FOcSCCJCV++l115QmzHhFd+ycw1zLBg==
+
 "@sinonjs/commons@^1", "@sinonjs/commons@^1.3.0", "@sinonjs/commons@^1.4.0":
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.6.0.tgz#ec7670432ae9c8eb710400d112c201a362d83393"
@@ -3462,6 +3467,11 @@ compression@^1.5.2:
     safe-buffer "5.1.2"
     vary "~1.1.2"
 
+compute-scroll-into-view@^1.0.9:
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/compute-scroll-into-view/-/compute-scroll-into-view-1.0.11.tgz#7ff0a57f9aeda6314132d8994cce7aeca794fecf"
+  integrity sha512-uUnglJowSe0IPmWOdDtrlHXof5CTIJitfJEyITHBW6zDVOGu9Pjk5puaLM73SLcwak0L4hEjO7Td88/a6P5i7A==
+
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
@@ -4431,6 +4441,17 @@ dotenv@6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-6.2.0.tgz#941c0410535d942c8becf28d3f357dbd9d476064"
   integrity sha512-HygQCKUBSFl8wKQZBSemMywRWcEDNidvNbjGVyZu3nbZ8qq9ubiPoGLMdRDpfSrpkkm9BXYFkpKxxFX38o/76w==
+
+downshift@^3.3.4:
+  version "3.3.4"
+  resolved "https://registry.yarnpkg.com/downshift/-/downshift-3.3.4.tgz#959be157e48be2ec2bbc50f184303647fc719026"
+  integrity sha512-3bM11S3p78p/moyJqDPc1j357dm/C+dN+54HKuc526k5etNXvnXyxsb+Ufd2yLL6qK4QZA62DysAgtMCIsKCNA==
+  dependencies:
+    "@babel/runtime" "^7.4.5"
+    "@reach/auto-id" "^0.2.0"
+    compute-scroll-into-view "^1.0.9"
+    prop-types "^15.7.2"
+    react-is "^16.9.0"
 
 duplexer@^0.1.1:
   version "0.1.1"


### PR DESCRIPTION
### :pushpin: References

* **Issue:** Closes #149 
* I am still testing this PR but uploading for @adrianq to also begin with the testing

### :memo: Implementation

- Program Indicators: Followed the same as per Indicators. The main difference is ```analyticsPeriodBoundaries``` but the object appears to be bundled inside.

- Program Indicator Groups: Followed the same as per Indicator Groups.

- Program Rules: Has a very strong relationship with ``program`` and I find dangerous synchronizing this metadata without controlling the element exists on remote.

- Program Rule variable: Has a very strong relationship with ``program``. ``programStage`` and ``dataElement``. This appears to be a dangerous uncontrolled operation.

For future versions of metadata-sync (or data-sync) we could try to automate the verification of some of these relationships in destination.

### :art: Screenshots

![image](https://user-images.githubusercontent.com/2181866/66579936-e102b080-eb7d-11e9-88ed-b1d7c7923f72.png)

### :fire: Is there anything the reviewer should know to test it?

- There are two WHO instances available for test, ask for credentials if needed.

- WHO does not currently use Program Indicator Groups but we want to push them so they begin using them for this synchronization purposes.

### :bookmark_tabs: Others
