### PR TITLE
[Feature] Add data statistics to sync report

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2019-12-23T21:01:32.052Z\n"
-"PO-Revision-Date: 2019-12-23T21:01:32.052Z\n"
+"POT-Creation-Date: 2019-12-25T08:43:28.148Z\n"
+"PO-Revision-Date: 2019-12-25T08:43:28.148Z\n"
 
 msgid "Search by name"
 msgstr ""
@@ -134,6 +134,18 @@ msgstr ""
 msgid "Total"
 msgstr ""
 
+msgid "Data element"
+msgstr ""
+
+msgid "Program"
+msgstr ""
+
+msgid "Number of entries"
+msgstr ""
+
+msgid "Org units"
+msgstr ""
+
 msgid "Identifier"
 msgstr ""
 
@@ -159,6 +171,9 @@ msgid "Summary"
 msgstr ""
 
 msgid "Messages"
+msgstr ""
+
+msgid "Data Statistics"
 msgstr ""
 
 msgid "JSON Response"

--- a/src/components/sync-summary/SyncSummary.jsx
+++ b/src/components/sync-summary/SyncSummary.jsx
@@ -1,10 +1,4 @@
-import React from "react";
-import _ from "lodash";
 import i18n from "@dhis2/d2-i18n";
-import PropTypes from "prop-types";
-import { ConfirmationDialog } from "d2-ui-components";
-import ReactJson from "react-json-view";
-
 import {
     DialogContent,
     ExpansionPanel,
@@ -15,10 +9,16 @@ import {
     TableCell,
     TableHead,
     TableRow,
+    Tooltip,
     Typography,
     withStyles,
 } from "@material-ui/core";
 import ExpandMoreIcon from "@material-ui/icons/ExpandMore";
+import { ConfirmationDialog } from "d2-ui-components";
+import _ from "lodash";
+import PropTypes from "prop-types";
+import React from "react";
+import ReactJson from "react-json-view";
 import SyncReport from "../../models/syncReport";
 
 const styles = theme => ({
@@ -36,6 +36,10 @@ const styles = theme => ({
     },
     expansionPanel: {
         paddingBottom: "10px",
+    },
+    tooltip: {
+        maxWidth: 650,
+        fontSize: "0.9em",
     },
 });
 
@@ -91,6 +95,42 @@ class SyncSummary extends React.Component {
                             </TableRow>
                         )
                     )}
+                </TableBody>
+            </Table>
+        );
+    }
+
+    static buildDataStatsTable(type, stats, classes) {
+        const elementName = type === "aggregated" ? i18n.t("Data element") : i18n.t("Program");
+
+        return (
+            <Table>
+                <TableHead>
+                    <TableRow>
+                        <TableCell>{elementName}</TableCell>
+                        <TableCell>{i18n.t("Number of entries")}</TableCell>
+                        {type === "events" && <TableCell>{i18n.t("Org units")}</TableCell>}
+                    </TableRow>
+                </TableHead>
+                <TableBody>
+                    {stats.map(({ dataElement, program, count, orgUnits }, i) => (
+                        <TableRow key={`row-${i}`}>
+                            <TableCell>{dataElement || program}</TableCell>
+                            <TableCell>{count}</TableCell>
+                            {type === "events" && (
+                                <Tooltip
+                                    classes={{ tooltip: classes.tooltip }}
+                                    open={orgUnits.length <= 3 ? false : undefined}
+                                    title={orgUnits.join(", ")}
+                                    placement="top"
+                                >
+                                    <TableCell>{`${_.take(orgUnits, 3).join(", ")} ${
+                                        orgUnits.length > 3 ? "and more" : ""
+                                    }`}</TableCell>
+                                </Tooltip>
+                            )}
+                        </TableRow>
+                    ))}
                 </TableBody>
             </Table>
         );
@@ -197,6 +237,24 @@ class SyncSummary extends React.Component {
                                 )}
                             </ExpansionPanel>
                         ))}
+
+                        {response.syncReport.dataStats && (
+                            <ExpansionPanel>
+                                <ExpansionPanelSummary expandIcon={<ExpandMoreIcon />}>
+                                    <Typography className={classes.expansionPanelHeading1}>
+                                        {i18n.t("Data Statistics")}
+                                    </Typography>
+                                </ExpansionPanelSummary>
+
+                                <ExpansionPanelDetails>
+                                    {SyncSummary.buildDataStatsTable(
+                                        response.syncReport.type,
+                                        response.syncReport.dataStats,
+                                        classes
+                                    )}
+                                </ExpansionPanelDetails>
+                            </ExpansionPanel>
+                        )}
 
                         <ExpansionPanel>
                             <ExpansionPanelSummary expandIcon={<ExpandMoreIcon />}>

