### PR TITLE
Add replicate and update default table actions

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2019-12-30T12:41:57.453Z\n"
-"PO-Revision-Date: 2019-12-30T12:41:57.453Z\n"
+"POT-Creation-Date: 2019-12-31T21:54:43.700Z\n"
+"PO-Revision-Date: 2019-12-31T21:54:43.700Z\n"
 
 msgid "Search by name"
 msgstr ""
@@ -529,6 +529,9 @@ msgid "Saving..."
 msgstr ""
 
 msgid "Edit"
+msgstr ""
+
+msgid "Replicate"
 msgstr ""
 
 msgid "Deleting Instances"

--- a/src/models/instance.ts
+++ b/src/models/instance.ts
@@ -34,6 +34,10 @@ export default class Instance {
         this.api = new D2ApiDefault({ baseUrl, auth: { username, password } });
     }
 
+    public replicate(): Instance {
+        return this.setName(`Copy of ${this.data.name}`).setId(generateUid());
+    }
+
     public get id(): string {
         return this.data.id;
     }

--- a/src/models/syncRule.ts
+++ b/src/models/syncRule.ts
@@ -46,6 +46,14 @@ export default class SyncRule {
         };
     }
 
+    public replicate(): SyncRule {
+        return this.updateName(`Copy of ${this.syncRule.name}`).updateId(generateUid());
+    }
+
+    public get id(): string {
+        return this.syncRule.id ?? "";
+    }
+
     public get name(): string {
         return this.syncRule.name;
     }
@@ -245,6 +253,13 @@ export default class SyncRule {
         const objects = _.slice(filteredObjects, firstItem, lastItem);
 
         return { objects, pager: { page, pageCount, total } };
+    }
+
+    public updateId(id: string): SyncRule {
+        return SyncRule.build({
+            ...this.syncRule,
+            id,
+        });
     }
 
     public updateName(name: string): SyncRule {

--- a/src/pages/history/HistoryPage.tsx
+++ b/src/pages/history/HistoryPage.tsx
@@ -179,6 +179,7 @@ const HistoryPage: React.FC<{ loading: any }> = ({ loading }) => {
             text: i18n.t("View summary"),
             icon: <DescriptionIcon />,
             multiple: false,
+            primary: true,
             onClick: ([data]) => !!data && setSyncReport(SyncReport.build(data)),
         },
     ];

