### PR TITLE
[Feature] Add attribute category option step

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2019-12-30T07:57:33.732Z\n"
-"PO-Revision-Date: 2019-12-30T07:57:33.732Z\n"
+"POT-Creation-Date: 2019-12-30T12:41:57.453Z\n"
+"PO-Revision-Date: 2019-12-30T12:41:57.453Z\n"
 
 msgid "Search by name"
 msgstr ""
@@ -311,6 +311,12 @@ msgstr ""
 msgid "Yes"
 msgstr ""
 
+msgid "Start date"
+msgstr ""
+
+msgid "End date"
+msgstr ""
+
 msgid "Target instances [{{total}}]"
 msgstr ""
 
@@ -381,12 +387,6 @@ msgid "Last six months"
 msgstr ""
 
 msgid "Last year"
-msgstr ""
-
-msgid "Start date"
-msgstr ""
-
-msgid "End date"
 msgstr ""
 
 msgid "Retrieving information from remote instances"

--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2019-12-25T08:43:28.148Z\n"
-"PO-Revision-Date: 2019-12-25T08:43:28.148Z\n"
+"POT-Creation-Date: 2019-12-30T07:57:33.732Z\n"
+"PO-Revision-Date: 2019-12-30T07:57:33.732Z\n"
 
 msgid "Search by name"
 msgstr ""
@@ -333,6 +333,9 @@ msgid "Save"
 msgstr ""
 
 msgid "Download JSON"
+msgstr ""
+
+msgid "Sync all attribute category options"
 msgstr ""
 
 msgid "UID"

--- a/src/components/sync-wizard/Steps.ts
+++ b/src/components/sync-wizard/Steps.ts
@@ -1,14 +1,15 @@
+import i18n from "@dhis2/d2-i18n";
 import { ReactNode } from "react";
-import i18n from "../../locales";
+import SyncRule from "../../models/syncRule";
 import GeneralInfoStep from "./common/GeneralInfoStep";
 import InstanceSelectionStep from "./common/InstanceSelectionStep";
-import SummaryStep from "./common/SummaryStep";
-import SchedulerStep from "./common/SchedulerStep";
-import CategoryOptionsSelectionStep from "./data/CategoryOptionsSelectionStep";
 import MetadataSelectionStep from "./common/MetadataSelectionStep";
+import SchedulerStep from "./common/SchedulerStep";
+import SummaryStep from "./common/SummaryStep";
+import CategoryOptionsSelectionStep from "./data/CategoryOptionsSelectionStep";
+import EventsSelectionStep from "./data/EventsSelectionStep";
 import OrganisationUnitsSelectionStep from "./data/OrganisationUnitsSelectionStep";
 import PeriodSelectionStep from "./data/PeriodSelectionStep";
