### PR TITLE
Sharing settings and administrative user role

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2019-10-08T15:37:48.096Z\n"
-"PO-Revision-Date: 2019-10-08T15:37:48.096Z\n"
+"POT-Creation-Date: 2019-10-10T16:55:48.806Z\n"
+"PO-Revision-Date: 2019-10-10T16:55:48.806Z\n"
 
 msgid "Metadata Synchronization"
 msgstr ""
@@ -425,10 +425,10 @@ msgstr ""
 msgid "Created by"
 msgstr ""
 
-msgid "Unknown"
+msgid "Who has access"
 msgstr ""
 
-msgid "Who has access"
+msgid "Close"
 msgstr ""
 
 msgid "Add users and user groups"

--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2019-09-17T10:45:09.309Z\n"
-"PO-Revision-Date: 2019-09-17T10:45:09.309Z\n"
+"POT-Creation-Date: 2019-10-08T15:37:48.096Z\n"
+"PO-Revision-Date: 2019-10-08T15:37:48.096Z\n"
 
 msgid "Metadata Synchronization"
 msgstr ""
@@ -378,6 +378,9 @@ msgstr ""
 msgid "Toggle scheduling"
 msgstr ""
 
+msgid "Sharing settings"
+msgstr ""
+
 msgid "Last executed date"
 msgstr ""
 
@@ -391,6 +394,48 @@ msgid "Are you sure you want to delete {{count}} rules?"
 msgid_plural "Are you sure you want to delete {{count}} rules?"
 msgstr[0] ""
 msgstr[1] ""
+
+msgid "External access"
+msgstr ""
+
+msgid "Anyone can view without login"
+msgstr ""
+
+msgid "No access"
+msgstr ""
+
+msgid "Public access"
+msgstr ""
+
+msgid "METADATA"
+msgstr ""
+
+msgid "Can edit and view"
+msgstr ""
+
+msgid "Can view only"
+msgstr ""
+
+msgid "DATA"
+msgstr ""
+
+msgid "Can capture and view"
+msgstr ""
+
+msgid "Created by"
+msgstr ""
+
+msgid "Unknown"
+msgstr ""
+
+msgid "Who has access"
+msgstr ""
+
+msgid "Add users and user groups"
+msgstr ""
+
+msgid "Enter names"
+msgstr ""
 
 msgid "Synchronize Metadata"
 msgstr ""

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "d2": "^31.1.1",
     "d2-manifest": "^1.0.0",
     "d2-ui-components": "^0.0.25",
+    "downshift": "^3.3.4",
     "enzyme": "^3.10.0",
     "enzyme-adapter-react-16": "^1.14.0",
     "enzyme-to-json": "^3.4.0",

--- a/src/components/app/App.jsx
+++ b/src/components/app/App.jsx
@@ -13,7 +13,7 @@ import Share from "../share/Share";
 import Instance from "../../models/instance";
 import { muiTheme } from "./themes/dhis2.theme";
 import muiThemeLegacy from "./themes/dhis2-legacy.theme";