--- a/src/pages/instance-creation/InstanceCreationPage.jsx
+++ b/src/pages/instance-creation/InstanceCreationPage.jsx
@@ -24,9 +24,12 @@ class InstanceCreationPage extends React.Component {
     isEdit = this.props.match.params.action === "edit" && this.id;
 
     componentDidMount = async () => {
+        const { instance: stateInstance } = this.props.location.state ?? {};
         if (this.isEdit) {
             const instance = await Instance.get(this.props.d2, this.id);
             this.setState({ instance });
+        } else if (stateInstance) {
+            this.setState({ instance: stateInstance });
         }
     };
 

--- a/src/pages/instance-list/InstanceListPage.jsx
+++ b/src/pages/instance-list/InstanceListPage.jsx
@@ -54,7 +54,17 @@ class InstancesPage extends React.Component {
     };
 
     editInstance = instance => {
-        this.props.history.push(`/instance-configurator/edit/${instance.id}`);
+        if (this.state.appConfigurator)
+            this.props.history.push(`/instance-configurator/edit/${instance.id}`);
+    };
+
+    replicateInstance = async data => {
+        const { history } = this.props;
+        const instance = await Instance.build(data);
+        history.push({
+            pathname: "/instance-configurator/new",
+            state: { instance: instance.replicate() },
+        });
     };
 
     testConnection = async instanceData => {
@@ -85,7 +95,15 @@ class InstancesPage extends React.Component {
             text: i18n.t("Edit"),
             multiple: false,
             isActive: () => this.state.appConfigurator,
+            isPrimary: true,
             onClick: this.editInstance,
+        },
+        {
+            name: "replicate",
+            text: i18n.t("Replicate"),
+            multiple: false,
+            onClick: this.replicateInstance,
+            icon: "content_copy",
         },
         {
             name: "delete",

--- a/src/pages/sync-rules-creation/SyncRulesCreationPage.tsx
+++ b/src/pages/sync-rules-creation/SyncRulesCreationPage.tsx
@@ -1,7 +1,7 @@
 import { useD2 } from "d2-api";
 import { ConfirmationDialog } from "d2-ui-components";
 import React, { useEffect, useState } from "react";
-import { useHistory, useParams } from "react-router-dom";
+import { useHistory, useParams, useLocation } from "react-router-dom";
 import PageHeader from "../../components/page-header/PageHeader";
 import SyncWizard from "../../components/sync-wizard/SyncWizard";
 import i18n from "../../locales";
@@ -9,12 +9,19 @@ import SyncRule from "../../models/syncRule";
 import { D2 } from "../../types/d2";
 import { SyncRuleType } from "../../types/synchronization";
 
+interface SyncRulesCreationParams {
+    id: string;
+    action: "edit" | "new";
+    type: SyncRuleType;
+}
+
 const SyncRulesCreation: React.FC = () => {
     const history = useHistory();
-    const { id, action, type } = useParams();
+    const location = useLocation();
+    const { id, action, type } = useParams() as SyncRulesCreationParams;
     const d2 = useD2();
     const [dialogOpen, updateDialogOpen] = useState(false);
-    const [syncRule, updateSyncRule] = useState(SyncRule.create(type as SyncRuleType | undefined));
+    const [syncRule, updateSyncRule] = useState(location.state?.syncRule ?? SyncRule.create(type));
     const isEdit = action === "edit" && !!id;
 
     const title = !isEdit

--- a/src/pages/sync-rules-list/SyncRulesListPage.jsx
+++ b/src/pages/sync-rules-list/SyncRulesListPage.jsx
@@ -225,6 +225,12 @@ class SyncRulesPage extends React.Component {
         history.push(`/sync-rules/${match.params.type}/edit/${rule.id}`);
     };
 
+    replicateRule = data => {
+        const { history, match } = this.props;
+        const syncRule = SyncRule.build(data).replicate();
+        history.push({ pathname: `/sync-rules/${match.params.type}/new`, state: { syncRule } });
+    };
+
     executeRule = async ({ builder, name, id: syncRule, type = "metadata" }) => {
         const { d2, loading } = this.props;
         const { api } = this.context;
@@ -338,6 +344,13 @@ class SyncRulesPage extends React.Component {
             multiple: false,
             onClick: this.downloadJSON,
             icon: "cloud_download",
+        },
+        {
+            name: "replicate",
+            text: i18n.t("Replicate"),
+            multiple: false,
+            onClick: this.replicateRule,
+            icon: "content_copy",
         },
         {
             name: "toggleEnable",


### PR DESCRIPTION
### :pushpin: References

* **Issue:** Works in #289 

### :memo: Implementation

- Add replicate contextual action to "SyncRules" and "Instances"
- Update default action in "Instances" page
- Update default action in "History" page

### :art: Screenshots

![image](https://user-images.githubusercontent.com/2181866/71644855-889c0480-2ccf-11ea-9761-11a929aa1c04.png)
![image](https://user-images.githubusercontent.com/2181866/71644857-8b96f500-2ccf-11ea-884e-20edff28c350.png)
![image](https://user-images.githubusercontent.com/2181866/71644859-92256c80-2ccf-11ea-8e98-bd5229081f0b.png)
![image](https://user-images.githubusercontent.com/2181866/71644861-95205d00-2ccf-11ea-8b32-6180af9e6569.png)

### :fire: Is there anything the reviewer should know to test it?


### :bookmark_tabs: Others