-import EventsSelectionStep from "./data/EventsSelectionStep";
 
 export interface SyncWizardStep {
     key: string;
@@ -19,6 +20,11 @@ export interface SyncWizardStep {
     component: ReactNode;
     validationKeys: string[];
     showOnSyncDialog?: boolean;
+}
+
+export interface SyncWizardStepProps {
+    syncRule: SyncRule;
+    onChange: (syncRule: SyncRule) => void;
 }
 
 const commonSteps: {

--- a/src/components/sync-wizard/common/MetadataSelectionStep.tsx
+++ b/src/components/sync-wizard/common/MetadataSelectionStep.tsx
@@ -10,13 +10,8 @@ import {
     ProgramModel,
 } from "../../../models/d2Model";
 import { metadataModels } from "../../../models/d2ModelFactory";
-import SyncRule from "../../../models/syncRule";
 import MetadataTable from "../../metadata-table/MetadataTable";
-
-interface MetadataSelectionStepProps {
-    syncRule: SyncRule;
-    onChange: (syncRule: SyncRule) => void;
-}
+import { SyncWizardStepProps } from "../Steps";
 
 const config = {
     metadata: {
@@ -38,7 +33,7 @@ const config = {
     },
 };
 
-export default function MetadataSelectionStep(props: MetadataSelectionStepProps) {
+export default function MetadataSelectionStep(props: SyncWizardStepProps) {
     const { syncRule, onChange } = props;
     const { models, childrenKeys } = config[syncRule.type];
 

--- a/src/components/sync-wizard/data/CategoryOptionsSelectionStep.tsx
+++ b/src/components/sync-wizard/data/CategoryOptionsSelectionStep.tsx
@@ -1,5 +1,64 @@
-import React from "react";
+import i18n from "@dhis2/d2-i18n";
+import { useD2, useD2Api, useD2ApiData } from "d2-api";
+import { MultiSelector } from "d2-ui-components";
+import _ from "lodash";
+import React, { useMemo } from "react";
+import { Toggle } from "../../toggle/Toggle";
+import { SyncWizardStepProps } from "../Steps";
 
-export default function CategoryOptionsSelectionStep() {
-    return <div></div>;
-}
+const CategoryOptionsSelectionStep: React.FC<SyncWizardStepProps> = ({ syncRule, onChange }) => {
+    const d2 = useD2();
+    const api = useD2Api();
+
+    const changeAttributeCategoryOptions = (attributeCategoryOptions: string[]) => {
+        onChange(syncRule.updateDataSyncAttributeCategoryOptions(attributeCategoryOptions));
+    };
+
+    const updateSyncAll = (value: boolean) => {
+        onChange(
+            syncRule
+                .updateDataSyncAllAttributeCategoryOptions(value)
+                .updateDataSyncAttributeCategoryOptions(undefined)
+        );
+    };
+
+    const { data } = useD2ApiData(
+        api.models.categoryOptionCombos.get({
+            paging: false,
+            fields: { id: true, name: true },
+            filter: {
+                "categoryCombo.dataDimensionType": { eq: "ATTRIBUTE" },
+            },
+        })
+    );
+
+    const options = useMemo(
+        () =>
+            _.map(data?.objects ?? [], ({ id, name }) => ({
+                value: id,
+                text: `${name} (${id})`,
+            })),
+        [data]
+    );
+
+    return (
+        <React.Fragment>
+            <Toggle
+                label={i18n.t("Sync all attribute category options")}
+                value={syncRule.dataSyncAllAttributeCategoryOptions}
+                onValueChange={updateSyncAll}
+            />
+            {!syncRule.dataSyncAllAttributeCategoryOptions && (
+                <MultiSelector
+                    d2={d2}
+                    height={300}
+                    onChange={changeAttributeCategoryOptions}
+                    options={options}
+                    selected={syncRule.dataSyncAttributeCategoryOptions}
+                />
+            )}
+        </React.Fragment>
+    );
+};
+
+export default CategoryOptionsSelectionStep;

--- a/src/components/sync-wizard/data/CategoryOptionsSelectionStep.tsx
+++ b/src/components/sync-wizard/data/CategoryOptionsSelectionStep.tsx
@@ -9,7 +9,9 @@ import { SyncWizardStepProps } from "../Steps";
 const CategoryOptionsSelectionStep: React.FC<SyncWizardStepProps> = ({ syncRule, onChange }) => {
     const d2 = useD2();
     const api = useD2Api();
-    const [selection, updateSelection] = useState<string[]>(syncRule.dataSyncAttributeCategoryOptions);
+    const [selection, updateSelection] = useState<string[]>(
+        syncRule.dataSyncAttributeCategoryOptions
+    );
 
     const updateSyncAll = (value: boolean) => {
         onChange(
@@ -30,7 +32,11 @@ const CategoryOptionsSelectionStep: React.FC<SyncWizardStepProps> = ({ syncRule,
     );
 
     const options = useMemo(
-        () => _.uniqBy(_.map(data?.objects ?? [], ({ name }) => ({ value: name, text: name })), "value"),
+        () =>
+            _.uniqBy(
+                _.map(data?.objects ?? [], ({ name }) => ({ value: name, text: name })),
+                "value"
+            ),
         [data]
     );
 

--- a/src/components/sync-wizard/data/EventsSelectionStep.tsx
+++ b/src/components/sync-wizard/data/EventsSelectionStep.tsx
@@ -3,16 +3,10 @@ import { useD2Api } from "d2-api";
 import { ObjectsTable, TableState } from "d2-ui-components";
 import _ from "lodash";
 import React, { useEffect, useState } from "react";
-import SyncRule from "../../../models/syncRule";
 import { ProgramEvent } from "../../../types/synchronization";
 import { getEventsData } from "../../../utils/synchronization";
 import { Toggle } from "../../toggle/Toggle";
-
-interface EventsSelectionStepProps {
-    syncRule: SyncRule;
-    onChange: (syncRule: SyncRule) => void;
-    type: "dataElements" | "programs";
-}
+import { SyncWizardStepProps } from "../Steps";
 
 const columns = [
     { name: "id" as const, text: i18n.t("UID"), sortable: true },
@@ -34,7 +28,7 @@ const details = [
     { name: "storedBy" as const, text: i18n.t("Stored by") },
 ];
 
-export default function EventsSelectionStep({ syncRule, onChange }: EventsSelectionStepProps) {
+export default function EventsSelectionStep({ syncRule, onChange }: SyncWizardStepProps) {
     const api = useD2Api();
     const [objects, setObjects] = useState<ProgramEvent[]>([]);
 

--- a/src/components/sync-wizard/data/OrganisationUnitsSelectionStep.tsx
+++ b/src/components/sync-wizard/data/OrganisationUnitsSelectionStep.tsx
@@ -1,21 +1,13 @@
-import React, { useEffect, useState } from "react";
-import { withSnackbar, OrgUnitsSelector } from "d2-ui-components";
-import SyncRule from "../../../models/syncRule";
-import { D2 } from "../../../types/d2";
-import { getCurrentUserOrganisationUnits } from "../../../utils/d2";
-import _ from "lodash";
 import CircularProgress from "@material-ui/core/CircularProgress";
 import { useD2 } from "d2-api";
+import { OrgUnitsSelector, withSnackbar } from "d2-ui-components";
+import _ from "lodash";
+import React, { useEffect, useState } from "react";
+import { D2 } from "../../../types/d2";
+import { getCurrentUserOrganisationUnits } from "../../../utils/d2";
+import { SyncWizardStepProps } from "../Steps";
 
-interface OrganisationUnitsStepProps {
-    syncRule: SyncRule;
-    onChange: (syncRule: SyncRule) => void;
-}
-
-const OrganisationUnitsSelectionStep: React.FC<OrganisationUnitsStepProps> = ({
-    syncRule,
-    onChange,
-}) => {
+const OrganisationUnitsSelectionStep: React.FC<SyncWizardStepProps> = ({ syncRule, onChange }) => {
     const d2 = useD2();
     const [organisationUnitsRootIds, setOrganisationUnitsRootIds] = useState<string[]>([]);
 

--- a/src/components/sync-wizard/data/PeriodSelectionStep.tsx
+++ b/src/components/sync-wizard/data/PeriodSelectionStep.tsx
@@ -1,16 +1,9 @@
 import i18n from "@dhis2/d2-i18n";
 import { DatePicker } from "d2-ui-components";
 import React from "react";
-import SyncRule from "../../../models/syncRule";
+import { SyncWizardStepProps } from "../Steps";
 
-interface PeriodSelectionStepProps {
-    syncRule: SyncRule;
-    onChange: (syncRule: SyncRule) => void;
-}
-
-export default function PeriodSelectionStep(props: PeriodSelectionStepProps) {
-    const { syncRule, onChange } = props;
-
+const PeriodSelectionStep: React.FC<SyncWizardStepProps> = ({ syncRule, onChange }) => {
     const updateStartDate = (date: Date | null) => {
         onChange(syncRule.updateDataSyncStartDate(date ?? undefined).updateDataSyncEvents([]));
     };
@@ -39,4 +32,6 @@ export default function PeriodSelectionStep(props: PeriodSelectionStepProps) {
             </div>
         </React.Fragment>
     );
-}
+};
+
+export default PeriodSelectionStep;

--- a/src/models/syncRule.ts
+++ b/src/models/syncRule.ts
@@ -65,6 +65,14 @@ export default class SyncRule {
         return this.syncRule.builder.metadataIds;
     }
 
+    public get dataSyncAttributeCategoryOptions(): string[] {
+        return this.syncRule.builder.dataParams?.attributeCategoryOptions ?? [];
+    }
+
+    public get dataSyncAllAttributeCategoryOptions(): boolean {
+        return this.syncRule.builder.dataParams?.allAttributeCategoryOptions ?? false;
+    }
+
     public get dataSyncOrgUnitPaths(): string[] {
         return this.syncRule.builder.dataParams?.orgUnitPaths ?? [];
     }
@@ -148,9 +156,6 @@ export default class SyncRule {
                 metadataIds: [],
                 dataParams: {
                     strategy: "NEW_AND_UPDATES",
-                    orgUnitPaths: [],
-                    startDate: undefined,
-                    endDate: undefined,
                 },
                 syncParams: {
                     importStrategy: "CREATE_AND_UPDATE",
@@ -263,6 +268,34 @@ export default class SyncRule {
             builder: {
                 ...this.syncRule.builder,
                 metadataIds,
+            },
+        });
+    }
+
+    public updateDataSyncAttributeCategoryOptions(attributeCategoryOptions?: string[]): SyncRule {
+        return SyncRule.build({
+            ...this.syncRule,
+            builder: {
+                ...this.syncRule.builder,
+                dataParams: {
+                    ...this.syncRule.builder.dataParams,
+                    attributeCategoryOptions,
+                },
+            },
+        });
+    }
+
+    public updateDataSyncAllAttributeCategoryOptions(
+        allAttributeCategoryOptions?: boolean
+    ): SyncRule {
+        return SyncRule.build({
+            ...this.syncRule,
+            builder: {
+                ...this.syncRule.builder,
+                dataParams: {
+                    ...this.syncRule.builder.dataParams,
+                    allAttributeCategoryOptions,
+                },
             },
         });
     }

--- a/src/models/syncRule.ts
+++ b/src/models/syncRule.ts
@@ -161,6 +161,7 @@ export default class SyncRule {
                 metadataIds: [],
                 dataParams: {
                     strategy: "NEW_AND_UPDATES",
+                    allAttributeCategoryOptions: true,
                 },
                 syncParams: {
                     importStrategy: "CREATE_AND_UPDATE",

--- a/src/types/synchronization.d.ts
+++ b/src/types/synchronization.d.ts
@@ -24,6 +24,8 @@ export interface MetadataSynchronizationParams extends MetadataImportParams {
 }
 
 export interface DataSynchronizationParams extends DataImportParams {
+    attributeCategoryOptions?: string[];
+    allAttributeCategoryOptions?: boolean;
     orgUnitPaths?: string[];
     startDate?: Date;
     endDate?: Date;

--- a/src/utils/synchronization.ts
+++ b/src/utils/synchronization.ts
@@ -244,9 +244,7 @@ export async function getAggregatedData(
     dataSet: string[] = [],
     dataElementGroup: string[] = []
 ) {
-
-    const { orgUnitPaths = [], allAttributeCategoryOptions,
-        attributeCategoryOptions, } = params;
+    const { orgUnitPaths = [], allAttributeCategoryOptions, attributeCategoryOptions } = params;
     const [startDate, endDate] = buildPeriodFromParams(params);
 
     if (dataSet.length === 0 && dataElementGroup.length === 0) return {};
@@ -264,7 +262,7 @@ export async function getAggregatedData(
             includeDeleted: false,
             startDate: startDate.format("YYYY-MM-DD"),
             endDate: endDate.format("YYYY-MM-DD"),
-                        attributeOptionCombo,
+            attributeOptionCombo,
             dataSet,
             dataElementGroup,
             orgUnit,

--- a/src/utils/synchronization.ts
+++ b/src/utils/synchronization.ts
@@ -214,11 +214,20 @@ export async function getAggregatedData(
     dataSet: string[] = [],
     dataElementGroup: string[] = []
 ) {
-    const { startDate, endDate, orgUnitPaths = [] } = params;
+    const {
+        startDate,
+        endDate,
+        orgUnitPaths = [],
+        allAttributeCategoryOptions,
+        attributeCategoryOptions,
+    } = params;
 
     if (dataSet.length === 0 && dataElementGroup.length === 0) return {};
 
     const orgUnit = _.compact(orgUnitPaths.map(path => _.last(path.split("/"))));
+    const attributeOptionCombo = !allAttributeCategoryOptions
+        ? attributeCategoryOptions
+        : undefined;
 
     return api
         .get("/dataValueSets", {
@@ -228,6 +237,7 @@ export async function getAggregatedData(
             includeDeleted: false,
             startDate: moment(startDate).format("YYYY-MM-DD"),
             endDate: moment(endDate).format("YYYY-MM-DD"),
+            attributeOptionCombo,
             dataSet,
             dataElementGroup,
             orgUnit,


### PR DESCRIPTION
### :pushpin: References

* **Issue:** Closes #171 

### :memo: Implementation

- Add new Category Option Selection Step
- As discussed, for simplicity we are only filtering "attributeCategoryOption" for now.
- Also as discussed, not yet implemented for events as it requires to gather feedback from client and understand the real needs.

### :art: Screenshots

![image](https://user-images.githubusercontent.com/2181866/71573215-fdf6b200-2ae2-11ea-95d3-12e15a03c4e2.png)
![image](https://user-images.githubusercontent.com/2181866/71573225-0818b080-2ae3-11ea-82ef-c24f259dfbb2.png)

### :fire: Is there anything the reviewer should know to test it?

- In the network tab we can validate that filtering is applied (example dataset: Drug distribution HMO23)

### :bookmark_tabs: Others

- Since category option combos name is not unique, we have the following as name ``Display Name (UID)``. 