-import { initializeAppRoles } from "../../utils/permissions";
+import { initializeAppRoles, isUserAdmin } from "../../utils/permissions";
 import "./App.css";
 
 const generateClassName = createGenerateClassName({
@@ -27,7 +27,11 @@ class App extends Component {
         appConfig: PropTypes.object.isRequired,
     };
 
-    componentDidMount() {
+    state = {
+        isUserAdmin: false
+    }
+
+    async componentDidMount() {
         const { d2, appConfig } = this.props;
         const appKey = _(this.props.appConfig).get("appKey");
 
@@ -44,10 +48,14 @@ class App extends Component {
         }
 
         initializeAppRoles(d2.Api.getApi().baseUrl);
+
+        const isAdmin = await isUserAdmin(d2);
+        this.setState({ isAdmin})
     }
 
     render() {
         const { d2, appConfig } = this.props;
+        const { isAdmin } = this.state;
         const showShareButton = _(appConfig).get("appearance.showShareButton") || false;
         const showHeader = !process.env.REACT_APP_CYPRESS;
 
@@ -63,7 +71,7 @@ class App extends Component {
                                     )}
 
                                     <div id="app" className="content">
-                                        <Root d2={d2} />
+                                        <Root d2={d2} isAdmin={isAdmin} />
                                     </div>
 
                                     <Share visible={showShareButton} />

--- a/src/components/app/App.jsx
+++ b/src/components/app/App.jsx
@@ -28,8 +28,8 @@ class App extends Component {
     };
 
     state = {
-        isUserAdmin: false
-    }
+        isUserAdmin: false,
+    };
 
     async componentDidMount() {
         const { d2, appConfig } = this.props;
@@ -50,7 +50,7 @@ class App extends Component {
         initializeAppRoles(d2.Api.getApi().baseUrl);
 
         const isAdmin = await isUserAdmin(d2);
-        this.setState({ isAdmin})
+        this.setState({ isAdmin });
     }
 
     render() {

--- a/src/components/app/App.jsx
+++ b/src/components/app/App.jsx
@@ -13,6 +13,7 @@ import Share from "../share/Share";
 import Instance from "../../models/instance";
 import { muiTheme } from "./themes/dhis2.theme";
 import muiThemeLegacy from "./themes/dhis2-legacy.theme";
+import { initializeAppRoles } from "../../utils/permissions";
 import "./App.css";
 
 const generateClassName = createGenerateClassName({
@@ -41,6 +42,8 @@ class App extends Component {
         if (appConfig && appConfig.encryptionKey) {
             Instance.setEncryptionKey(appConfig.encryptionKey);
         }
+
+        initializeAppRoles(d2.Api.getApi().baseUrl);
     }
 
     render() {

--- a/src/components/app/App.jsx
+++ b/src/components/app/App.jsx
@@ -13,7 +13,7 @@ import Share from "../share/Share";
 import Instance from "../../models/instance";
 import { muiTheme } from "./themes/dhis2.theme";
 import muiThemeLegacy from "./themes/dhis2-legacy.theme";
-import { initializeAppRoles, isUserAdmin } from "../../utils/permissions";
+import { initializeAppRoles } from "../../utils/permissions";
 import "./App.css";
 
 const generateClassName = createGenerateClassName({
@@ -25,10 +25,6 @@ class App extends Component {
     static propTypes = {
         d2: PropTypes.object.isRequired,
         appConfig: PropTypes.object.isRequired,
-    };
-
-    state = {
-        isUserAdmin: false,
     };
 
     async componentDidMount() {
@@ -47,15 +43,11 @@ class App extends Component {
             Instance.setEncryptionKey(appConfig.encryptionKey);
         }
 
-        initializeAppRoles(d2.Api.getApi().baseUrl);
-
-        const isAdmin = await isUserAdmin(d2);
-        this.setState({ isAdmin });
+        await initializeAppRoles(d2.Api.getApi().baseUrl);
     }
 
     render() {
         const { d2, appConfig } = this.props;
-        const { isAdmin } = this.state;
         const showShareButton = _(appConfig).get("appearance.showShareButton") || false;
         const showHeader = !process.env.REACT_APP_CYPRESS;
 
@@ -71,7 +63,7 @@ class App extends Component {
                                     )}
 
                                     <div id="app" className="content">
-                                        <Root d2={d2} isAdmin={isAdmin} />
+                                        <Root d2={d2} />
                                     </div>
 
                                     <Share visible={showShareButton} />

--- a/src/components/app/Root.jsx
+++ b/src/components/app/Root.jsx
@@ -61,7 +61,10 @@ class Root extends React.Component {
                     render={props => <DeletedObjectsPage {...this.props} {...props} />}
                 />
 
-                <Route path="/history/:id?" render={props => <HistoryPage {...this.props} {...props} />} />
+                <Route
+                    path="/history/:id?"
+                    render={props => <HistoryPage {...this.props} {...props} />}
+                />
 
                 {isAdmin && (
                     <Route

--- a/src/components/app/Root.jsx
+++ b/src/components/app/Root.jsx
@@ -13,18 +13,30 @@ import DeletedObjectsPage from "../synchronization-page/DeletedObjectsPage";
 import HistoryPage from "../history-list-page/HistoryPage";
 import SyncRulesWizard from "../rules-creation-page/SyncRulesWizard";
 import SyncRulesConfigurator from "../rules-list-page/SyncRulesPage";
+import { isAppAdmin } from "../../utils/permissions";
 
 class Root extends React.Component {
     static propTypes = {
         d2: PropTypes.object.isRequired,
     };
 
+    state = {
+        appAdmin: false,
+    };
+
+    async componentDidMount() {
+        const { d2 } = this.props;
+        const appAdmin = await isAppAdmin(d2);
+
+        this.setState({ appAdmin });
+    }
+
     render() {
-        const { isAdmin } = this.props;
+        const { appAdmin } = this.state;
 
         return (
             <Switch>
-                {isAdmin && (
+                {appAdmin && (
                     <Route
                         path={"/instance-configurator/:action(new|edit)/:id?"}
                         render={props => <InstanceFormBuilder {...this.props} {...props} />}
@@ -66,7 +78,7 @@ class Root extends React.Component {
                     render={props => <HistoryPage {...this.props} {...props} />}
                 />
 
-                {isAdmin && (
+                {appAdmin && (
                     <Route
                         path={"/synchronization-rules/:action(new|edit)/:id?"}
                         render={props => <SyncRulesWizard {...this.props} {...props} />}

--- a/src/components/app/Root.jsx
+++ b/src/components/app/Root.jsx
@@ -13,21 +13,36 @@ import DeletedObjectsPage from "../synchronization-page/DeletedObjectsPage";
 import HistoryPage from "../history-list-page/HistoryPage";
 import SyncRulesWizard from "../rules-creation-page/SyncRulesWizard";
 import SyncRulesConfigurator from "../rules-list-page/SyncRulesPage";
+import { getUserInfo } from "../../utils/permissions";
 
 class Root extends React.Component {
     static propTypes = {
         d2: PropTypes.object.isRequired,
     };
 
+    state = {
+        isAdmin: false,
+    };
+
+    componentDidMount = async () => {
+        const { d2 } = this.props;
+        const { isAdmin } = await getUserInfo(d2);
+
+        this.setState({ isAdmin });
+    };
+
     render() {
         const { d2 } = this.props;
+        const { isAdmin } = this.state;
 
         return (
             <Switch>
-                <Route
-                    path={"/instance-configurator/:action(new|edit)/:id?"}
-                    render={props => <InstanceFormBuilder d2={d2} {...props} />}
-                />
+                {isAdmin && (
+                    <Route
+                        path={"/instance-configurator/:action(new|edit)/:id?"}
+                        render={props => <InstanceFormBuilder d2={d2} {...props} />}
+                    />
+                )}
 
                 <Route
                     path="/instance-configurator"
@@ -61,10 +76,12 @@ class Root extends React.Component {
 
                 <Route path="/history/:id?" render={props => <HistoryPage d2={d2} {...props} />} />
 
-                <Route
-                    path={"/synchronization-rules/:action(new|edit)/:id?"}
-                    render={props => <SyncRulesWizard d2={d2} {...props} />}
-                />
+                {isAdmin && (
+                    <Route
+                        path={"/synchronization-rules/:action(new|edit)/:id?"}
+                        render={props => <SyncRulesWizard d2={d2} {...props} />}
+                    />
+                )}
 
                 <Route
                     path="/synchronization-rules"

--- a/src/components/app/Root.jsx
+++ b/src/components/app/Root.jsx
@@ -13,82 +13,69 @@ import DeletedObjectsPage from "../synchronization-page/DeletedObjectsPage";
 import HistoryPage from "../history-list-page/HistoryPage";
 import SyncRulesWizard from "../rules-creation-page/SyncRulesWizard";
 import SyncRulesConfigurator from "../rules-list-page/SyncRulesPage";
-import { getUserInfo } from "../../utils/permissions";
 
 class Root extends React.Component {
     static propTypes = {
         d2: PropTypes.object.isRequired,
     };
 
-    state = {
-        isAdmin: false,
-    };
-
-    componentDidMount = async () => {
-        const { d2 } = this.props;
-        const { isAdmin } = await getUserInfo(d2);
-
-        this.setState({ isAdmin });
-    };
-
     render() {
-        const { d2 } = this.props;
-        const { isAdmin } = this.state;
+        const { isAdmin } = this.props;
 
         return (
             <Switch>
                 {isAdmin && (
                     <Route
                         path={"/instance-configurator/:action(new|edit)/:id?"}
-                        render={props => <InstanceFormBuilder d2={d2} {...props} />}
+                        render={props => <InstanceFormBuilder {...this.props} {...props} />}
                     />
                 )}
 
                 <Route
                     path="/instance-configurator"
-                    render={props => <InstanceConfigurator d2={d2} {...props} />}
+                    render={props => <InstanceConfigurator {...this.props} {...props} />}
                 />
 
                 <Route
                     path="/sync/organisationUnits"
-                    render={props => <OrganisationUnitPage d2={d2} {...props} />}
+                    render={props => <OrganisationUnitPage {...this.props} {...props} />}
                 />
 
                 <Route
                     path="/sync/dataElements"
-                    render={props => <DataElementPage d2={d2} {...props} />}
+                    render={props => <DataElementPage {...this.props} {...props} />}
                 />
 
                 <Route
                     path="/sync/indicators"
-                    render={props => <IndicatorPage d2={d2} {...props} />}
+                    render={props => <IndicatorPage {...this.props} {...props} />}
                 />
 
                 <Route
                     path="/sync/validationRules"
-                    render={props => <ValidationRulePage d2={d2} {...props} />}
+                    render={props => <ValidationRulePage {...this.props} {...props} />}
                 />
 
                 <Route
                     path="/sync/deleted"
-                    render={props => <DeletedObjectsPage d2={d2} {...props} />}
+                    render={props => <DeletedObjectsPage {...this.props} {...props} />}
                 />
 
-                <Route path="/history/:id?" render={props => <HistoryPage d2={d2} {...props} />} />
+                <Route path="/history/:id?" render={props => <HistoryPage {...this.props} {...props} />} />
 
                 {isAdmin && (
                     <Route
                         path={"/synchronization-rules/:action(new|edit)/:id?"}
-                        render={props => <SyncRulesWizard d2={d2} {...props} />}
+                        render={props => <SyncRulesWizard {...this.props} {...props} />}
                     />
                 )}
 
                 <Route
                     path="/synchronization-rules"
-                    render={props => <SyncRulesConfigurator d2={d2} {...props} />}
+                    render={props => <SyncRulesConfigurator {...this.props} {...props} />}
                 />
 
-                <Route render={() => <LandingPage d2={d2} />} />
+                <Route render={() => <LandingPage {...this.props} />} />
             </Switch>
         );
     }

--- a/src/components/app/Root.jsx
+++ b/src/components/app/Root.jsx
@@ -13,35 +13,19 @@ import DeletedObjectsPage from "../synchronization-page/DeletedObjectsPage";
 import HistoryPage from "../history-list-page/HistoryPage";
 import SyncRulesWizard from "../rules-creation-page/SyncRulesWizard";
 import SyncRulesConfigurator from "../rules-list-page/SyncRulesPage";
-import { isAppAdmin } from "../../utils/permissions";
 
 class Root extends React.Component {
     static propTypes = {
         d2: PropTypes.object.isRequired,
     };
 
-    state = {
-        appAdmin: false,
-    };
-
-    async componentDidMount() {
-        const { d2 } = this.props;
-        const appAdmin = await isAppAdmin(d2);
-
-        this.setState({ appAdmin });
-    }
-
     render() {
-        const { appAdmin } = this.state;
-
         return (
             <Switch>
-                {appAdmin && (
-                    <Route
-                        path={"/instance-configurator/:action(new|edit)/:id?"}
-                        render={props => <InstanceFormBuilder {...this.props} {...props} />}
-                    />
-                )}
+                <Route
+                    path={"/instance-configurator/:action(new|edit)/:id?"}
+                    render={props => <InstanceFormBuilder {...this.props} {...props} />}
+                />
 
                 <Route
                     path="/instance-configurator"
@@ -78,12 +62,10 @@ class Root extends React.Component {
                     render={props => <HistoryPage {...this.props} {...props} />}
                 />
 
-                {appAdmin && (
-                    <Route
-                        path={"/synchronization-rules/:action(new|edit)/:id?"}
-                        render={props => <SyncRulesWizard {...this.props} {...props} />}
-                    />
-                )}
+                <Route
+                    path={"/synchronization-rules/:action(new|edit)/:id?"}
+                    render={props => <SyncRulesWizard {...this.props} {...props} />}
+                />
 
                 <Route
                     path="/synchronization-rules"

--- a/src/components/instance-list-page/InstancesPage.jsx
+++ b/src/components/instance-list-page/InstancesPage.jsx
@@ -6,8 +6,8 @@ import { ConfirmationDialog, ObjectsTable, withLoading, withSnackbar } from "d2-
 import { withRouter } from "react-router-dom";
 
 import PageHeader from "../page-header/PageHeader";
-
 import Instance from "../../models/instance";
+import { hasUserRole, AppRoles } from "../../utils/permissions";
 
 class InstancesPage extends React.Component {
     static propTypes = {
@@ -26,7 +26,15 @@ class InstancesPage extends React.Component {
     state = {
         tableKey: Math.random(),
         toDelete: null,
+        isUserAdmin: false,
     };
+
+    async componentDidMount() {
+        const { d2 } = this.props;
+        const isUserAdmin = await hasUserRole(d2, AppRoles.METADATA_SYNC_ADMINISTRATOR);
+
+        this.setState({ isUserAdmin });
+    }
 
     columns = [
         { name: "name", text: i18n.t("Server name"), sortable: true },
@@ -76,12 +84,14 @@ class InstancesPage extends React.Component {
             name: "edit",
             text: i18n.t("Edit"),
             multiple: false,
+            isActive: () => this.state.isUserAdmin,
             onClick: this.editInstance,
         },
         {
             name: "delete",
             text: i18n.t("Delete"),
             multiple: true,
+            isActive: () => this.state.isUserAdmin,
             onClick: this.deleteInstance,
         },
         {
@@ -126,7 +136,7 @@ class InstancesPage extends React.Component {
     };
 
     render() {
-        const { tableKey, toDelete } = this.state;
+        const { tableKey, toDelete, isUserAdmin } = this.state;
         const { d2 } = this.props;
 
         return (
@@ -153,7 +163,7 @@ class InstancesPage extends React.Component {
                     detailsFields={this.detailsFields}
                     pageSize={10}
                     actions={this.actions}
-                    onButtonClick={this.createInstance}
+                    onButtonClick={isUserAdmin ? this.createInstance : null}
                     list={Instance.list}
                 />
             </React.Fragment>

--- a/src/components/instance-list-page/InstancesPage.jsx
+++ b/src/components/instance-list-page/InstancesPage.jsx
@@ -7,7 +7,6 @@ import { withRouter } from "react-router-dom";
 
 import PageHeader from "../page-header/PageHeader";
 import Instance from "../../models/instance";
-import { getUserInfo } from "../../utils/permissions";
 
 class InstancesPage extends React.Component {
     static propTypes = {
@@ -26,15 +25,7 @@ class InstancesPage extends React.Component {
     state = {
         tableKey: Math.random(),
         toDelete: null,
-        isAdmin: false,
     };
-
-    async componentDidMount() {
-        const { d2 } = this.props;
-        const { isAdmin } = await getUserInfo(d2);
-
-        this.setState({ isAdmin });
-    }
 
     columns = [
         { name: "name", text: i18n.t("Server name"), sortable: true },
@@ -84,14 +75,14 @@ class InstancesPage extends React.Component {
             name: "edit",
             text: i18n.t("Edit"),
             multiple: false,
-            isActive: () => this.state.isAdmin,
+            isActive: () => this.props.isAdmin,
             onClick: this.editInstance,
         },
         {
             name: "delete",
             text: i18n.t("Delete"),
             multiple: true,
-            isActive: () => this.state.isAdmin,
+            isActive: () => this.props.isAdmin,
             onClick: this.deleteInstance,
         },
         {
@@ -136,8 +127,8 @@ class InstancesPage extends React.Component {
     };
 
     render() {
-        const { tableKey, toDelete, isAdmin } = this.state;
-        const { d2 } = this.props;
+        const { tableKey, toDelete } = this.state;
+        const { d2, isAdmin } = this.props;
 
         return (
             <React.Fragment>

--- a/src/components/instance-list-page/InstancesPage.jsx
+++ b/src/components/instance-list-page/InstancesPage.jsx
@@ -7,6 +7,7 @@ import { withRouter } from "react-router-dom";
 
 import PageHeader from "../page-header/PageHeader";
 import Instance from "../../models/instance";
+import { isAppAdmin } from "../../utils/permissions";
 
 class InstancesPage extends React.Component {
     static propTypes = {
@@ -25,7 +26,15 @@ class InstancesPage extends React.Component {
     state = {
         tableKey: Math.random(),
         toDelete: null,
+        appAdmin: false,
     };
+
+    async componentDidMount() {
+        const { d2 } = this.props;
+        const appAdmin = await isAppAdmin(d2);
+
+        this.setState({ appAdmin });
+    }
 
     columns = [
         { name: "name", text: i18n.t("Server name"), sortable: true },
@@ -75,14 +84,14 @@ class InstancesPage extends React.Component {
             name: "edit",
             text: i18n.t("Edit"),
             multiple: false,
-            isActive: () => this.props.isAdmin,
+            isActive: () => this.state.appAdmin,
             onClick: this.editInstance,
         },
         {
             name: "delete",
             text: i18n.t("Delete"),
             multiple: true,
-            isActive: () => this.props.isAdmin,
+            isActive: () => this.state.appAdmin,
             onClick: this.deleteInstance,
         },
         {
@@ -127,8 +136,8 @@ class InstancesPage extends React.Component {
     };
 
     render() {
-        const { tableKey, toDelete } = this.state;
-        const { d2, isAdmin } = this.props;
+        const { tableKey, toDelete, appAdmin } = this.state;
+        const { d2 } = this.props;
 
         return (
             <React.Fragment>
@@ -154,7 +163,7 @@ class InstancesPage extends React.Component {
                     detailsFields={this.detailsFields}
                     pageSize={10}
                     actions={this.actions}
-                    onButtonClick={isAdmin ? this.createInstance : null}
+                    onButtonClick={appAdmin ? this.createInstance : null}
                     list={Instance.list}
                 />
             </React.Fragment>

--- a/src/components/instance-list-page/InstancesPage.jsx
+++ b/src/components/instance-list-page/InstancesPage.jsx
@@ -7,7 +7,7 @@ import { withRouter } from "react-router-dom";
 
 import PageHeader from "../page-header/PageHeader";
 import Instance from "../../models/instance";
-import { isAppAdmin } from "../../utils/permissions";
+import { isAppConfigurator } from "../../utils/permissions";
 
 class InstancesPage extends React.Component {
     static propTypes = {
@@ -26,14 +26,14 @@ class InstancesPage extends React.Component {
     state = {
         tableKey: Math.random(),
         toDelete: null,
-        appAdmin: false,
+        appConfigurator: false,
     };
 
     async componentDidMount() {
         const { d2 } = this.props;
-        const appAdmin = await isAppAdmin(d2);
+        const appConfigurator = await isAppConfigurator(d2);
 
-        this.setState({ appAdmin });
+        this.setState({ appConfigurator });
     }
 
     columns = [
@@ -84,14 +84,14 @@ class InstancesPage extends React.Component {
             name: "edit",
             text: i18n.t("Edit"),
             multiple: false,
-            isActive: () => this.state.appAdmin,
+            isActive: () => this.state.appConfigurator,
             onClick: this.editInstance,
         },
         {
             name: "delete",
             text: i18n.t("Delete"),
             multiple: true,
-            isActive: () => this.state.appAdmin,
+            isActive: () => this.state.appConfigurator,
             onClick: this.deleteInstance,
         },
         {
@@ -136,7 +136,7 @@ class InstancesPage extends React.Component {
     };
 
     render() {
-        const { tableKey, toDelete, appAdmin } = this.state;
+        const { tableKey, toDelete, appConfigurator } = this.state;
         const { d2 } = this.props;
 
         return (
@@ -163,7 +163,7 @@ class InstancesPage extends React.Component {
                     detailsFields={this.detailsFields}
                     pageSize={10}
                     actions={this.actions}
-                    onButtonClick={appAdmin ? this.createInstance : null}
+                    onButtonClick={appConfigurator ? this.createInstance : null}
                     list={Instance.list}
                 />
             </React.Fragment>

--- a/src/components/instance-list-page/InstancesPage.jsx
+++ b/src/components/instance-list-page/InstancesPage.jsx
@@ -7,7 +7,7 @@ import { withRouter } from "react-router-dom";
 
 import PageHeader from "../page-header/PageHeader";
 import Instance from "../../models/instance";
-import { hasUserRole, AppRoles } from "../../utils/permissions";
+import { getUserInfo } from "../../utils/permissions";
 
 class InstancesPage extends React.Component {
     static propTypes = {
@@ -26,14 +26,14 @@ class InstancesPage extends React.Component {
     state = {
         tableKey: Math.random(),
         toDelete: null,
-        isUserAdmin: false,
+        isAdmin: false,
     };
 
     async componentDidMount() {
         const { d2 } = this.props;
-        const isUserAdmin = await hasUserRole(d2, AppRoles.METADATA_SYNC_ADMINISTRATOR);
+        const { isAdmin } = await getUserInfo(d2);
 
-        this.setState({ isUserAdmin });
+        this.setState({ isAdmin });
     }
 
     columns = [
@@ -84,14 +84,14 @@ class InstancesPage extends React.Component {
             name: "edit",
             text: i18n.t("Edit"),
             multiple: false,
-            isActive: () => this.state.isUserAdmin,
+            isActive: () => this.state.isAdmin,
             onClick: this.editInstance,
         },
         {
             name: "delete",
             text: i18n.t("Delete"),
             multiple: true,
-            isActive: () => this.state.isUserAdmin,
+            isActive: () => this.state.isAdmin,
             onClick: this.deleteInstance,
         },
         {
@@ -136,7 +136,7 @@ class InstancesPage extends React.Component {
     };
 
     render() {
-        const { tableKey, toDelete, isUserAdmin } = this.state;
+        const { tableKey, toDelete, isAdmin } = this.state;
         const { d2 } = this.props;
 
         return (
@@ -163,7 +163,7 @@ class InstancesPage extends React.Component {
                     detailsFields={this.detailsFields}
                     pageSize={10}
                     actions={this.actions}
-                    onButtonClick={isUserAdmin ? this.createInstance : null}
+                    onButtonClick={isAdmin ? this.createInstance : null}
                     list={Instance.list}
                 />
             </React.Fragment>

--- a/src/components/rules-list-page/SyncRulesPage.jsx
+++ b/src/components/rules-list-page/SyncRulesPage.jsx
@@ -230,7 +230,7 @@ class SyncRulesPage extends React.Component {
         this.setState({ sharingSettingsObject: null });
     };
 
-    verifyUserHasAccess = (d2, data, role) => {
+    verifyUserHasAccess = (d2, data, condition) => {
         const { userInfo, globalAdmin } = this.state;
         if (globalAdmin) return true;
 
@@ -240,7 +240,7 @@ class SyncRulesPage extends React.Component {
             if (!rule.isVisibleToUser(userInfo, "WRITE")) return false;
         }
 
-        return role;
+        return condition || true;
     };
 
     verifyUserCanEdit = (d2, data) => {

--- a/src/components/rules-list-page/SyncRulesPage.jsx
+++ b/src/components/rules-list-page/SyncRulesPage.jsx
@@ -230,7 +230,7 @@ class SyncRulesPage extends React.Component {
         this.setState({ sharingSettingsObject: null });
     };
 
-    verifyUserHasAccess = (d2, data, condition) => {
+    verifyUserHasAccess = (d2, data, condition = false) => {
         const { userInfo, globalAdmin } = this.state;
         if (globalAdmin) return true;
 
@@ -240,7 +240,7 @@ class SyncRulesPage extends React.Component {
             if (!rule.isVisibleToUser(userInfo, "WRITE")) return false;
         }
 
-        return condition || true;
+        return condition;
     };
 
     verifyUserCanEdit = (d2, data) => {

--- a/src/components/rules-list-page/SyncRulesPage.jsx
+++ b/src/components/rules-list-page/SyncRulesPage.jsx
@@ -227,15 +227,20 @@ class SyncRulesPage extends React.Component {
 
     verifyUserCanEdit = (d2, data) => {
         const { userInfo, globalAdmin } = this.state;
-        const rule = SyncRule.build(data);
+        if (globalAdmin) return true;
 
-        return globalAdmin || rule.isVisibleToUser(userInfo, "WRITE");
+        const rules = Array.isArray(data) ? data : [data];
+        for (const ruleData of rules) {
+            const rule = SyncRule.build(ruleData);
+
+            if (!rule.isVisibleToUser(userInfo, "WRITE")) return false;
+        }
+        
+        return true;
     };
 
     verifyUserCanExecute = (d2, rule) => {
-        const { appExecutor } = this.state;
-
-        return appExecutor;
+        return this.state.appExecutor;
     };
 
     actions = [

--- a/src/components/rules-list-page/SyncRulesPage.jsx
+++ b/src/components/rules-list-page/SyncRulesPage.jsx
@@ -49,9 +49,7 @@ class SyncRulesPage extends React.Component {
         lastExecutedFilter: null,
         syncReport: SyncReport.create(),
         syncSummaryOpen: false,
-        userInfo: {
-            isAdmin: false,
-        },
+        userInfo: {},
     };
 
     getTargetInstances = ruleData => {
@@ -222,7 +220,8 @@ class SyncRulesPage extends React.Component {
     };
 
     verifyUserHasPermissions = (d2, rule) => {
-        const { id: userId, userGroups, isAdmin } = this.state.userInfo;
+        const { isAdmin } =this.props;
+        const { id: userId, userGroups } = this.state.userInfo;
         const { publicAccess = "--------", userAccesses = [], userGroupAccesses = [] } = rule;
 
         return (
@@ -362,9 +361,8 @@ class SyncRulesPage extends React.Component {
             enabledFilter,
             lastExecutedFilter,
             sharingSettingsObject,
-            userInfo,
         } = this.state;
-        const { d2 } = this.props;
+        const { d2, isAdmin } = this.props;
 
         return (
             <React.Fragment>
@@ -378,7 +376,7 @@ class SyncRulesPage extends React.Component {
                     pageSize={10}
                     actions={this.actions}
                     list={SyncRule.list}
-                    onButtonClick={userInfo.isAdmin ? this.createRule : null}
+                    onButtonClick={isAdmin ? this.createRule : null}
                     customFiltersComponent={this.renderCustomFilters}
                     customFilters={{ targetInstanceFilter, enabledFilter, lastExecutedFilter }}
                 />

--- a/src/components/rules-list-page/SyncRulesPage.jsx
+++ b/src/components/rules-list-page/SyncRulesPage.jsx
@@ -379,7 +379,7 @@ class SyncRulesPage extends React.Component {
 
                 <SharingDialog
                     isOpen={!!sharingSettingsObject}
-                    isDataShareable={true}
+                    isDataShareable={false}
                     sharedObject={sharingSettingsObject}
                     onCancel={this.closeSharingSettings}
                     onSharingChanged={this.onSharingChanged}

--- a/src/components/rules-list-page/SyncRulesPage.jsx
+++ b/src/components/rules-list-page/SyncRulesPage.jsx
@@ -220,7 +220,7 @@ class SyncRulesPage extends React.Component {
     };
 
     verifyUserHasPermissions = (d2, rule) => {
-        const { isAdmin } =this.props;
+        const { isAdmin } = this.props;
         const { id: userId, userGroups } = this.state.userInfo;
         const { publicAccess = "--------", userAccesses = [], userGroupAccesses = [] } = rule;
 

--- a/src/components/rules-list-page/SyncRulesPage.jsx
+++ b/src/components/rules-list-page/SyncRulesPage.jsx
@@ -21,6 +21,7 @@ import SyncSummary from "../sync-summary/SyncSummary";
 import Dropdown from "../dropdown/Dropdown";
 import SharingDialog from "../sharing-dialog/SharingDialog";
 import { getValidationMessages } from "../../utils/validations";
+import { hasUserRole, AppRoles } from "../../utils/permissions";
 
 class SyncRulesPage extends React.Component {
     static propTypes = {
@@ -48,6 +49,7 @@ class SyncRulesPage extends React.Component {
         lastExecutedFilter: null,
         syncReport: SyncReport.create(),
         syncSummaryOpen: false,
+        isUserAdmin: false,
     };
 
     getTargetInstances = ruleData => {
@@ -118,7 +120,9 @@ class SyncRulesPage extends React.Component {
     async componentDidMount() {
         const { d2 } = this.props;
         const { objects: allInstances } = await Instance.list(d2, null, null);
-        this.setState({ allInstances });
+        const isUserAdmin = await hasUserRole(d2, AppRoles.METADATA_SYNC_ADMINISTRATOR);
+
+        this.setState({ allInstances, isUserAdmin });
     }
 
     backHome = () => {
@@ -226,12 +230,14 @@ class SyncRulesPage extends React.Component {
             name: "edit",
             text: i18n.t("Edit"),
             multiple: false,
+            isActive: () => this.state.isUserAdmin,
             onClick: this.editRule,
         },
         {
             name: "delete",
             text: i18n.t("Delete"),
             multiple: true,
+            isActive: () => this.state.isUserAdmin,
             onClick: this.deleteSyncRules,
         },
         {
@@ -245,6 +251,7 @@ class SyncRulesPage extends React.Component {
             name: "toggleEnable",
             text: i18n.t("Toggle scheduling"),
             multiple: false,
+            isActive: () => this.state.isUserAdmin,
             onClick: this.toggleEnable,
             icon: "timer",
         },
@@ -252,6 +259,7 @@ class SyncRulesPage extends React.Component {
             name: "sharingSettings",
             text: i18n.t("Sharing settings"),
             multiple: false,
+            isActive: () => this.state.isUserAdmin,
             onClick: this.openSharingSettings,
             icon: "share",
         },
@@ -335,6 +343,7 @@ class SyncRulesPage extends React.Component {
             enabledFilter,
             lastExecutedFilter,
             sharingSettingsObject,
+            isUserAdmin,
         } = this.state;
         const { d2 } = this.props;
 
@@ -350,7 +359,7 @@ class SyncRulesPage extends React.Component {
                     pageSize={10}
                     actions={this.actions}
                     list={SyncRule.list}
-                    onButtonClick={this.createRule}
+                    onButtonClick={isUserAdmin ? this.createRule : null}
                     customFiltersComponent={this.renderCustomFilters}
                     customFilters={{ targetInstanceFilter, enabledFilter, lastExecutedFilter }}
                 />

--- a/src/components/sharing-dialog/Access.jsx
+++ b/src/components/sharing-dialog/Access.jsx
@@ -76,7 +76,7 @@ export const Access = withStyles(styles)(
                 onChange={onChange}
                 disabled={disabled}
             />
-            <IconButton disabled={!onRemove} onClick={onRemove || (() => {})}>
+            <IconButton disabled={!onRemove} onClick={onRemove}>
                 <ClearIcon color={!onRemove ? "disabled" : "action"} />
             </IconButton>
         </div>
@@ -95,8 +95,8 @@ Access.propTypes = {
 };
 
 Access.defaultProps = {
-    secondaryText: undefined,
-    onRemove: undefined,
+    secondaryText: null,
+    onRemove: null,
     disabled: false,
 };
 

--- a/src/components/sharing-dialog/Access.jsx
+++ b/src/components/sharing-dialog/Access.jsx
@@ -6,6 +6,7 @@ import PersonIcon from "@material-ui/icons/Person";
 import GroupIcon from "@material-ui/icons/Group";
 import PublicIcon from "@material-ui/icons/Public";
 import BusinessIcon from "@material-ui/icons/Business";
+import { withStyles } from "@material-ui/core/styles";
 import i18n from "@dhis2/d2-i18n";
 
 import PermissionPicker from "./PermissionPicker";
@@ -51,32 +52,35 @@ const useAccessObjectFormat = props => ({
     onChange: newAccess => props.onChange(accessObjectToString(newAccess)),
 });
 
-export const Access = ({
-    access,
-    accessType,
-    accessOptions,
-    primaryText,
-    secondaryText,
-    onChange,
-    onRemove,
-    disabled,
-}) => (
-    <div style={styles.accessView}>
-        <SvgIcon userType={accessType} />
-        <div style={styles.accessDescription}>
-            <div>{primaryText}</div>
-            <div style={{ color: "#818181", paddingTop: 4 }}>{secondaryText || " "}</div>
+export const Access = withStyles(styles)(
+    ({
+        access,
+        accessType,
+        accessOptions,
+        primaryText,
+        secondaryText,
+        onChange,
+        onRemove,
+        disabled,
+        classes,
+    }) => (
+        <div className={classes.accessView}>
+            <SvgIcon userType={accessType} />
+            <div className={classes.accessDescription}>
+                <div>{primaryText}</div>
+                <div style={{ color: "#818181", paddingTop: 4 }}>{secondaryText || " "}</div>
+            </div>
+            <PermissionPicker
+                access={access}
+                accessOptions={accessOptions}
+                onChange={onChange}
+                disabled={disabled}
+            />
+            <IconButton disabled={!onRemove} onClick={onRemove || (() => {})}>
+                <ClearIcon color={!onRemove ? "disabled" : "action"} />
+            </IconButton>
         </div>
-        <PermissionPicker
-            access={access}
-            accessOptions={accessOptions}
-            onChange={onChange}
-            disabled={disabled}
-        />
-        <IconButton disabled={!onRemove} onClick={onRemove || (() => {})}>
-            <ClearIcon color={!onRemove ? "disabled" : "action"} />
-        </IconButton>
-    </div>
+    )
 );
 
 Access.propTypes = {

--- a/src/components/sharing-dialog/Access.jsx
+++ b/src/components/sharing-dialog/Access.jsx
@@ -1,0 +1,161 @@
+import React from "react";
+import PropTypes from "prop-types";
+import IconButton from "@material-ui/core/IconButton";
+import ClearIcon from "@material-ui/icons/Clear";
+import PersonIcon from "@material-ui/icons/Person";
+import GroupIcon from "@material-ui/icons/Group";
+import PublicIcon from "@material-ui/icons/Public";
+import BusinessIcon from "@material-ui/icons/Business";
+import i18n from "@dhis2/d2-i18n";
+
+import PermissionPicker from "./PermissionPicker";
+import { accessStringToObject, accessObjectToString } from "./utils";
+
+const icons = {
+    user: PersonIcon,
+    userGroup: GroupIcon,
+    external: PublicIcon,
+    public: BusinessIcon,
+};
+
+const SvgIcon = ({ userType }) => {
+    const Icon = icons[userType] || PersonIcon;
+
+    return <Icon color="action" />;
+};
+
+SvgIcon.propTypes = {
+    userType: PropTypes.string.isRequired,
+};
+
+const styles = {
+    accessView: {
+        fontWeight: "400",
+        display: "flex",
+        flexDirection: "row",
+        justifyContent: "space-between",
+        alignItems: "center",
+        padding: "4px 8px",
+    },
+    accessDescription: {
+        display: "flex",
+        flexDirection: "column",
+        flex: 1,
+        paddingLeft: 16,
+    },
+};
+
+const useAccessObjectFormat = props => ({
+    ...props,
+    access: accessStringToObject(props.access),
+    onChange: newAccess => props.onChange(accessObjectToString(newAccess)),
+});
+
+export const Access = ({
+    access,
+    accessType,
+    accessOptions,
+    primaryText,
+    secondaryText,
+    onChange,
+    onRemove,
+    disabled,
+}) => (
+    <div style={styles.accessView}>
+        <SvgIcon userType={accessType} />
+        <div style={styles.accessDescription}>
+            <div>{primaryText}</div>
+            <div style={{ color: "#818181", paddingTop: 4 }}>{secondaryText || " "}</div>
+        </div>
+        <PermissionPicker
+            access={access}
+            accessOptions={accessOptions}
+            onChange={onChange}
+            disabled={disabled}
+        />
+        <IconButton disabled={!onRemove} onClick={onRemove || (() => {})}>
+            <ClearIcon color={!onRemove ? "disabled" : "action"} />
+        </IconButton>
+    </div>
+);
+
+Access.propTypes = {
+    access: PropTypes.object.isRequired,
+    accessType: PropTypes.string.isRequired,
+    accessOptions: PropTypes.object.isRequired,
+    primaryText: PropTypes.string.isRequired,
+    onChange: PropTypes.func.isRequired,
+    disabled: PropTypes.bool,
+    secondaryText: PropTypes.string,
+    onRemove: PropTypes.func,
+};
+
+Access.defaultProps = {
+    secondaryText: undefined,
+    onRemove: undefined,
+    disabled: false,
+};
+
+export const GroupAccess = basicProps => {
+    const props = useAccessObjectFormat(basicProps);
+    const newProps = {
+        accessType: props.groupType,
+        primaryText: props.groupName,
+        accessOptions: {
+            meta: { canView: true, canEdit: true, noAccess: false },
+            data: props.dataShareable && {
+                canView: true,
+                canEdit: true,
+                noAccess: true,
+            },
+        },
+    };
+
+    return <Access {...props} {...newProps} />;
+};
+
+export const ExternalAccess = props => {
+    const newProps = {
+        ...props,
+        accessType: "external",
+        primaryText: i18n.t("External access"),
+        secondaryText: props.access ? i18n.t("Anyone can view without login") : i18n.t("No access"),
+        access: {
+            meta: { canEdit: false, canView: props.access },
+            data: { canEdit: false, canView: false },
+        },
+        onChange: newAccess => props.onChange(newAccess.meta.canView),
+        accessOptions: {
+            meta: { canView: true, canEdit: false, noAccess: true },
+        },
+    };
+
+    return <Access {...props} {...newProps} />;
+};
+
+export const PublicAccess = basicProps => {
+    const props = useAccessObjectFormat(basicProps);
+    const { canEdit, canView } = props.access.meta;
+    const description = canEdit
+        ? "Anyone can find and view"
+        : canView
+        ? "Anyone can view"
+        : "No access";
+
+    const newProps = {
+        ...props,
+        accessType: "public",
+        primaryText: i18n.t("Public access"),
+        secondaryText: description,
+        accessOptions: {
+            meta: { canView: true, canEdit: true, noAccess: true },
+            data: props.dataShareable && {
+                canView: true,
+                canEdit: true,
+                noAccess: true,
+            },
+        },
+    };
+
+    return <Access {...props} {...newProps} />;
+};

--- a/src/components/sharing-dialog/AutoComplete.jsx
+++ b/src/components/sharing-dialog/AutoComplete.jsx
@@ -1,0 +1,156 @@
+import React, { Component } from "react";
+import PropTypes from "prop-types";
+import Downshift from "downshift";
+import { withStyles } from "@material-ui/core/styles";
+import TextField from "@material-ui/core/TextField";
+import Paper from "@material-ui/core/Paper";
+import MenuItem from "@material-ui/core/MenuItem";
+import Popper from "@material-ui/core/Popper";
+
+const Input = ({ InputProps }) => {
+    return <TextField id="user-search-input" fullWidth InputProps={{ ...InputProps }} />;
+};
+
+Input.propTypes = {
+    InputProps: PropTypes.object.isRequired,
+};
+
+const Suggestion = ({ suggestion, itemProps, isHighlighted, selectedItem }) => {
+    const isSelected = selectedItem && selectedItem.id === suggestion.id;
+
+    return (
+        <MenuItem
+            {...itemProps}
+            key={suggestion.label}
+            selected={isHighlighted}
+            component="div"
+            style={{
+                fontWeight: isSelected ? 500 : 400,
+            }}
+        >
+            {suggestion.displayName}
+        </MenuItem>
+    );
+};
+
+Suggestion.propTypes = {
+    isHighlighted: PropTypes.bool.isRequired,
+    itemProps: PropTypes.object,
+    selectedItem: PropTypes.object,
+    suggestion: PropTypes.shape({ displayName: PropTypes.string }).isRequired,
+};
+
+const styles = theme => ({
+    root: {
+        flexGrow: 1,
+        height: 60,
+    },
+    popper: {
+        zIndex: 2000,
+        maxHeight: "420px",
+        overflowY: "hidden",
+        boxShadow: "0px 0px 1px 1px rgba(0,0,0,0.2)",
+    },
+    container: {
+        flexGrow: 1,
+        position: "relative",
+    },
+    inputRoot: {
+        flexWrap: "wrap",
+    },
+});
+
+let popperNode;
+
+class AutoComplete extends Component {
+    render() {
+        const { classes, placeholderText, suggestions, searchText } = this.props;
+
+        return (
+            <div className={classes.root}>
+                <Downshift
+                    id="user-autocomplete"
+                    onInputValueChange={this.props.onInputChanged}
+                    onChange={this.props.onItemSelected}
+                    itemToString={item => (item ? item.name : "")}
+                    inputValue={searchText}
+                >
+                    {({
+                        getInputProps,
+                        getItemProps,
+                        getMenuProps,
+                        highlightedIndex,
+                        isOpen,
+                        selectedItem,
+                    }) => {
+                        return (
+                            <div className={classes.container}>
+                                <Input
+                                    fullWidth
+                                    classes={classes}
+                                    InputProps={getInputProps({
+                                        placeholder: placeholderText,
+                                        inputRef: node => {
+                                            popperNode = node;
+                                        },
+                                    })}
+                                />
+                                <div {...getMenuProps()}>
+                                    {isOpen && (
+                                        <Popper
+                                            className={classes.popper}
+                                            open
+                                            anchorEl={popperNode}
+                                        >
+                                            <Paper
+                                                square
+                                                style={{
+                                                    width: popperNode
+                                                        ? popperNode.clientWidth
+                                                        : null,
+                                                }}
+                                            >
+                                                {suggestions.map((suggestion, index) => {
+                                                    return (
+                                                        <Suggestion
+                                                            key={suggestion.id}
+                                                            suggestion={suggestion}
+                                                            itemProps={getItemProps({
+                                                                item: {
+                                                                    name: suggestion.displayName,
+                                                                    id: suggestion.id,
+                                                                },
+                                                            })}
+                                                            isHighlighted={
+                                                                highlightedIndex === index
+                                                            }
+                                                            selectedItem={selectedItem}
+                                                        />
+                                                    );
+                                                })}
+                                            </Paper>
+                                        </Popper>
+                                    )}
+                                </div>
+                            </div>
+                        );
+                    }}
+                </Downshift>
+            </div>
+        );
+    }
+}
+
+AutoComplete.propTypes = {
+    classes: PropTypes.object.isRequired,
+    placeholderText: PropTypes.string,
+    onInputChanged: PropTypes.func.isRequired,
+    onItemSelected: PropTypes.func.isRequired,
+    suggestions: PropTypes.array.isRequired,
+};
+
+AutoComplete.defaultProps = {
+    placeholderText: "",
+};
+
+export default withStyles(styles)(AutoComplete);

--- a/src/components/sharing-dialog/PermissionOption.jsx
+++ b/src/components/sharing-dialog/PermissionOption.jsx
@@ -1,0 +1,36 @@
+import React from "react";
+import PropTypes from "prop-types";
+import DoneIcon from "@material-ui/icons/Done";
+import MenuItem from "@material-ui/core/MenuItem";
+import ListItemIcon from "@material-ui/core/ListItemIcon";
+import ListItemText from "@material-ui/core/ListItemText";
+
+const PermissionOption = props => {
+    if (props.disabled) {
+        return null;
+    }
+
+    return (
+        <MenuItem disabled={props.disabled} onClick={props.onClick} selected={props.isSelected}>
+            {props.isSelected && (
+                <ListItemIcon>
+                    <DoneIcon />
+                </ListItemIcon>
+            )}
+            <ListItemText inset primary={props.primaryText} />
+        </MenuItem>
+    );
+};
+
+PermissionOption.propTypes = {
+    disabled: PropTypes.bool.isRequired,
+    isSelected: PropTypes.bool,
+    primaryText: PropTypes.string.isRequired,
+    onClick: PropTypes.func.isRequired,
+};
+
+PermissionOption.defaultProps = {
+    isSelected: false,
+};
+
+export default PermissionOption;

--- a/src/components/sharing-dialog/PermissionPicker.jsx
+++ b/src/components/sharing-dialog/PermissionPicker.jsx
@@ -7,6 +7,7 @@ import Popover from "@material-ui/core/Popover";
 import NotInterestedIcon from "@material-ui/icons/NotInterested";
 import CreateIcon from "@material-ui/icons/Create";
 import VisibilityIcon from "@material-ui/icons/Visibility";
+import { withStyles } from "@material-ui/core/styles";
 import i18n from "@dhis2/d2-i18n";
 
 import PermissionOption from "./PermissionOption";
@@ -155,7 +156,9 @@ PermissionPicker.defaultProps = {
     disabled: false,
 };
 
-const OptionHeader = ({ text }) => <div style={styles.optionHeader}>{text.toUpperCase()}</div>;
+const OptionHeader = withStyles(styles)(({ text, classes }) => (
+    <div className={classes.optionHeader}>{text.toUpperCase()}</div>
+));
 
 OptionHeader.propTypes = {
     text: PropTypes.string.isRequired,

--- a/src/components/sharing-dialog/PermissionPicker.jsx
+++ b/src/components/sharing-dialog/PermissionPicker.jsx
@@ -1,0 +1,164 @@
+import PropTypes from "prop-types";
+import React, { Component, Fragment } from "react";
+import IconButton from "@material-ui/core/IconButton";
+import Divider from "@material-ui/core/Divider";
+import MenuList from "@material-ui/core/MenuList";
+import Popover from "@material-ui/core/Popover";
+import NotInterestedIcon from "@material-ui/icons/NotInterested";
+import CreateIcon from "@material-ui/icons/Create";
+import VisibilityIcon from "@material-ui/icons/Visibility";
+import i18n from "@dhis2/d2-i18n";
+
+import PermissionOption from "./PermissionOption";
+
+const styles = {
+    optionHeader: {
+        paddingLeft: 16,
+        paddingTop: 16,
+        fontWeight: "500",
+        color: "gray",
+    },
+};
+
+const AccessIcon = ({ metaAccess, disabled }) => {
+    const iconProps = {
+        color: disabled ? "disabled" : "action",
+    };
+    if (metaAccess.canEdit) {
+        return <CreateIcon {...iconProps} />;
+    }
+
+    return metaAccess.canView ? (
+        <VisibilityIcon {...iconProps} />
+    ) : (
+        <NotInterestedIcon {...iconProps} />
+    );
+};
+
+class PermissionPicker extends Component {
+    state = {
+        open: false,
+    };
+
+    onOptionClick = access => () => {
+        const newAccess = {
+            ...this.props.access,
+            ...access,
+        };
+
+        this.props.onChange(newAccess);
+    };
+
+    openMenu = event => {
+        event.preventDefault();
+        this.setState({
+            open: true,
+            anchor: event.currentTarget,
+        });
+    };
+
+    closeMenu = () => {
+        this.setState({
+            open: false,
+        });
+    };
+
+    render = () => {
+        const { data, meta } = this.props.access;
+        const { data: dataOptions, meta: metaOptions } = this.props.accessOptions;
+
+        return (
+            <Fragment>
+                <IconButton onClick={this.openMenu} disabled={this.props.disabled}>
+                    <AccessIcon metaAccess={meta} disabled={this.props.disabled} />
+                </IconButton>
+                <Popover
+                    open={this.state.open}
+                    anchorEl={this.state.anchor}
+                    onClose={this.closeMenu}
+                >
+                    <OptionHeader text={i18n.t("METADATA")} />
+                    <MenuList>
+                        <PermissionOption
+                            disabled={!metaOptions.canEdit}
+                            primaryText={i18n.t("Can edit and view")}
+                            isSelected={meta.canEdit}
+                            onClick={this.onOptionClick({ meta: { canView: true, canEdit: true } })}
+                        />
+                        <PermissionOption
+                            disabled={!metaOptions.canView}
+                            primaryText={i18n.t("Can view only")}
+                            isSelected={!meta.canEdit && meta.canView}
+                            onClick={this.onOptionClick({
+                                meta: { canView: true, canEdit: false },
+                            })}
+                        />
+                        <PermissionOption
+                            disabled={!metaOptions.noAccess}
+                            primaryText={i18n.t("No access")}
+                            isSelected={!meta.canEdit && !meta.canView}
+                            onClick={this.onOptionClick({
+                                meta: { canView: false, canEdit: false },
+                            })}
+                        />
+                    </MenuList>
+                    <Divider />
+
+                    {dataOptions && (
+                        <Fragment>
+                            <OptionHeader text={i18n.t("DATA")} />
+                            <MenuList>
+                                <PermissionOption
+                                    disabled={!dataOptions.canEdit}
+                                    primaryText={i18n.t("Can capture and view")}
+                                    isSelected={data.canEdit}
+                                    onClick={this.onOptionClick({
+                                        data: { canView: true, canEdit: true },
+                                    })}
+                                />
+                                <PermissionOption
+                                    disabled={!dataOptions.canView}
+                                    primaryText={i18n.t("Can view only")}
+                                    isSelected={!data.canEdit && data.canView}
+                                    onClick={this.onOptionClick({
+                                        data: { canView: true, canEdit: false },
+                                    })}
+                                />
+                                <PermissionOption
+                                    disabled={!dataOptions.noAccess}
+                                    primaryText={i18n.t("No access")}
+                                    isSelected={!data.canEdit && !data.canView}
+                                    onClick={this.onOptionClick({
+                                        data: {
+                                            canView: false,
+                                            canEdit: false,
+                                        },
+                                    })}
+                                />
+                            </MenuList>
+                        </Fragment>
+                    )}
+                </Popover>
+            </Fragment>
+        );
+    };
+}
+
+PermissionPicker.propTypes = {
+    access: PropTypes.object.isRequired,
+    accessOptions: PropTypes.object.isRequired,
+    onChange: PropTypes.func.isRequired,
+    disabled: PropTypes.bool,
+};
+
+PermissionPicker.defaultProps = {
+    disabled: false,
+};
+
+const OptionHeader = ({ text }) => <div style={styles.optionHeader}>{text.toUpperCase()}</div>;
+
+OptionHeader.propTypes = {
+    text: PropTypes.string.isRequired,
+};
+
+export default PermissionPicker;

--- a/src/components/sharing-dialog/Sharing.jsx
+++ b/src/components/sharing-dialog/Sharing.jsx
@@ -113,7 +113,7 @@ class Sharing extends React.Component {
 
         return (
             <div>
-                <h2>{displayName || name}</h2>
+                <Typography variant="h5">{displayName || name}</Typography>
                 {user && (
                     <div className={classes.createdBy}>
                         {`${i18n.t("Created by")}: ${user.name}`}

--- a/src/components/sharing-dialog/Sharing.jsx
+++ b/src/components/sharing-dialog/Sharing.jsx
@@ -9,6 +9,13 @@ import UserSearch from "./UserSearch";
 import { PublicAccess, ExternalAccess, GroupAccess } from "./Access";
 
 const styles = {
+    title: {
+        fontSize: "24px",
+        fontWeight: 300,
+        color: "rgba(0, 0, 0, 0.87)",
+        padding: "16px 0px 5px",
+        margin: "0px",
+    },
     createdBy: {
         color: "#818181",
     },
@@ -113,7 +120,7 @@ class Sharing extends React.Component {
 
         return (
             <div>
-                <Typography variant="h5">{displayName || name}</Typography>
+                <h2 className={classes.title}>{displayName || name}</h2>
                 {user && (
                     <div className={classes.createdBy}>
                         {`${i18n.t("Created by")}: ${user.name}`}

--- a/src/components/sharing-dialog/Sharing.jsx
+++ b/src/components/sharing-dialog/Sharing.jsx
@@ -2,6 +2,7 @@ import PropTypes from "prop-types";
 import React from "react";
 import Divider from "@material-ui/core/Divider";
 import Typography from "@material-ui/core/Typography";
+import { withStyles } from "@material-ui/core/styles";
 import i18n from "@dhis2/d2-i18n";
 
 import UserSearch from "./UserSearch";
@@ -104,6 +105,7 @@ class Sharing extends React.Component {
             externalAccess,
         } = this.props.sharedObject.object;
         const { allowPublicAccess, allowExternalAccess } = this.props.sharedObject.meta;
+        const { classes } = this.props;
 
         const accessIds = (userAccesses || [])
             .map(access => access.id)
@@ -112,13 +114,15 @@ class Sharing extends React.Component {
         return (
             <div>
                 <h2>{displayName || name}</h2>
-                {user && <div style={styles.createdBy}>
-                    {`${i18n.t("Created by")}: ${user.name}`}
-                </div>}
-                <div style={styles.titleBodySpace} />
+                {user && (
+                    <div className={classes.createdBy}>
+                        {`${i18n.t("Created by")}: ${user.name}`}
+                    </div>
+                )}
+                <div className={classes.titleBodySpace} />
                 <Typography variant="subtitle1">{i18n.t("Who has access")}</Typography>
                 <Divider />
-                <div style={styles.rules} ref={this.setAccessListRef}>
+                <div className={classes.rules} ref={this.setAccessListRef}>
                     <PublicAccess
                         access={publicAccess}
                         disabled={!allowPublicAccess}
@@ -196,4 +200,4 @@ Sharing.propTypes = {
     onSearch: PropTypes.func.isRequired,
 };
 
-export default Sharing;
+export default withStyles(styles)(Sharing);

--- a/src/components/sharing-dialog/Sharing.jsx
+++ b/src/components/sharing-dialog/Sharing.jsx
@@ -1,0 +1,199 @@
+import PropTypes from "prop-types";
+import React from "react";
+import Divider from "@material-ui/core/Divider";
+import Typography from "@material-ui/core/Typography";
+import i18n from "@dhis2/d2-i18n";
+
+import UserSearch from "./UserSearch";
+import { PublicAccess, ExternalAccess, GroupAccess } from "./Access";
+
+const styles = {
+    createdBy: {
+        color: "#818181",
+    },
+    titleBodySpace: {
+        paddingTop: 30,
+    },
+    rules: {
+        height: "240px",
+        overflowY: "scroll",
+    },
+};
+
+/**
+ * Content of the sharing dialog; a set of components for changing sharing
+ * preferences.
+ */
+class Sharing extends React.Component {
+    onAccessRuleChange = id => accessRule => {
+        const changeWithId = rule => (rule.id === id ? { ...rule, access: accessRule } : rule);
+        const userAccesses = (this.props.sharedObject.object.userAccesses || []).map(changeWithId);
+        const userGroupAccesses = (this.props.sharedObject.object.userGroupAccesses || []).map(
+            changeWithId
+        );
+
+        this.props.onChange({
+            userAccesses,
+            userGroupAccesses,
+        });
+    };
+
+    onAccessRemove = accessOwnerId => () => {
+        const withoutId = accessOwner => accessOwner.id !== accessOwnerId;
+        const userAccesses = (this.props.sharedObject.object.userAccesses || []).filter(withoutId);
+        const userGroupAccesses = (this.props.sharedObject.object.userGroupAccesses || []).filter(
+            withoutId
+        );
+
+        this.props.onChange({
+            userAccesses,
+            userGroupAccesses,
+        });
+    };
+
+    onPublicAccessChange = publicAccess => {
+        this.props.onChange({
+            publicAccess,
+        });
+    };
+
+    onExternalAccessChange = externalAccess => {
+        this.props.onChange({
+            externalAccess,
+        });
+    };
+
+    setAccessListRef = ref => {
+        this.accessListRef = ref;
+    };
+
+    accessListRef = null;
+
+    addUserAccess = userAccess => {
+        const currentAccesses = this.props.sharedObject.object.userAccesses || [];
+        this.props.onChange(
+            {
+                userAccesses: [...currentAccesses, userAccess],
+            },
+            this.scrollAccessListToBottom()
+        );
+    };
+
+    addUserGroupAccess = userGroupAccess => {
+        const currentAccesses = this.props.sharedObject.object.userGroupAccesses || [];
+        this.props.onChange(
+            {
+                userGroupAccesses: [...currentAccesses, userGroupAccess],
+            },
+            this.scrollAccessListToBottom()
+        );
+    };
+
+    scrollAccessListToBottom = () => {
+        this.accessListRef.scrollTop = this.accessListRef.scrollHeight;
+    };
+
+    render() {
+        const {
+            user,
+            displayName,
+            name,
+            userAccesses,
+            userGroupAccesses,
+            publicAccess,
+            externalAccess,
+        } = this.props.sharedObject.object;
+        const { allowPublicAccess, allowExternalAccess } = this.props.sharedObject.meta;
+
+        const accessIds = (userAccesses || [])
+            .map(access => access.id)
+            .concat((userGroupAccesses || []).map(access => access.id));
+
+        return (
+            <div>
+                <h2>{displayName || name}</h2>
+                {user && <div style={styles.createdBy}>
+                    {`${i18n.t("Created by")}: ${user.name}`}
+                </div>}
+                <div style={styles.titleBodySpace} />
+                <Typography variant="subtitle1">{i18n.t("Who has access")}</Typography>
+                <Divider />
+                <div style={styles.rules} ref={this.setAccessListRef}>
+                    <PublicAccess
+                        access={publicAccess}
+                        disabled={!allowPublicAccess}
+                        dataShareable={this.props.dataShareable}
+                        onChange={this.onPublicAccessChange}
+                    />
+                    <Divider />
+                    <ExternalAccess
+                        access={externalAccess}
+                        disabled={!allowExternalAccess}
+                        onChange={this.onExternalAccessChange}
+                    />
+                    <Divider />
+                    {userAccesses &&
+                        userAccesses.map(access => (
+                            <div key={access.id}>
+                                <GroupAccess
+                                    groupName={access.displayName}
+                                    groupType="user"
+                                    access={access.access}
+                                    dataShareable={this.props.dataShareable}
+                                    onRemove={this.onAccessRemove(access.id)}
+                                    onChange={this.onAccessRuleChange(access.id)}
+                                />
+                                <Divider />
+                            </div>
+                        ))}
+                    {userGroupAccesses &&
+                        userGroupAccesses.map(access => (
+                            <div key={access.id}>
+                                <GroupAccess
+                                    access={access.access}
+                                    groupName={access.displayName}
+                                    groupType="userGroup"
+                                    dataShareable={this.props.dataShareable}
+                                    onRemove={this.onAccessRemove(access.id)}
+                                    onChange={this.onAccessRuleChange(access.id)}
+                                />
+                                <Divider />
+                            </div>
+                        ))}
+                </div>
+                <UserSearch
+                    onSearch={this.props.onSearch}
+                    addUserAccess={this.addUserAccess}
+                    addUserGroupAccess={this.addUserGroupAccess}
+                    dataShareable={this.props.dataShareable}
+                    currentAccessIds={accessIds}
+                />
+            </div>
+        );
+    }
+}
+
+Sharing.propTypes = {
+    /**
+     * The object to share
+     */
+    sharedObject: PropTypes.object.isRequired,
+
+    /*
+     * If true, the object's data should have their own settings.
+     */
+    dataShareable: PropTypes.bool.isRequired,
+
+    /**
+     * Function that takes an object containing updated sharing preferences and
+     * an optional callback fired when the change was successfully posted.
+     */
+    onChange: PropTypes.func.isRequired,
+
+    /**
+     * Takes a string and a callback, and returns matching users and userGroups.
+     */
+    onSearch: PropTypes.func.isRequired,
+};
+
+export default Sharing;

--- a/src/components/sharing-dialog/SharingDialog.jsx
+++ b/src/components/sharing-dialog/SharingDialog.jsx
@@ -1,0 +1,42 @@
+import React from "react";
+import i18n from "@dhis2/d2-i18n";
+import { ConfirmationDialog } from "d2-ui-components";
+import DialogContent from "@material-ui/core/DialogContent";
+
+import Sharing from "./Sharing";
+
+const SharingDialog = ({
+    isOpen,
+    isDataShareable,
+    sharedObject,
+    onCancel,
+    onSharingChanged,
+    onSearchRequest,
+}) => {
+    return (
+        <React.Fragment>
+            <ConfirmationDialog
+                isOpen={isOpen}
+                title={i18n.t("Sharing settings")}
+                onCancel={onCancel}
+                cancelText={i18n.t("Close")}
+                maxWidth={"lg"}
+                fullWidth={true}
+                disableEnforceFocus
+            >
+                <DialogContent>
+                    {sharedObject && (
+                        <Sharing
+                            sharedObject={sharedObject}
+                            dataShareable={isDataShareable}
+                            onChange={onSharingChanged}
+                            onSearch={onSearchRequest}
+                        />
+                    )}
+                </DialogContent>
+            </ConfirmationDialog>
+        </React.Fragment>
+    );
+};
+
+export default SharingDialog;

--- a/src/components/sharing-dialog/UserSearch.jsx
+++ b/src/components/sharing-dialog/UserSearch.jsx
@@ -1,0 +1,163 @@
+import React, { Component } from "react";
+import PropTypes from "prop-types";
+import { Subject } from "rxjs/Subject";
+import { timer } from "rxjs/observable/timer";
+import { debounce } from "rxjs/operators";
+import i18n from "@dhis2/d2-i18n";
+
+import { accessObjectToString } from "./utils";
+import PermissionPicker from "./PermissionPicker";
+import AutoComplete from "./AutoComplete";
+
+const styles = {
+    container: {
+        fontWeight: "400",
+        padding: 16,
+        backgroundColor: "#F5F5F5",
+        display: "flex",
+        flexDirection: "column",
+        justifyContent: "center",
+    },
+
+    innerContainer: {
+        display: "flex",
+        flexDirection: "row",
+        flex: 1,
+    },
+
+    title: {
+        color: "#818181",
+        paddingBottom: 8,
+    },
+};
+
+const searchDelay = 300;
+
+class UserSearch extends Component {
+    state = {
+        defaultAccess: {
+            meta: { canView: true, canEdit: true },
+            data: { canView: false, canEdit: false },
+        },
+        searchResult: [],
+        searchText: "",
+    };
+
+    componentDidMount() {
+        this.inputStream.pipe(debounce(() => timer(searchDelay))).subscribe(searchText => {
+            this.fetchSearchResult(searchText);
+        });
+    }
+
+    onItemSelected = selected => {
+        // Material UI triggers an 'onUpdateInput' when a search result is clicked. Therefore, we
+        // immediately pushes a new item to the search stream to prevent the stream from searching
+        // for the item again.
+        this.inputStream.next("");
+
+        const selection = this.state.searchResult.find(r => r.id === selected.id);
+
+        const type = selection.type;
+        delete selection.type;
+
+        if (type === "userAccess") {
+            this.props.addUserAccess({
+                ...selection,
+                access: accessObjectToString(this.state.defaultAccess),
+            });
+        } else {
+            this.props.addUserGroupAccess({
+                ...selection,
+                access: accessObjectToString(this.state.defaultAccess),
+            });
+        }
+        this.clearSearchText();
+    };
+
+    inputStream = new Subject();
+
+    hasNoCurrentAccess = userOrGroup => this.props.currentAccessIds.indexOf(userOrGroup.id) === -1;
+
+    fetchSearchResult = searchText => {
+        if (searchText === "") {
+            this.handleSearchResult([]);
+        } else {
+            this.props.onSearch(searchText).then(({ users, userGroups }) => {
+                const addType = type => result => ({ ...result, type });
+                const searchResult = users
+                    .map(addType("userAccess"))
+                    .filter(this.hasNoCurrentAccess)
+                    .concat(
+                        userGroups.map(addType("userGroupAccess")).filter(this.hasNoCurrentAccess)
+                    );
+
+                this.handleSearchResult(searchResult);
+            });
+        }
+    };
+
+    handleSearchResult = searchResult => {
+        this.setState({ searchResult });
+    };
+
+    onInputChanged = searchText => {
+        this.inputStream.next(searchText);
+        this.setState({ searchText });
+    };
+
+    accessOptionsChanged = accessOptions => {
+        this.setState({
+            defaultAccess: accessOptions,
+        });
+    };
+
+    clearSearchText = () => {
+        this.setState({
+            searchText: "",
+        });
+    };
+
+    render() {
+        return (
+            <div style={styles.container}>
+                <div style={styles.title}>{i18n.t("Add users and user groups")}</div>
+                <div style={styles.innerContainer}>
+                    <AutoComplete
+                        suggestions={this.state.searchResult}
+                        placeholderText={i18n.t("Enter names")}
+                        onItemSelected={this.onItemSelected}
+                        onInputChanged={this.onInputChanged}
+                        searchText={this.state.searchText}
+                        classes={{}}
+                    />
+                    <PermissionPicker
+                        access={this.state.defaultAccess}
+                        accessOptions={{
+                            meta: {
+                                canView: true,
+                                canEdit: true,
+                                noAccess: false,
+                            },
+                            data: this.props.dataShareable && {
+                                canView: true,
+                                canEdit: true,
+                                noAccess: true,
+                            },
+                        }}
+                        onChange={this.accessOptionsChanged}
+                    />
+                </div>
+            </div>
+        );
+    }
+}
+
+UserSearch.propTypes = {
+    onSearch: PropTypes.func.isRequired,
+    addUserAccess: PropTypes.func.isRequired,
+    dataShareable: PropTypes.bool.isRequired,
+    addUserGroupAccess: PropTypes.func.isRequired,
+    currentAccessIds: PropTypes.array.isRequired,
+};
+
+export default UserSearch;

--- a/src/components/sharing-dialog/UserSearch.jsx
+++ b/src/components/sharing-dialog/UserSearch.jsx
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 import { Subject } from "rxjs/Subject";
 import { timer } from "rxjs/observable/timer";
 import { debounce } from "rxjs/operators";
+import { withStyles } from "@material-ui/core/styles";
 import i18n from "@dhis2/d2-i18n";
 
 import { accessObjectToString } from "./utils";
@@ -118,10 +119,11 @@ class UserSearch extends Component {
     };
 
     render() {
+        const { classes } = this.props;
         return (
-            <div style={styles.container}>
-                <div style={styles.title}>{i18n.t("Add users and user groups")}</div>
-                <div style={styles.innerContainer}>
+            <div className={classes.container}>
+                <div className={classes.title}>{i18n.t("Add users and user groups")}</div>
+                <div className={classes.innerContainer}>
                     <AutoComplete
                         suggestions={this.state.searchResult}
                         placeholderText={i18n.t("Enter names")}
@@ -160,4 +162,4 @@ UserSearch.propTypes = {
     currentAccessIds: PropTypes.array.isRequired,
 };
 
-export default UserSearch;
+export default withStyles(styles)(UserSearch);

--- a/src/components/sharing-dialog/utils.js
+++ b/src/components/sharing-dialog/utils.js
@@ -1,0 +1,56 @@
+export const cachedAccessTypeToString = (canView, canEdit) => {
+    if (canView) {
+        return canEdit ? "rw------" : "r-------";
+    }
+
+    return "--------";
+};
+
+export const transformAccessObject = (access, type) => ({
+    id: access.id,
+    name: access.name,
+    displayName: access.displayName,
+    type,
+    canView: access.access && access.access.includes("r"),
+    canEdit: access.access && access.access.includes("rw"),
+});
+
+export const accessStringToObject = access => {
+    if (!access) {
+        return {
+            data: { canView: false, canEdit: false },
+            meta: { canView: false, canEdit: false },
+        };
+    }
+
+    const metaAccess = access.substring(0, 2);
+    const dataAccess = access.substring(2, 4);
+
+    return {
+        meta: {
+            canView: metaAccess.includes("r"),
+            canEdit: metaAccess.includes("rw"),
+        },
+        data: {
+            canView: dataAccess.includes("r"),
+            canEdit: dataAccess.includes("rw"),
+        },
+    };
+};
+
+export const accessObjectToString = accessObject => {
+    const convert = ({ canEdit, canView }) => {
+        if (canEdit) {
+            return "rw";
+        }
+
+        return canView ? "r-" : "--";
+    };
+
+    let accessString = "";
+    accessString += convert(accessObject.meta);
+    accessString += convert(accessObject.data);
+    accessString += "----";
+
+    return accessString;
+};

--- a/src/components/synchronization-page/GenericSynchronizationPage.jsx
+++ b/src/components/synchronization-page/GenericSynchronizationPage.jsx
@@ -12,6 +12,7 @@ import SyncDialog from "../sync-dialog/SyncDialog";
 import SyncSummary from "../sync-summary/SyncSummary";
 import PageHeader from "../page-header/PageHeader";
 import SyncReport from "../../models/syncReport";
+import { isAppAdmin } from "../../utils/permissions";
 
 class GenericSynchronizationPage extends React.Component {
     static propTypes = {
@@ -28,7 +29,15 @@ class GenericSynchronizationPage extends React.Component {
         importResponse: SyncReport.create(),
         syncDialogOpen: false,
         syncSummaryOpen: false,
+        appAdmin: false,
     };
+
+    async componentDidMount() {
+        const { d2 } = this.props;
+        const appAdmin = await isAppAdmin(d2);
+
+        this.setState({ appAdmin });
+    }
 
     goHome = () => {
         this.props.history.push("/");
@@ -89,8 +98,14 @@ class GenericSynchronizationPage extends React.Component {
     };
 
     render() {
-        const { d2, isAdmin, title, models, ...rest } = this.props;
-        const { syncDialogOpen, syncSummaryOpen, importResponse, metadataIds } = this.state;
+        const { d2, title, models, ...rest } = this.props;
+        const {
+            syncDialogOpen,
+            syncSummaryOpen,
+            importResponse,
+            metadataIds,
+            appAdmin,
+        } = this.state;
 
         return (
             <React.Fragment>
@@ -102,7 +117,7 @@ class GenericSynchronizationPage extends React.Component {
                     initialModel={models[0]}
                     initialSelection={metadataIds}
                     notifyNewSelection={this.changeSelection}
-                    onButtonClick={isAdmin ? this.startSynchronization : null}
+                    onButtonClick={appAdmin ? this.startSynchronization : null}
                     buttonLabel={<SyncIcon />}
                     {...rest}
                 />

--- a/src/components/synchronization-page/GenericSynchronizationPage.jsx
+++ b/src/components/synchronization-page/GenericSynchronizationPage.jsx
@@ -12,7 +12,6 @@ import SyncDialog from "../sync-dialog/SyncDialog";
 import SyncSummary from "../sync-summary/SyncSummary";
 import PageHeader from "../page-header/PageHeader";
 import SyncReport from "../../models/syncReport";
-import { getUserInfo } from "../../utils/permissions";
 
 class GenericSynchronizationPage extends React.Component {
     static propTypes = {
@@ -29,15 +28,7 @@ class GenericSynchronizationPage extends React.Component {
         importResponse: SyncReport.create(),
         syncDialogOpen: false,
         syncSummaryOpen: false,
-        isAdmin: false,
     };
-
-    async componentDidMount() {
-        const { d2 } = this.props;
-        const { isAdmin } = await getUserInfo(d2);
-
-        this.setState({ isAdmin });
-    }
 
     goHome = () => {
         this.props.history.push("/");
@@ -98,13 +89,12 @@ class GenericSynchronizationPage extends React.Component {
     };
 
     render() {
-        const { d2, title, models, ...rest } = this.props;
+        const { d2, isAdmin, title, models, ...rest } = this.props;
         const {
             syncDialogOpen,
             syncSummaryOpen,
             importResponse,
             metadataIds,
-            isAdmin,
         } = this.state;
 
         return (

--- a/src/components/synchronization-page/GenericSynchronizationPage.jsx
+++ b/src/components/synchronization-page/GenericSynchronizationPage.jsx
@@ -12,7 +12,7 @@ import SyncDialog from "../sync-dialog/SyncDialog";
 import SyncSummary from "../sync-summary/SyncSummary";
 import PageHeader from "../page-header/PageHeader";
 import SyncReport from "../../models/syncReport";
-import { isAppAdmin } from "../../utils/permissions";
+import { isAppConfigurator } from "../../utils/permissions";
 
 class GenericSynchronizationPage extends React.Component {
     static propTypes = {
@@ -29,14 +29,14 @@ class GenericSynchronizationPage extends React.Component {
         importResponse: SyncReport.create(),
         syncDialogOpen: false,
         syncSummaryOpen: false,
-        appAdmin: false,
+        appConfigurator: false,
     };
 
     async componentDidMount() {
         const { d2 } = this.props;
-        const appAdmin = await isAppAdmin(d2);
+        const appConfigurator = await isAppConfigurator(d2);
 
-        this.setState({ appAdmin });
+        this.setState({ appConfigurator });
     }
 
     goHome = () => {
@@ -104,7 +104,7 @@ class GenericSynchronizationPage extends React.Component {
             syncSummaryOpen,
             importResponse,
             metadataIds,
-            appAdmin,
+            appConfigurator,
         } = this.state;
 
         return (
@@ -117,7 +117,7 @@ class GenericSynchronizationPage extends React.Component {
                     initialModel={models[0]}
                     initialSelection={metadataIds}
                     notifyNewSelection={this.changeSelection}
-                    onButtonClick={appAdmin ? this.startSynchronization : null}
+                    onButtonClick={appConfigurator ? this.startSynchronization : null}
                     buttonLabel={<SyncIcon />}
                     {...rest}
                 />

--- a/src/components/synchronization-page/GenericSynchronizationPage.jsx
+++ b/src/components/synchronization-page/GenericSynchronizationPage.jsx
@@ -12,6 +12,7 @@ import SyncDialog from "../sync-dialog/SyncDialog";
 import SyncSummary from "../sync-summary/SyncSummary";
 import PageHeader from "../page-header/PageHeader";
 import SyncReport from "../../models/syncReport";
+import { hasUserRole, AppRoles } from "../../utils/permissions";
 
 class GenericSynchronizationPage extends React.Component {
     static propTypes = {
@@ -28,7 +29,15 @@ class GenericSynchronizationPage extends React.Component {
         importResponse: SyncReport.create(),
         syncDialogOpen: false,
         syncSummaryOpen: false,
+        isUserAdmin: false,
     };
+
+    async componentDidMount() {
+        const { d2 } = this.props;
+        const isUserAdmin = await hasUserRole(d2, AppRoles.METADATA_SYNC_ADMINISTRATOR);
+
+        this.setState({ isUserAdmin });
+    }
 
     goHome = () => {
         this.props.history.push("/");
@@ -90,7 +99,13 @@ class GenericSynchronizationPage extends React.Component {
 
     render() {
         const { d2, title, models, ...rest } = this.props;
-        const { syncDialogOpen, syncSummaryOpen, importResponse, metadataIds } = this.state;
+        const {
+            syncDialogOpen,
+            syncSummaryOpen,
+            importResponse,
+            metadataIds,
+            isUserAdmin,
+        } = this.state;
 
         return (
             <React.Fragment>
@@ -102,7 +117,7 @@ class GenericSynchronizationPage extends React.Component {
                     initialModel={models[0]}
                     initialSelection={metadataIds}
                     notifyNewSelection={this.changeSelection}
-                    onButtonClick={this.startSynchronization}
+                    onButtonClick={isUserAdmin ? this.startSynchronization : null}
                     buttonLabel={<SyncIcon />}
                     {...rest}
                 />

--- a/src/components/synchronization-page/GenericSynchronizationPage.jsx
+++ b/src/components/synchronization-page/GenericSynchronizationPage.jsx
@@ -90,12 +90,7 @@ class GenericSynchronizationPage extends React.Component {
 
     render() {
         const { d2, isAdmin, title, models, ...rest } = this.props;
-        const {
-            syncDialogOpen,
-            syncSummaryOpen,
-            importResponse,
-            metadataIds,
-        } = this.state;
+        const { syncDialogOpen, syncSummaryOpen, importResponse, metadataIds } = this.state;
 
         return (
             <React.Fragment>

--- a/src/components/synchronization-page/GenericSynchronizationPage.jsx
+++ b/src/components/synchronization-page/GenericSynchronizationPage.jsx
@@ -12,7 +12,7 @@ import SyncDialog from "../sync-dialog/SyncDialog";
 import SyncSummary from "../sync-summary/SyncSummary";
 import PageHeader from "../page-header/PageHeader";
 import SyncReport from "../../models/syncReport";
-import { hasUserRole, AppRoles } from "../../utils/permissions";
+import { getUserInfo } from "../../utils/permissions";
 
 class GenericSynchronizationPage extends React.Component {
     static propTypes = {
@@ -29,14 +29,14 @@ class GenericSynchronizationPage extends React.Component {
         importResponse: SyncReport.create(),
         syncDialogOpen: false,
         syncSummaryOpen: false,
-        isUserAdmin: false,
+        isAdmin: false,
     };
 
     async componentDidMount() {
         const { d2 } = this.props;
-        const isUserAdmin = await hasUserRole(d2, AppRoles.METADATA_SYNC_ADMINISTRATOR);
+        const { isAdmin } = await getUserInfo(d2);
 
-        this.setState({ isUserAdmin });
+        this.setState({ isAdmin });
     }
 
     goHome = () => {
@@ -104,7 +104,7 @@ class GenericSynchronizationPage extends React.Component {
             syncSummaryOpen,
             importResponse,
             metadataIds,
-            isUserAdmin,
+            isAdmin,
         } = this.state;
 
         return (
@@ -117,7 +117,7 @@ class GenericSynchronizationPage extends React.Component {
                     initialModel={models[0]}
                     initialSelection={metadataIds}
                     notifyNewSelection={this.changeSelection}
-                    onButtonClick={isUserAdmin ? this.startSynchronization : null}
+                    onButtonClick={isAdmin ? this.startSynchronization : null}
                     buttonLabel={<SyncIcon />}
                     {...rest}
                 />

--- a/src/models/instance.ts
+++ b/src/models/instance.ts
@@ -8,6 +8,7 @@ import { deleteData, getData, getDataById, getPaginatedData, saveData } from "./
 import { D2, Response } from "../types/d2";
 import { Validation } from "../types/validations";
 import { TableFilters, TableList, TablePagination } from "../types/d2-ui-components";
+import { isAppAdmin } from "../utils/permissions";
 
 const instancesDataStoreKey = "instances";
 
@@ -97,6 +98,13 @@ export default class Instance {
     }
 
     public async save(d2: D2): Promise<Response> {
+        const appAdmin = await isAppAdmin(d2);
+        if (!appAdmin)
+            return {
+                status: false,
+                error: new Error("You do not have permissions to save Instance"),
+            };
+
         const instance = await this.encryptPassword();
         const exists = !!instance.data.id;
         const element = exists ? instance.data : { ...instance.data, id: generateUid() };

--- a/src/models/instance.ts
+++ b/src/models/instance.ts
@@ -8,7 +8,6 @@ import { deleteData, getData, getDataById, getPaginatedData, saveData } from "./
 import { D2, Response } from "../types/d2";
 import { Validation } from "../types/validations";
 import { TableFilters, TableList, TablePagination } from "../types/d2-ui-components";
-import { isAppAdmin } from "../utils/permissions";
 
 const instancesDataStoreKey = "instances";
 
@@ -98,13 +97,6 @@ export default class Instance {
     }
 
     public async save(d2: D2): Promise<Response> {
-        const appAdmin = await isAppAdmin(d2);
-        if (!appAdmin)
-            return {
-                status: false,
-                error: new Error("You do not have permissions to save Instance"),
-            };
-
         const instance = await this.encryptPassword();
         const exists = !!instance.data.id;
         const element = exists ? instance.data : { ...instance.data, id: generateUid() };

--- a/src/models/syncRule.ts
+++ b/src/models/syncRule.ts
@@ -85,7 +85,7 @@ export default class SyncRule {
                 metadataIds: [],
             },
             enabled: false,
-            publicAccess: "rw----",
+            publicAccess: "rw------",
             userAccesses: [],
             userGroupAccesses: [],
         });

--- a/src/models/syncRule.ts
+++ b/src/models/syncRule.ts
@@ -207,6 +207,9 @@ export default class SyncRule {
     }
 
     public async save(d2: D2): Promise<void> {
+        const userInfo = await getUserInfo(d2);
+        if (!this.isVisibleToUser(userInfo, "WRITE")) return;
+
         const exists = !!this.syncRule.id;
         const element = exists ? this.syncRule : { ...this.syncRule, id: generateUid() };
 

--- a/src/models/syncRule.ts
+++ b/src/models/syncRule.ts
@@ -5,6 +5,7 @@ import { generateUid } from "d2/uid";
 
 import { deleteData, getDataById, getPaginatedData, saveData } from "./dataStore";
 import isValidCronExpression from "../utils/validCronExpression";
+import { getUserInfo } from "../utils/permissions";
 import { D2 } from "../types/d2";
 import { SyncRuleTableFilters, TableList, TablePagination } from "../types/d2-ui-components";
 import { SynchronizationRule } from "../types/synchronization";
@@ -107,8 +108,21 @@ export default class SyncRule {
     ): Promise<TableList> {
         const { targetInstanceFilter = null, enabledFilter = null, lastExecutedFilter = null } =
             filters || {};
+        const userInfo = await getUserInfo(d2);
         const data = await getPaginatedData(d2, dataStoreKey, filters, pagination);
         const objects = _(data.objects)
+            .filter(
+                rule =>
+                    userInfo.isAdmin ||
+                    rule.publicAccess.substring(0, 2).includes("r") ||
+                    _(rule.userAccesses)
+                        .filter(({ access }) => access.substring(0, 2).includes("r"))
+                        .find(({ id }: { id: string }) => id === userInfo.id) ||
+                    _(rule.userGroupAccesses)
+                        .filter(({ access }) => access.substring(0, 2).includes("r"))
+                        .intersectionBy(userInfo.userGroups, "id")
+                        .value().length > 0
+            )
             .filter(rule =>
                 targetInstanceFilter
                     ? rule.builder.targetInstances.includes(targetInstanceFilter)

--- a/src/models/syncRule.ts
+++ b/src/models/syncRule.ts
@@ -124,13 +124,12 @@ export default class SyncRule {
 
         const globalAdmin = await isGlobalAdmin(d2);
         const userInfo = await getUserInfo(d2);
-        
 
         const data = await getPaginatedData(d2, dataStoreKey, filters, pagination);
         const objects = _(data.objects)
             .filter(data => {
                 const rule = SyncRule.build(data);
-                return globalAdmin || rule.isVisibleToUser(userInfo)
+                return globalAdmin || rule.isVisibleToUser(userInfo);
             })
             .filter(rule =>
                 targetInstanceFilter

--- a/src/models/syncRule.ts
+++ b/src/models/syncRule.ts
@@ -109,12 +109,16 @@ export default class SyncRule {
         const { targetInstanceFilter = null, enabledFilter = null, lastExecutedFilter = null } =
             filters || {};
 
-        const globalAdmin = isGlobalAdmin(d2);
+        const globalAdmin = await isGlobalAdmin(d2);
         const userInfo = await getUserInfo(d2);
+        
 
         const data = await getPaginatedData(d2, dataStoreKey, filters, pagination);
         const objects = _(data.objects)
-            .filter(rule => globalAdmin || rule.isVisibleToUser(userInfo))
+            .filter(data => {
+                const rule = SyncRule.build(data);
+                return globalAdmin || rule.isVisibleToUser(userInfo)
+            })
             .filter(rule =>
                 targetInstanceFilter
                     ? rule.builder.targetInstances.includes(targetInstanceFilter)

--- a/src/models/syncRule.ts
+++ b/src/models/syncRule.ts
@@ -207,9 +207,6 @@ export default class SyncRule {
     }
 
     public async save(d2: D2): Promise<void> {
-        const userInfo = await getUserInfo(d2);
-        if (!this.isVisibleToUser(userInfo, "WRITE")) return;
-
         const exists = !!this.syncRule.id;
         const element = exists ? this.syncRule : { ...this.syncRule, id: generateUid() };
 

--- a/src/models/syncRule.ts
+++ b/src/models/syncRule.ts
@@ -26,6 +26,9 @@ export default class SyncRule {
                 "enabled",
                 "frequency",
                 "lastExecuted",
+                "publicAccess",
+                "userAccesses",
+                "userGroupAccesses",
             ]),
         };
     }
@@ -82,6 +85,9 @@ export default class SyncRule {
                 metadataIds: [],
             },
             enabled: false,
+            publicAccess: "rw----",
+            userAccesses: [],
+            userGroupAccesses: [],
         });
     }
 

--- a/src/models/syncRule.ts
+++ b/src/models/syncRule.ts
@@ -5,7 +5,7 @@ import { generateUid } from "d2/uid";
 
 import { deleteData, getDataById, getPaginatedData, saveData } from "./dataStore";
 import isValidCronExpression from "../utils/validCronExpression";
-import { getUserInfo } from "../utils/permissions";
+import { getUserInfo, isUserAdmin } from "../utils/permissions";
 import { D2 } from "../types/d2";
 import { SyncRuleTableFilters, TableList, TablePagination } from "../types/d2-ui-components";
 import { SynchronizationRule } from "../types/synchronization";
@@ -108,12 +108,15 @@ export default class SyncRule {
     ): Promise<TableList> {
         const { targetInstanceFilter = null, enabledFilter = null, lastExecutedFilter = null } =
             filters || {};
+
         const userInfo = await getUserInfo(d2);
+        const isAdmin = await isUserAdmin(d2);
+
         const data = await getPaginatedData(d2, dataStoreKey, filters, pagination);
         const objects = _(data.objects)
             .filter(
                 rule =>
-                    userInfo.isAdmin ||
+                    isAdmin ||
                     rule.publicAccess.substring(0, 2).includes("r") ||
                     _(rule.userAccesses)
                         .filter(({ access }) => access.substring(0, 2).includes("r"))

--- a/src/types/d2.d.ts
+++ b/src/types/d2.d.ts
@@ -86,6 +86,7 @@ export interface D2 {
         name: string;
         email: string;
         getUserRoles(): Promise<any>;
+        getUserGroups(): Promise<any>;
     };
 }
 

--- a/src/types/d2.d.ts
+++ b/src/types/d2.d.ts
@@ -85,6 +85,7 @@ export interface D2 {
         username: string;
         name: string;
         email: string;
+        getUserRoles(): Promise<any>;
     };
 }
 

--- a/src/types/modules.d.ts
+++ b/src/types/modules.d.ts
@@ -17,3 +17,7 @@ declare module "@dhis2/d2-i18n" {
 declare module "@dhis2/d2-i18n" {
     export function t(value: string, variable?: any): string;
 }
+
+declare module "nano-memoize" {
+    export default function memoize(method: Function): Function;
+}

--- a/src/types/synchronization.d.ts
+++ b/src/types/synchronization.d.ts
@@ -60,4 +60,14 @@ export interface SynchronizationRule {
     enabled: boolean;
     lastExecuted?: Date;
     frequency?: string;
+    publicAccess: string;
+    userAccesses: SharingSetting[];
+    userGroupAccesses: SharingSetting[];
+}
+
+export interface SharingSetting {
+    access: string;
+    displayName: string;
+    id: string;
+    name: string;
 }

--- a/src/utils/permissions.ts
+++ b/src/utils/permissions.ts
@@ -14,23 +14,25 @@ export const isUserAdmin = memoize(async (d2: D2) => {
         .find((role: any) => role.name === AppRoles.METADATA_SYNC_ADMINISTRATOR);
 });
 
-export const getUserInfo = memoize(async (
-    d2: D2
-): Promise<{
-    userGroups: any[];
-    id: string;
-    name: string;
-    username: string;
-}> => {
-    const userGroups = await d2.currentUser.getUserGroups();
+export const getUserInfo = memoize(
+    async (
+        d2: D2
+    ): Promise<{
+        userGroups: any[];
+        id: string;
+        name: string;
+        username: string;
+    }> => {
+        const userGroups = await d2.currentUser.getUserGroups();
 
-    return {
-        userGroups: userGroups.toArray(),
-        id: d2.currentUser.id,
-        name: d2.currentUser.name,
-        username: d2.currentUser.username,
-    };
-});
+        return {
+            userGroups: userGroups.toArray(),
+            id: d2.currentUser.id,
+            name: d2.currentUser.name,
+            username: d2.currentUser.username,
+        };
+    }
+);
 
 export const initializeAppRoles = async (baseUrl: string) => {
     for (const role in AppRoles) {

--- a/src/utils/permissions.ts
+++ b/src/utils/permissions.ts
@@ -1,0 +1,42 @@
+import axios from "axios";
+
+import { D2 } from "../types/d2";
+
+export enum AppRoles {
+    METADATA_SYNC_ADMINISTRATOR,
+}
+
+export const hasUserRole = async (d2: D2, userRole: AppRoles) => {
+    const userRoles = await d2.currentUser.getUserRoles();
+    return userRoles.toArray().find((role: any) => role.name === AppRoles[userRole]);
+};
+
+export const initializeAppRoles = async (baseUrl: string) => {
+    for (const role in AppRoles) {
+        const { userRoles } = (await axios.get(baseUrl + "/metadata", {
+            withCredentials: true,
+            params: {
+                userRoles: true,
+                filter: `name:eq:${role}`,
+                fields: "id",
+            },
+        })).data as { userRoles?: { id: string }[] };
+
+        if (!userRoles || userRoles.length === 0) {
+            await axios.post(
+                baseUrl + "/metadata.json",
+                {
+                    userRoles: [
+                        {
+                            name: role,
+                            publicAccess: "--------",
+                        },
+                    ],
+                },
+                {
+                    withCredentials: true,
+                }
+            );
+        }
+    }
+};

--- a/src/utils/permissions.ts
+++ b/src/utils/permissions.ts
@@ -6,9 +6,30 @@ export enum AppRoles {
     METADATA_SYNC_ADMINISTRATOR,
 }
 
-export const hasUserRole = async (d2: D2, userRole: AppRoles) => {
+export const getUserInfo = async (
+    d2: D2
+): Promise<{
+    userGroups: any[];
+    userRoles: any[];
+    id: string;
+    name: string;
+    username: string;
+    isAdmin: boolean;
+}> => {
+    const userGroups = await d2.currentUser.getUserGroups();
     const userRoles = await d2.currentUser.getUserRoles();
-    return userRoles.toArray().find((role: any) => role.name === AppRoles[userRole]);
+    const isAdmin = userRoles
+        .toArray()
+        .find((role: any) => role.name === AppRoles[AppRoles.METADATA_SYNC_ADMINISTRATOR]);
+
+    return {
+        userGroups: userGroups.toArray(),
+        userRoles: userRoles.toArray(),
+        id: d2.currentUser.id,
+        name: d2.currentUser.name,
+        username: d2.currentUser.username,
+        isAdmin,
+    };
 };
 
 export const initializeAppRoles = async (baseUrl: string) => {

--- a/src/utils/permissions.ts
+++ b/src/utils/permissions.ts
@@ -61,7 +61,6 @@ export const getUserInfo = memoize(
 
 export const initializeAppRoles = async (baseUrl: string) => {
     for (const role in AppRoles) {
-        console.log(role, AppRoles);
         const { userRoles } = (await axios.get(baseUrl + "/metadata", {
             withCredentials: true,
             params: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1270,6 +1270,11 @@
   resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz#2b5a3ab3f918cca48a8c754c08168e3f03eba61b"
   integrity sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==
 
+"@reach/auto-id@^0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@reach/auto-id/-/auto-id-0.2.0.tgz#97f9e48fe736aa5c6f4f32cf73c1f19d005f8550"
+  integrity sha512-lVK/svL2HuQdp7jgvlrLkFsUx50Az9chAhxpiPwBqcS83I2pVWvXp98FOcSCCJCV++l115QmzHhFd+ycw1zLBg==
+
 "@sinonjs/commons@^1", "@sinonjs/commons@^1.3.0", "@sinonjs/commons@^1.4.0":
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.6.0.tgz#ec7670432ae9c8eb710400d112c201a362d83393"
@@ -3462,6 +3467,11 @@ compression@^1.5.2:
     safe-buffer "5.1.2"
     vary "~1.1.2"
 
+compute-scroll-into-view@^1.0.9:
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/compute-scroll-into-view/-/compute-scroll-into-view-1.0.11.tgz#7ff0a57f9aeda6314132d8994cce7aeca794fecf"
+  integrity sha512-uUnglJowSe0IPmWOdDtrlHXof5CTIJitfJEyITHBW6zDVOGu9Pjk5puaLM73SLcwak0L4hEjO7Td88/a6P5i7A==
+
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
@@ -4431,6 +4441,17 @@ dotenv@6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-6.2.0.tgz#941c0410535d942c8becf28d3f357dbd9d476064"
   integrity sha512-HygQCKUBSFl8wKQZBSemMywRWcEDNidvNbjGVyZu3nbZ8qq9ubiPoGLMdRDpfSrpkkm9BXYFkpKxxFX38o/76w==
+
+downshift@^3.3.4:
+  version "3.3.4"
+  resolved "https://registry.yarnpkg.com/downshift/-/downshift-3.3.4.tgz#959be157e48be2ec2bbc50f184303647fc719026"
+  integrity sha512-3bM11S3p78p/moyJqDPc1j357dm/C+dN+54HKuc526k5etNXvnXyxsb+Ufd2yLL6qK4QZA62DysAgtMCIsKCNA==
+  dependencies:
+    "@babel/runtime" "^7.4.5"
+    "@reach/auto-id" "^0.2.0"
+    compute-scroll-into-view "^1.0.9"
+    prop-types "^15.7.2"
+    react-is "^16.9.0"
 
 duplexer@^0.1.1:
   version "0.1.1"


### PR DESCRIPTION
### :pushpin: References

* **Issue:** Closes #148 

### :memo: Implementation

- Visual component for Sharing settings
  - Add ``downshift`` dependency
  - Import Sharing component from d2-ui
  - Remove old ``d2.i18n`` code, ``recompose`` library and logic coupling inside the components
  - Expose the logic methods as props in the components to make them agnostic (allowing dataStore support)
- Administrative user roles
  - On application load it checks if the user role exists and creates it if negative
  - For creation of sync rules and/or instances we verify user has the administrative role
- Sharing settings and user access
  - For ``SyncRule.list`` we filter the results with the ones the user has access (read)
  - For contextual actions (edit, delete, sharing settings, toggle enabled) we verify user has access (write)
  - We support public access rules (both read and/or write)
  - We allow administrative users to always have read and write permissions (as DHIS2 does)

### :art: Screenshots

![image](https://user-images.githubusercontent.com/2181866/66605712-dc0b2480-ebb0-11e9-8c98-1f594f23bc99.png)

![image](https://user-images.githubusercontent.com/2181866/66605723-e3323280-ebb0-11e9-8c75-a3e76382f3cd.png)

### :fire: Is there anything the reviewer should know to test it?

- The administrative user role is called "METADATA_SYNC_ADMINISTRATOR"
- The original issue contemplated two user roles (configurators/executors) but this is superseded by one single user role (configurator) + sharing settings (executors only are meant to view/execute the rules they have access to)

### :bookmark_tabs: Others

- When we have ready our logic library I would like to revisit this part and add more robust methods (using d2-api).
- Version 2.31 adds support for dataStore sharingSettings natively in the /sharings endpoint, I would like to add that extra validations but does not make sense doing it until we have our communication library