### PR TITLE
Fix/model centralization

### DIFF
--- a/src/components/rules-creation-page/steps/MetadataSelectionStep.jsx
+++ b/src/components/rules-creation-page/steps/MetadataSelectionStep.jsx
@@ -5,7 +5,7 @@ import _ from "lodash";
 import { withSnackbar } from "d2-ui-components";
 
 import MetadataTable from "../../metadata-table/MetadataTable";
-import { metadataModels } from "../../../models/d2Model";
+import { metadataModels } from "../../../models/d2ModelFactory";
 
 class MetadataSelectionStep extends React.Component {
     static propTypes = {

--- a/src/components/synchronization-page/MetadataPage.jsx
+++ b/src/components/synchronization-page/MetadataPage.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import i18n from "@dhis2/d2-i18n";
-import { metadataModels } from "../../models/d2Model";
+import { metadataModels } from "../../models/d2ModelFactory";
 import GenericSynchronizationPage from "./GenericSynchronizationPage";
 
 export default class MetadataPage extends React.Component {

--- a/src/models/__tests__/d2ModelFactory.spec.js
+++ b/src/models/__tests__/d2ModelFactory.spec.js
@@ -1,0 +1,16 @@
+import {d2ModelFactory} from "../d2ModelFactory";
+import {DataElementGroupModel} from "../d2Model"
+
+describe("d2ModelFactory", () => {
+    describe("d2ModelFactory should return specific model", () => {
+        it("DataElementGroup", async () => {
+            const d2Stub = { models: { dataElementGroups: { name: "dataElementGroup" } } };
+
+            const d2Model = d2ModelFactory(d2Stub, "dataElementGroups");
+
+            expect(d2Model).toEqual(DataElementGroupModel);
+        });
+    });
+});
+
+export {};

--- a/src/models/d2Model.ts
+++ b/src/models/d2Model.ts
@@ -318,21 +318,3 @@ export function defaultModel(pascalCaseModelName: string): any {
         protected static metadataType = pascalCaseModelName;
     };
 }
-
-export const metadataModels = [
-    DataElementModel,
-    DataElementGroupModel,
-    DataElementGroupSetModel,
-    IndicatorModel,
-    IndicatorGroupModel,
-    IndicatorGroupSetModel,
-    OrganisationUnitModel,
-    OrganisationUnitGroupModel,
-    OrganisationUnitGroupSetModel,
-    ValidationRuleModel,
-    ValidationRuleGroupModel,
-    ProgramIndicatorModel,
-    ProgramIndicatorGroupModel,
-    ProgramRuleModel,
-    ProgramRuleVariableModel,
-];

--- a/src/models/d2ModelFactory.ts
+++ b/src/models/d2ModelFactory.ts
@@ -1,8 +1,43 @@
-import { D2Model, defaultModel, metadataModels } from "./d2Model";
+import {
+    D2Model, defaultModel, DataElementModel,
+    DataElementGroupModel,
+    DataElementGroupSetModel,
+    IndicatorModel,
+    IndicatorGroupModel,
+    IndicatorGroupSetModel,
+    OrganisationUnitModel,
+    OrganisationUnitGroupModel,
+    OrganisationUnitGroupSetModel,
+    ValidationRuleModel,
+    ValidationRuleGroupModel,
+    ProgramIndicatorModel,
+    ProgramIndicatorGroupModel,
+    ProgramRuleModel,
+    ProgramRuleVariableModel
+} from "./d2Model";
+
 import { D2 } from "../types/d2";
 import _ from "lodash";
 
-const classes: { [modelName: string]: typeof D2Model } = _.keyBy(metadataModels, o => o.name);
+const classes: { [modelName: string]: typeof D2Model } = {
+    DataElementModel,
+    DataElementGroupModel,
+    DataElementGroupSetModel,
+    IndicatorModel,
+    IndicatorGroupModel,
+    IndicatorGroupSetModel,
+    OrganisationUnitModel,
+    OrganisationUnitGroupModel,
+    OrganisationUnitGroupSetModel,
+    ValidationRuleModel,
+    ValidationRuleGroupModel,
+    ProgramIndicatorModel,
+    ProgramIndicatorGroupModel,
+    ProgramRuleModel,
+    ProgramRuleVariableModel
+};
+
+export const metadataModels = Object.values(classes);
 
 /**
  * D2ModelProxy allows to create on-demand d2Model classes
@@ -12,5 +47,13 @@ const classes: { [modelName: string]: typeof D2Model } = _.keyBy(metadataModels,
 export function d2ModelFactory(d2: D2, d2ModelName: string): typeof D2Model {
     const modelName = d2.models[d2ModelName].name;
     const className = modelName.charAt(0).toUpperCase() + modelName.slice(1) + "Model";
-    return classes[className] || defaultModel(modelName);
+
+    let model = classes[className];
+
+    if (!model) {
+        console.log(`d2ModelFactory for modelName ${d2ModelName} return defaultModel`)
+        model = defaultModel(modelName);
+    }
+
+    return model;
 }


### PR DESCRIPTION
### :pushpin: References

* **Issue:** Closes #184 

### :memo: Implementation
After some testing, the problem seems to be the use of keyBy Lodash method in d2ModelFactory.
For some reason I don't understand, after building with WebPack the classes dictionary in the production environment only the last model in array ProgramRuleVariableModel, and in the development environment had all.

- Solution:
I have changed the strategy to centralize metadataModels array without to use keyBy Lodash method. I have restored the old approach in d2ModelFactory as @SferaDev suggested and I have added a new export metadataModels array here based on classes dictionary. 
I have removed metadataModels array from D2Model and all places where was used now the import has been changed to metadataModels in d2ModelFactory.

* Trace
I have added a console.log when d2ModelFactory return defaultModel

* Testing
I have added a new unit test for d2ModelFactory but this jest test works on the development and Travis even with the error because jest tests are executed in the prebuild phase.
I think the unique way the test is failing in Travis when a similar problem occurs is creating an integration test.
The problem is the time needed to invest to create this type of test because it is necessary to create a test environment data totally controlled by the tests so as not to depend on data from a specific server of dhis2 since they would be very brittle tests.

### :art: Screenshots


### :fire: Is there anything the reviewer should know to test it?
**UseCase 1**: try to synchronize dataElementGroups then the final summary should to show that Datalements has been imported also
**UseCase 2**: In the metadata sync page on metadata type dropdown should appear all metadata models.
**UseCase 3**: In the metadata step of metadata sync rules wizard, on metadata type dropdown should appear all metadata models.

### :bookmark_tabs: Others
