### PR TITLE
[Feature] Allow relative periods for data sync

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2019-12-25T08:43:28.148Z\n"
-"PO-Revision-Date: 2019-12-25T08:43:28.148Z\n"
+"POT-Creation-Date: 2019-12-30T09:29:50.313Z\n"
+"PO-Revision-Date: 2019-12-30T09:29:50.313Z\n"
 
 msgid "Search by name"
 msgstr ""
@@ -354,6 +354,30 @@ msgid "Due date"
 msgstr ""
 
 msgid "Sync all events"
+msgstr ""
+
+msgid "All periods"
+msgstr ""
+
+msgid "Fixed period"
+msgstr ""
+
+msgid "Last day"
+msgstr ""
+
+msgid "Last week"
+msgstr ""
+
+msgid "Last month"
+msgstr ""
+
+msgid "Last three months"
+msgstr ""
+
+msgid "Last six months"
+msgstr ""
+
+msgid "Last year"
 msgstr ""
 
 msgid "Start date"

--- a/src/components/sync-wizard/Steps.ts
+++ b/src/components/sync-wizard/Steps.ts
@@ -145,7 +145,7 @@ export const eventsSteps: SyncWizardStep[] = [
         key: "period",
         label: i18n.t("Period"),
         component: PeriodSelectionStep,
-        validationKeys: [],
+        validationKeys: ["dataSyncStartDate", "dataSyncEndDate"],
         showOnSyncDialog: true,
     },
     {

--- a/src/components/sync-wizard/common/SummaryStep.jsx
+++ b/src/components/sync-wizard/common/SummaryStep.jsx
@@ -141,21 +141,6 @@ const SaveStep = ({ syncRule, classes, onCancel, loading }) => {
                     </LiEntry>
                 ))}
 
-                <LiEntry
-                    label={i18n.t("Target instances [{{total}}]", {
-                        total: syncRule.targetInstances.length,
-                    })}
-                >
-                    <ul>
-                        {syncRule.targetInstances.map(id => {
-                            const instance = instanceOptions.find(e => e.value === id);
-                            return instance ? (
-                                <LiEntry key={instance.value} label={instance.text} />
-                            ) : null;
-                        })}
-                    </ul>
-                </LiEntry>
-
                 {syncRule.type !== "metadata" && (
                     <LiEntry
                         label={i18n.t("Period")}
@@ -179,6 +164,21 @@ const SaveStep = ({ syncRule, classes, onCancel, loading }) => {
                         )}
                     </LiEntry>
                 )}
