### PR TITLE
[Bugfix] Move filtering into request and pre-calculate pager

### DIFF
--- a/src/models/dataStore.ts
+++ b/src/models/dataStore.ts
@@ -72,7 +72,8 @@ export async function getPaginatedData(
     d2: D2,
     dataStoreKey: string,
     filters: TableFilters,
-    pagination: TablePagination
+    pagination: TablePagination,
+    externalFilters: Function = (objects: any[]) => objects
 ): Promise<TableList> {
     const { search = null } = filters || {};
     const { page = 1, pageSize = 20, paging = true, sorting = ["id", "asc"] } = pagination || {};
@@ -80,13 +81,13 @@ export async function getPaginatedData(
     const rawData = await getDataStore(d2, dataStoreKey, []);
 
     const filteredData = search
-        ? _.filter(rawData, o =>
+        ? _.filter(externalFilters(rawData), o =>
               _(o)
                   .keys()
                   .filter(k => typeof o[k] === "string")
                   .some(k => o[k].toLowerCase().includes(search.toLowerCase()))
           )
-        : rawData;
+        : externalFilters(rawData);
 
     const [field, direction] = sorting;
     const sortedData = _.orderBy(

--- a/src/models/dataStore.ts
+++ b/src/models/dataStore.ts
@@ -72,8 +72,7 @@ export async function getPaginatedData(
     d2: D2,
     dataStoreKey: string,
     filters: TableFilters,
-    pagination: TablePagination,
-    externalFilters: Function = (objects: any[]) => objects
+    pagination: TablePagination
 ): Promise<TableList> {
     const { search = null } = filters || {};
     const { page = 1, pageSize = 20, paging = true, sorting = ["id", "asc"] } = pagination || {};
@@ -81,13 +80,13 @@ export async function getPaginatedData(
     const rawData = await getDataStore(d2, dataStoreKey, []);
 
     const filteredData = search
-        ? _.filter(externalFilters(rawData), o =>
+        ? _.filter(rawData, o =>
               _(o)
                   .keys()
                   .filter(k => typeof o[k] === "string")
                   .some(k => o[k].toLowerCase().includes(search.toLowerCase()))
           )
-        : externalFilters(rawData);
+        : rawData;
 
     const [field, direction] = sorting;
     const sortedData = _.orderBy(

--- a/src/models/syncReport.ts
+++ b/src/models/syncReport.ts
@@ -57,10 +57,21 @@ export default class SyncReport {
         pagination: TablePagination
     ): Promise<TableList> {
         const { statusFilter } = filters;
-        const filteringMethod = (data: any[]) =>
-            statusFilter ? _.filter(data, e => e.status === statusFilter) : data;
+        const { page = 1, pageSize = 20, paging = true } = pagination || {};
 
-        return getPaginatedData(d2, dataStoreKey, filters, pagination, filteringMethod);
+        const data = await getPaginatedData(d2, dataStoreKey, filters, pagination);
+
+        const filteredObjects = statusFilter
+            ? _.filter(data.objects, e => e.status === statusFilter)
+            : data.objects;
+
+        const total = filteredObjects.length;
+        const pageCount = paging ? Math.ceil(filteredObjects.length / pageSize) : 1;
+        const firstItem = paging ? (page - 1) * pageSize : 0;
+        const lastItem = paging ? firstItem + pageSize : total;
+        const objects = _.slice(filteredObjects, firstItem, lastItem);
+
+        return { objects, pager: { page, pageCount, total } };
     }
 
     public async save(d2: D2): Promise<void> {

--- a/src/models/syncReport.ts
+++ b/src/models/syncReport.ts
@@ -57,10 +57,10 @@ export default class SyncReport {
         pagination: TablePagination
     ): Promise<TableList> {
         const { statusFilter } = filters;
-        const data = await getPaginatedData(d2, dataStoreKey, filters, pagination);
-        return statusFilter
-            ? { ...data, objects: _.filter(data.objects, e => e.status === statusFilter) }
-            : data;
+        const filteringMethod = (data: any[]) =>
+            statusFilter ? _.filter(data, e => e.status === statusFilter) : data;
+
+        return getPaginatedData(d2, dataStoreKey, filters, pagination, filteringMethod);
     }
 
     public async save(d2: D2): Promise<void> {

--- a/src/models/syncReport.ts
+++ b/src/models/syncReport.ts
@@ -57,21 +57,10 @@ export default class SyncReport {
         pagination: TablePagination
     ): Promise<TableList> {
         const { statusFilter } = filters;
-        const { page = 1, pageSize = 20, paging = true } = pagination || {};
+        const filteringMethod = (data: any[]) =>
+            statusFilter ? _.filter(data, e => e.status === statusFilter) : data;
 
-        const data = await getPaginatedData(d2, dataStoreKey, filters, pagination);
-
-        const filteredObjects = statusFilter
-            ? _.filter(data.objects, e => e.status === statusFilter)
-            : data.objects;
-
-        const total = filteredObjects.length;
-        const pageCount = paging ? Math.ceil(filteredObjects.length / pageSize) : 1;
-        const firstItem = paging ? (page - 1) * pageSize : 0;
-        const lastItem = paging ? firstItem + pageSize : total;
-        const objects = _.slice(filteredObjects, firstItem, lastItem);
-
-        return { objects, pager: { page, pageCount, total } };
+        return getPaginatedData(d2, dataStoreKey, filters, pagination, filteringMethod);
     }
 
     public async save(d2: D2): Promise<void> {

--- a/src/models/syncRule.ts
+++ b/src/models/syncRule.ts
@@ -101,21 +101,25 @@ export default class SyncRule {
     ): Promise<TableList> {
         const { targetInstanceFilter = null, enabledFilter = null, lastExecutedFilter = null } =
             filters || {};
-        const data = await getPaginatedData(d2, dataStoreKey, filters, pagination);
-        const objects = _(data.objects)
-            .filter(rule =>
-                targetInstanceFilter
-                    ? rule.builder.targetInstances.includes(targetInstanceFilter)
-                    : true
-            )
-            .filter(rule => (enabledFilter ? rule.enabled && enabledFilter === "enabled" : true))
-            .filter(rule =>
-                lastExecutedFilter && rule.lastExecuted
-                    ? moment(lastExecutedFilter).isSameOrBefore(rule.lastExecuted)
-                    : true
-            )
-            .value();
-        return { ...data, objects };
+
+        const filteringMethod = (data: any[]) =>
+            _(data)
+                .filter(rule =>
+                    targetInstanceFilter
+                        ? rule.builder.targetInstances.includes(targetInstanceFilter)
+                        : true
+                )
+                .filter(rule =>
+                    enabledFilter ? rule.enabled && enabledFilter === "enabled" : true
+                )
+                .filter(rule =>
+                    lastExecutedFilter && rule.lastExecuted
+                        ? moment(lastExecutedFilter).isSameOrBefore(rule.lastExecuted)
+                        : true
+                )
+                .value();
+
+        return getPaginatedData(d2, dataStoreKey, filters, pagination, filteringMethod);
     }
 
     public updateName(name: string): SyncRule {

--- a/src/models/syncRule.ts
+++ b/src/models/syncRule.ts
@@ -101,30 +101,28 @@ export default class SyncRule {
     ): Promise<TableList> {
         const { targetInstanceFilter = null, enabledFilter = null, lastExecutedFilter = null } =
             filters || {};
-        const { page = 1, pageSize = 20, paging = true } = pagination || {};
 
-        const data = await getPaginatedData(d2, dataStoreKey, filters, pagination);
-        const filteredObjects = _(data.objects)
-            .filter(rule =>
-                targetInstanceFilter
-                    ? rule.builder.targetInstances.includes(targetInstanceFilter)
-                    : true
-            )
-            .filter(rule => (enabledFilter ? rule.enabled && enabledFilter === "enabled" : true))
-            .filter(rule =>
-                lastExecutedFilter && rule.lastExecuted
-                    ? moment(lastExecutedFilter).isSameOrBefore(rule.lastExecuted)
-                    : true
-            )
-            .value();
+        const filteringMethod = (data: any[]) =>
+            _(data)
+                .filter(rule =>
+                    targetInstanceFilter
+                        ? rule.builder.targetInstances.includes(targetInstanceFilter)
+                        : true
+                )
+                .filter(rule =>
+                    enabledFilter
+                        ? (rule.enabled && enabledFilter === "enabled") ||
+                          (!rule.enabled && enabledFilter !== "enabled")
+                        : true
+                )
+                .filter(rule =>
+                    lastExecutedFilter && rule.lastExecuted
+                        ? moment(lastExecutedFilter).isSameOrBefore(rule.lastExecuted)
+                        : true
+                )
+                .value();
 
-        const total = filteredObjects.length;
-        const pageCount = paging ? Math.ceil(filteredObjects.length / pageSize) : 1;
-        const firstItem = paging ? (page - 1) * pageSize : 0;
-        const lastItem = paging ? firstItem + pageSize : total;
-        const objects = _.slice(filteredObjects, firstItem, lastItem);
-
-        return { objects, pager: { page, pageCount, total } };
+        return getPaginatedData(d2, dataStoreKey, filters, pagination, filteringMethod);
     }
 
     public updateName(name: string): SyncRule {


### PR DESCRIPTION
### :pushpin: References

* **Issue:** Closes #205 

### :memo: Implementation

- Re-calculate pagination after applying custom filters by tapping into the ``getPaginatedData`` call with a filtering function.

### :art: Screenshots


### :fire: Is there anything the reviewer should know to test it?

- This change does not apply DRY, but are temporal fixes until we are ready to move to the new approach using the new ``DataTable`` and ``d2Api.dataStore``. We will completely re-do this filtering calls and pagination calculation.

### :bookmark_tabs: Others
