### PR TITLE
Remove time from lastUpdated query to d2Model

### DIFF
--- a/src/models/d2Model.ts
+++ b/src/models/d2Model.ts
@@ -59,7 +59,7 @@ export abstract class D2Model {
         const filter = _.compact([
             search && isValidUid(search) ? `id:eq:${search}` : null,
             search && !isValidUid(search) ? `displayName:ilike:${search}` : null,
-            lastUpdatedDate ? `lastUpdated:ge:${lastUpdatedDate.toISOString()}` : null,
+            lastUpdatedDate ? `lastUpdated:ge:${lastUpdatedDate.format("YYYY-MM-DD")}` : null,
             groupFilter ? `${this.groupFilterName}.id:eq:${groupFilter}` : null,
             ...customFilters,
         ]);


### PR DESCRIPTION
### :pushpin: References

* **Issue:** Closes #198 

### :memo: Implementation

- Remove the exact time in the filter that goes into the query.

### :art: Screenshots

![image](https://user-images.githubusercontent.com/2181866/68190217-409d8180-ffad-11e9-9635-fabeeb6de0d4.png)

### :fire: Is there anything the reviewer should know to test it?

See the network requests.

Before:

```
http://taris.sferadev.com:9004/api/dataElements?filter=lastUpdated:ge:2019-10-26T08:56:00.000Z&fields=id&page=1&pageSize=20&order=name%3Aiasc&paging=false
```

After:

```
http://taris.sferadev.com:9004/api/dataElements?filter=lastUpdated:ge:2019-10-26&fields=id&page=1&pageSize=20&order=name%3Aiasc&paging=false
```

### :bookmark_tabs: Others

[Last updated date filter set time to 00:00](https://app.gitkraken.com/glo/board/XaBKjXlqfAAPh4Tg/card/XbrZCRz3OwAPE_BZ)