### PR TITLE
[Bugfix] Clear selection on delete history page

### DIFF
--- a/src/pages/history/HistoryPage.tsx
+++ b/src/pages/history/HistoryPage.tsx
@@ -93,7 +93,7 @@ const HistoryPage: React.FC<{ loading: any }> = ({ loading }) => {
                 { type, statusFilter, syncRuleFilter },
                 tableState ?? initialState
             ).then(updateResponse);
-            updateSelection(tableState?.selection ?? []);
+            updateSelection(selection => tableState?.selection ?? selection);
         },
         [d2, statusFilter, syncRuleFilter, type, updateSelection]
     );
@@ -106,7 +106,7 @@ const HistoryPage: React.FC<{ loading: any }> = ({ loading }) => {
     }, [d2, id, type]);
 
     useEffect(() => {
-        updateTable({ selection });
+        updateTable();
     }, [d2, updateTable, toDelete]);
 
     const columns: TableColumn<SynchronizationReport>[] = [

--- a/src/pages/history/HistoryPage.tsx
+++ b/src/pages/history/HistoryPage.tsx
@@ -75,6 +75,7 @@ const HistoryPage: React.FC<{ loading: any }> = ({ loading }) => {
     const [syncRules, setSyncRules] = useState<SynchronizationRule[]>([]);
     const [syncReport, setSyncReport] = useState<SyncReport | null>(null);
     const [toDelete, setToDelete] = useState<SynchronizationReport[]>([]);
+    const [selection, updateSelection] = useState<string[]>([]);
     const [response, updateResponse] = useState<{
         rows: SynchronizationReport[];
         pager: Partial<TablePagination>;
@@ -86,14 +87,15 @@ const HistoryPage: React.FC<{ loading: any }> = ({ loading }) => {
     const goBack = () => history.goBack();
 
     const updateTable = useCallback(
-        (tableState?: TableState<SynchronizationReport>) => {
+        (tableState?: Partial<TableState<SynchronizationReport>>) => {
             SyncReport.list(
                 d2 as D2,
                 { type, statusFilter, syncRuleFilter },
                 tableState ?? initialState
             ).then(updateResponse);
+            updateSelection(tableState?.selection ?? []);
         },
-        [d2, statusFilter, syncRuleFilter, type]
+        [d2, statusFilter, syncRuleFilter, type, updateSelection]
     );
 
     useEffect(() => {
@@ -104,7 +106,7 @@ const HistoryPage: React.FC<{ loading: any }> = ({ loading }) => {
     }, [d2, id, type]);
 
     useEffect(() => {
-        updateTable();
+        updateTable({ selection });
     }, [d2, updateTable, toDelete]);
 
     const columns: TableColumn<SynchronizationReport>[] = [
@@ -202,6 +204,7 @@ const HistoryPage: React.FC<{ loading: any }> = ({ loading }) => {
             );
         }
 
+        updateSelection([]);
         setToDelete([]);
     };
 
@@ -233,6 +236,7 @@ const HistoryPage: React.FC<{ loading: any }> = ({ loading }) => {
                 details={details}
                 initialState={{ sorting: { field: "date", order: "desc" } }}
                 pagination={response.pager}
+                selection={selection}
                 actions={actions}
                 filterComponents={customFilters}
                 onChange={updateTable}

--- a/src/pages/history/HistoryPage.tsx
+++ b/src/pages/history/HistoryPage.tsx
@@ -93,7 +93,7 @@ const HistoryPage: React.FC<{ loading: any }> = ({ loading }) => {
                 { type, statusFilter, syncRuleFilter },
                 tableState ?? initialState
             ).then(updateResponse);
-            updateSelection(selection => tableState?.selection ?? selection);
+            updateSelection(oldSelection => tableState?.selection ?? oldSelection);
         },
         [d2, statusFilter, syncRuleFilter, type, updateSelection]
     );

--- a/src/pages/history/HistoryPage.tsx
+++ b/src/pages/history/HistoryPage.tsx
@@ -87,7 +87,7 @@ const HistoryPage: React.FC<{ loading: any }> = ({ loading }) => {
     const goBack = () => history.goBack();
 
     const updateTable = useCallback(
-        (tableState?: Partial<TableState<SynchronizationReport>>) => {
+        (tableState?: TableState<SynchronizationReport>) => {
             SyncReport.list(
                 d2 as D2,
                 { type, statusFilter, syncRuleFilter },


### PR DESCRIPTION
### :pushpin: References

* **Issue:** Closes #274 

### :memo: Implementation

- Clear selection after delete

### :art: Screenshots


### :fire: Is there anything the reviewer should know to test it?

Steps to reproduce bug:

- Select one item in any History page
- Delete the history entry
- Selection is still available in other pages

### :bookmark_tabs: Others