--- a/src/logic/sync/generic.ts
+++ b/src/logic/sync/generic.ts
@@ -64,7 +64,7 @@ export abstract class GenericSync {
             types: _.keys(metadataPackage),
             status: "RUNNING" as SynchronizationReportStatus,
             syncRule,
-            type: "events",
+            type: this.type,
             dataStats,
         });
     }

--- a/src/logic/sync/metadata.ts
+++ b/src/logic/sync/metadata.ts
@@ -100,4 +100,8 @@ export class MetadataSync extends GenericSync {
     protected cleanResponse(response: MetadataImportResponse, instance: Instance) {
         return cleanMetadataImportResponse(response, instance);
     }
+
+    protected async buildDataStats() {
+        return undefined;
+    }
 }

--- a/src/models/syncReport.ts
+++ b/src/models/syncReport.ts
@@ -32,7 +32,16 @@ export default class SyncReport {
         this.syncReport = {
             id: generateUid(),
             date: new Date(),
-            ..._.pick(syncReport, ["id", "date", "user", "status", "types", "syncRule", "type"]),
+            ..._.pick(syncReport, [
+                "id",
+                "date",
+                "user",
+                "status",
+                "types",
+                "syncRule",
+                "type",
+                "dataStats",
+            ]),
         };
     }
 

--- a/src/types/synchronization.d.ts
+++ b/src/types/synchronization.d.ts
@@ -78,6 +78,18 @@ export interface SynchronizationReport {
     types: string[];
     syncRule?: string;
     type: SyncRuleType;
+    dataStats?: AggregatedDataStats[] | EventsDataStats[];
+}
+
+export interface AggregatedDataStats {
+    dataElement: string;
+    count: number;
+}
+
+export interface EventsDataStats {
+    program: string;
+    count: number;
+    orgUnits: string[];
 }
 
 export interface NestedRules {

--- a/src/utils/synchronization.ts
+++ b/src/utils/synchronization.ts
@@ -349,3 +349,30 @@ export async function postEventsData(
 ): Promise<any> {
     return postData(instance, "/events", data, _.pick(additionalParams, []));
 }
+
+export function buildMetadataDictionary(metadataPackage: MetadataPackage) {
+    return _(metadataPackage)
+        .values()
+        .flatten()
+        .tap(array => {
+            const dataSetElements = _.flatten(
+                _.map(metadataPackage.dataSets ?? [], e =>
+                    _.map(e.dataSetElements ?? [], ({ dataElement }) => dataElement)
+                )
+            );
+
+            const groupDataElements = _.flatten(
+                _.map(metadataPackage.dataElementGroups ?? [], e => e.dataElements ?? [])
+            );
+
+            const groupSetDataElements = _.flatten(
+                _.map(metadataPackage.dataElementGroupSets ?? [], e =>
+                    _.flatten(_.map(e.dataElementGroups ?? [], ({ dataElements }) => dataElements))
+                )
+            );
+
+            array.push(...dataSetElements, ...groupDataElements, ...groupSetDataElements);
+        })
+        .keyBy("id")
+        .value();
+}


### PR DESCRIPTION
### :pushpin: References

* **Issue:** Closes #242 
* **Issue:** Closes #243  
* **Issue:** Closes #244  
* **Issue:** Closes #246  

### :memo: Implementation

- Generate data statistics during synchronization
- Show a new "Data Statistics" section in the Sync Summary component

### :art: Screenshots

![image](https://user-images.githubusercontent.com/2181866/71439905-aaa7ec80-26fb-11ea-9590-74275dedce4f.png)
![image](https://user-images.githubusercontent.com/2181866/71439927-bdbabc80-26fb-11ea-8c2c-a5cd8256df8c.png)
![image](https://user-images.githubusercontent.com/2181866/71441513-0bd2be80-2702-11ea-8487-e53ad786e7d3.png)

### :fire: Is there anything the reviewer should know to test it?

- Tooltip becomes available when there are more than 3 org units provided

### :bookmark_tabs: Others