+
+                <LiEntry
+                    label={i18n.t("Target instances [{{total}}]", {
+                        total: syncRule.targetInstances.length,
+                    })}
+                >
+                    <ul>
+                        {syncRule.targetInstances.map(id => {
+                            const instance = instanceOptions.find(e => e.value === id);
+                            return instance ? (
+                                <LiEntry key={instance.value} label={instance.text} />
+                            ) : null;
+                        })}
+                    </ul>
+                </LiEntry>
 
                 {syncRule.type === "metadata" && (
                     <LiEntry label={i18n.t("Advanced options")}>

--- a/src/components/sync-wizard/common/SummaryStep.jsx
+++ b/src/components/sync-wizard/common/SummaryStep.jsx
@@ -14,6 +14,7 @@ import { getBaseUrl } from "../../../utils/d2";
 import { getMetadata } from "../../../utils/synchronization";
 import { getValidationMessages } from "../../../utils/validations";
 import { getInstances } from "./InstanceSelectionStep";
+import { availablePeriods } from "../data/PeriodSelectionStep";
 
 const LiEntry = ({ label, value, children }) => {
     return (
@@ -154,6 +155,30 @@ const SaveStep = ({ syncRule, classes, onCancel, loading }) => {
                         })}
                     </ul>
                 </LiEntry>
+
+                {syncRule.type !== "metadata" && (
+                    <LiEntry
+                        label={i18n.t("Period")}
+                        value={_.find(availablePeriods, { id: syncRule.dataSyncPeriod })?.name}
+                    >
+                        {syncRule.dataSyncPeriod === "FIXED" && (
+                            <ul>
+                                <LiEntry
+                                    label={i18n.t("Start date")}
+                                    value={syncRule.dataSyncStartDate.format("YYYY-MM-DD")}
+                                />
+                            </ul>
+                        )}
+                        {syncRule.dataSyncPeriod === "FIXED" && (
+                            <ul>
+                                <LiEntry
+                                    label={i18n.t("End date")}
+                                    value={syncRule.dataSyncEndDate.format("YYYY-MM-DD")}
+                                />
+                            </ul>
+                        )}
+                    </LiEntry>
+                )}
 
                 {syncRule.type === "metadata" && (
                     <LiEntry label={i18n.t("Advanced options")}>

--- a/src/components/sync-wizard/data/EventsSelectionStep.tsx
+++ b/src/components/sync-wizard/data/EventsSelectionStep.tsx
@@ -42,9 +42,7 @@ export default function EventsSelectionStep({ syncRule, onChange }: EventsSelect
         getEventsData(
             api,
             {
-                orgUnitPaths: syncRule.dataSyncOrgUnitPaths,
-                startDate: syncRule.dataSyncStartDate ?? undefined,
-                endDate: syncRule.dataSyncEndDate ?? undefined,
+                ...syncRule.dataParams,
                 allEvents: true,
             },
             syncRule.metadataIds

--- a/src/components/sync-wizard/data/PeriodSelectionStep.tsx
+++ b/src/components/sync-wizard/data/PeriodSelectionStep.tsx
@@ -1,15 +1,58 @@
 import i18n from "@dhis2/d2-i18n";
+import { makeStyles } from "@material-ui/core";
 import { DatePicker } from "d2-ui-components";
 import React from "react";
 import SyncRule from "../../../models/syncRule";
+import { DataSyncPeriod } from "../../../types/synchronization";
+import Dropdown from "../../dropdown/Dropdown";
+import Typography from "@material-ui/core/Typography";
 
 interface PeriodSelectionStepProps {
     syncRule: SyncRule;
     onChange: (syncRule: SyncRule) => void;
 }
 
+const useStyles = makeStyles({
+    title: {
+        fontWeight: 500,
+    },
+    dropdown: {
+        marginTop: 20,
+        marginLeft: -10,
+    },
+    fixedPeriod: {
+        marginTop: 20,
+        marginBottom: -20,
+    },
+    datePicker: {
+        marginTop: -10,
+    },
+});
+
+const dropdownItems = [
+    { id: "ALL", name: i18n.t("All periods") },
+    { id: "FIXED", name: i18n.t("Fixed period") },
+    { id: "LAST_DAY", name: i18n.t("Last day") },
+    { id: "LAST_WEEK", name: i18n.t("Last week") },
+    { id: "LAST_MONTH", name: i18n.t("Last month") },
+    { id: "LAST_THREE_MONTHS", name: i18n.t("Last three months") },
+    { id: "LAST_SIX_MONTHS", name: i18n.t("Last six months") },
+    { id: "LAST_YEAR", name: i18n.t("Last year") },
+];
+
 export default function PeriodSelectionStep(props: PeriodSelectionStepProps) {
     const { syncRule, onChange } = props;
+    const classes = useStyles();
+
+    const updatePeriod = (period: DataSyncPeriod) => {
+        onChange(
+            syncRule
+                .updateDataSyncPeriod(period)
+                .updateDataSyncStartDate(undefined)
+                .updateDataSyncEndDate(undefined)
+                .updateDataSyncEvents([])
+        );
+    };
 
     const updateStartDate = (date: Date | null) => {
         onChange(syncRule.updateDataSyncStartDate(date ?? undefined).updateDataSyncEvents([]));
@@ -19,24 +62,39 @@ export default function PeriodSelectionStep(props: PeriodSelectionStepProps) {
         onChange(syncRule.updateDataSyncEndDate(date ?? undefined).updateDataSyncEvents([]));
     };
 
-    const mandatory = syncRule.type === "aggregated" ? " (*)" : "";
-
     return (
         <React.Fragment>
-            <div>
-                <DatePicker
-                    label={i18n.t("Start date") + mandatory}
-                    value={syncRule.dataSyncStartDate || null}
-                    onChange={updateStartDate}
+            <div className={classes.dropdown}>
+                <Dropdown
+                    label={i18n.t("Period")}
+                    items={dropdownItems}
+                    value={syncRule.dataSyncPeriod}
+                    onValueChange={updatePeriod}
+                    hideEmpty={true}
                 />
             </div>
-            <div>
-                <DatePicker
-                    label={i18n.t("End date") + mandatory}
-                    value={syncRule.dataSyncEndDate || null}
-                    onChange={updateEndDate}
-                />
-            </div>
+
+            {syncRule.dataSyncPeriod === "FIXED" && (
+                <div className={classes.fixedPeriod}>
+                    <Typography className={classes.title} variant={"subtitle1"}>
+                        {i18n.t("Fixed period")}
+                    </Typography>
+                    <div className={classes.datePicker}>
+                        <DatePicker
+                            label={`${i18n.t("Start date")} (*)`}
+                            value={syncRule.dataSyncStartDate || null}
+                            onChange={updateStartDate}
+                        />
+                    </div>
+                    <div className={classes.datePicker}>
+                        <DatePicker
+                            label={`${i18n.t("End date")} (*)`}
+                            value={syncRule.dataSyncEndDate || null}
+                            onChange={updateEndDate}
+                        />
+                    </div>
+                </div>
+            )}
         </React.Fragment>
     );
 }

--- a/src/components/sync-wizard/data/PeriodSelectionStep.tsx
+++ b/src/components/sync-wizard/data/PeriodSelectionStep.tsx
@@ -5,7 +5,6 @@ import React from "react";
 import SyncRule from "../../../models/syncRule";
 import { DataSyncPeriod } from "../../../types/synchronization";
 import Dropdown from "../../dropdown/Dropdown";
-import Typography from "@material-ui/core/Typography";
 
 interface PeriodSelectionStepProps {
     syncRule: SyncRule;
@@ -13,15 +12,12 @@ interface PeriodSelectionStepProps {
 }
 
 const useStyles = makeStyles({
-    title: {
-        fontWeight: 500,
-    },
     dropdown: {
         marginTop: 20,
         marginLeft: -10,
     },
     fixedPeriod: {
-        marginTop: 20,
+        marginTop: 5,
         marginBottom: -20,
     },
     datePicker: {
@@ -76,9 +72,6 @@ export default function PeriodSelectionStep(props: PeriodSelectionStepProps) {
 
             {syncRule.dataSyncPeriod === "FIXED" && (
                 <div className={classes.fixedPeriod}>
-                    <Typography className={classes.title} variant={"subtitle1"}>
-                        {i18n.t("Fixed period")}
-                    </Typography>
                     <div className={classes.datePicker}>
                         <DatePicker
                             label={`${i18n.t("Start date")} (*)`}

--- a/src/components/sync-wizard/data/PeriodSelectionStep.tsx
+++ b/src/components/sync-wizard/data/PeriodSelectionStep.tsx
@@ -25,7 +25,7 @@ const useStyles = makeStyles({
     },
 });
 
-const dropdownItems = [
+export const availablePeriods = [
     { id: "ALL", name: i18n.t("All periods") },
     { id: "FIXED", name: i18n.t("Fixed period") },
     { id: "LAST_DAY", name: i18n.t("Last day") },
@@ -63,7 +63,7 @@ export default function PeriodSelectionStep(props: PeriodSelectionStepProps) {
             <div className={classes.dropdown}>
                 <Dropdown
                     label={i18n.t("Period")}
-                    items={dropdownItems}
+                    items={availablePeriods}
                     value={syncRule.dataSyncPeriod}
                     onValueChange={updatePeriod}
                     hideEmpty={true}

--- a/src/models/syncRule.ts
+++ b/src/models/syncRule.ts
@@ -6,6 +6,7 @@ import { D2 } from "../types/d2";
 import { SyncRuleTableFilters, TableList, TablePagination } from "../types/d2-ui-components";
 import {
     DataSynchronizationParams,
+    DataSyncPeriod,
     MetadataSynchronizationParams,
     SharingSetting,
     SynchronizationRule,
@@ -67,6 +68,10 @@ export default class SyncRule {
 
     public get dataSyncOrgUnitPaths(): string[] {
         return this.syncRule.builder.dataParams?.orgUnitPaths ?? [];
+    }
+
+    public get dataSyncPeriod(): DataSyncPeriod {
+        return this.syncRule.builder.dataParams?.period ?? "ALL";
     }
 
     public get dataSyncStartDate(): Date | null {
@@ -280,6 +285,19 @@ export default class SyncRule {
         });
     }
 
+    public updateDataSyncPeriod(period?: DataSyncPeriod): SyncRule {
+        return SyncRule.build({
+            ...this.syncRule,
+            builder: {
+                ...this.syncRule.builder,
+                dataParams: {
+                    ...this.syncRule.builder.dataParams,
+                    period,
+                },
+            },
+        });
+    }
+
     public updateDataSyncStartDate(startDate?: Date): SyncRule {
         return SyncRule.build({
             ...this.syncRule,
@@ -457,7 +475,7 @@ export default class SyncRule {
                     : null,
             ]),
             dataSyncStartDate: _.compact([
-                this.type === "aggregated" && !this.dataSyncStartDate
+                this.dataSyncPeriod === "FIXED" && !this.dataSyncStartDate
                     ? {
                           key: "cannot_be_empty",
                           namespace: { element: "start date" },
@@ -465,13 +483,13 @@ export default class SyncRule {
                     : null,
             ]),
             dataSyncEndDate: _.compact([
-                this.type === "aggregated" && !this.dataSyncEndDate
+                this.dataSyncPeriod === "FIXED" && !this.dataSyncEndDate
                     ? {
                           key: "cannot_be_empty",
                           namespace: { element: "end date" },
                       }
                     : null,
-                this.type === "aggregated" &&
+                this.dataSyncPeriod === "FIXED" &&
                 this.dataSyncEndDate &&
                 this.dataSyncStartDate &&
                 moment(this.dataSyncEndDate).isBefore(this.dataSyncStartDate)

--- a/src/types/synchronization.d.ts
+++ b/src/types/synchronization.d.ts
@@ -25,6 +25,7 @@ export interface MetadataSynchronizationParams extends MetadataImportParams {
 
 export interface DataSynchronizationParams extends DataImportParams {
     orgUnitPaths?: string[];
+    period?: DataSyncPeriod;
     startDate?: Date;
     endDate?: Date;
     events?: string[];
@@ -159,3 +160,13 @@ export interface DataValue {
     lastUpdated: string;
     followUp: boolean;
 }
+
+export type DataSyncPeriod =
+    | "ALL"
+    | "FIXED"
+    | "LAST_DAY"
+    | "LAST_WEEK"
+    | "LAST_MONTH"
+    | "LAST_THREE_MONTHS"
+    | "LAST_SIX_MONTHS"
+    | "LAST_YEAR";

--- a/src/utils/synchronization.ts
+++ b/src/utils/synchronization.ts
@@ -2,25 +2,25 @@ import axios, { AxiosBasicCredentials } from "axios";
 import { D2Api } from "d2-api";
 import { isValidUid } from "d2/uid";
 import _ from "lodash";
+import moment, { Moment } from "moment";
+import memoize from "nano-memoize";
 import Instance from "../models/instance";
 import {
     D2,
-    MetadataImportParams,
-    MetadataImportResponse,
     DataImportParams,
     DataImportResponse,
+    MetadataImportParams,
+    MetadataImportResponse,
 } from "../types/d2";
 import {
     DataSynchronizationParams,
     MetadataPackage,
     NestedRules,
-    SynchronizationResult,
     ProgramEvent,
+    SynchronizationResult,
 } from "../types/synchronization";
 import "../utils/lodash-mixins";
 import { cleanModelName, getClassName } from "./d2";
-import moment from "moment";
-import memoize from "nano-memoize";
 
 const blacklistedProperties = ["access"];
 const userProperties = ["user", "userAccesses", "userGroupAccesses"];
@@ -208,13 +208,37 @@ export function cleanDataImportResponse(
     };
 }
 
+function buildPeriodFromParams(params: DataSynchronizationParams): [Moment, Moment] {
+    const { period, startDate = "1970-01-01", endDate = moment().format("YYYY-MM-DD") } = params;
+
+    switch (period) {
+        case "LAST_DAY":
+            return [moment().subtract(1, "day"), moment()];
+        case "LAST_WEEK":
+            return [moment().subtract(1, "week"), moment()];
+        case "LAST_MONTH":
+            return [moment().subtract(1, "month"), moment()];
+        case "LAST_THREE_MONTHS":
+            return [moment().subtract(3, "months"), moment()];
+        case "LAST_SIX_MONTHS":
+            return [moment().subtract(6, "months"), moment()];
+        case "LAST_YEAR":
+            return [moment().subtract(1, "year"), moment()];
+        default:
+        case "ALL":
+        case "FIXED":
+            return [moment(startDate), moment(endDate)];
+    }
+}
+
 export async function getAggregatedData(
     api: D2Api,
     params: DataSynchronizationParams,
     dataSet: string[] = [],
     dataElementGroup: string[] = []
 ) {
-    const { startDate, endDate, orgUnitPaths = [] } = params;
+    const { orgUnitPaths = [] } = params;
+    const [startDate, endDate] = buildPeriodFromParams(params);
 
     if (dataSet.length === 0 && dataElementGroup.length === 0) return {};
 
@@ -226,8 +250,8 @@ export async function getAggregatedData(
             orgUnitIdScheme: "UID",
             categoryOptionComboIdScheme: "UID",
             includeDeleted: false,
-            startDate: moment(startDate).format("YYYY-MM-DD"),
-            endDate: moment(endDate).format("YYYY-MM-DD"),
+            startDate: startDate.format("YYYY-MM-DD"),
+            endDate: endDate.format("YYYY-MM-DD"),
             dataSet,
             dataElementGroup,
             orgUnit,
@@ -265,7 +289,8 @@ export async function getEventsData(
     params: DataSynchronizationParams,
     programs: string[] = []
 ) {
-    const { startDate, endDate, orgUnitPaths = [], events = [], allEvents } = params;
+    const { period, orgUnitPaths = [], events = [], allEvents } = params;
+    const [startDate, endDate] = buildPeriodFromParams(params);
     const defaults = await getDefaultIds(api);
 
     if (programs.length === 0) return [];
@@ -279,8 +304,8 @@ export async function getEventsData(
             .get("/events", {
                 paging: false,
                 program,
-                startDate: startDate ? moment(startDate).format("YYYY-MM-DD") : undefined,
-                endDate: endDate ? moment(endDate).format("YYYY-MM-DD") : undefined,
+                startDate: period !== "ALL" ? startDate.format("YYYY-MM-DD") : undefined,
+                endDate: period !== "ALL" ? endDate.format("YYYY-MM-DD") : undefined,
             })
             .getData()) as { events: (ProgramEvent & { event: string })[] };
 


### PR DESCRIPTION
### :pushpin: References

* **Issue:** Closes #239 

### :memo: Implementation

- Add dropdown in "Period" step for both aggregated and events
- Calculate startDate and endDate from the dropdown selection
- Delegate filtering to DHIS2 api endpoints

### :art: Screenshots

![image](https://user-images.githubusercontent.com/2181866/71571316-f67edb00-2ad9-11ea-9b57-268053fcdb7f.png)
![image](https://user-images.githubusercontent.com/2181866/71571321-fe3e7f80-2ad9-11ea-84b7-839206ef6ae7.png)
![image](https://user-images.githubusercontent.com/2181866/71571327-0696ba80-2ada-11ea-91ba-451671715c3a.png)
![image](https://user-images.githubusercontent.com/2181866/71571330-0c8c9b80-2ada-11ea-8970-48cdce11e583.png)

### :fire: Is there anything the reviewer should know to test it?

- We can verify that the dates are correctly calculated in the network call (we are not doing any kind of filtering in the app).

### :bookmark_tabs: Others
