### PR TITLE
Add more relative periods

### DIFF
--- a/src/components/sync-wizard/common/SummaryStep.jsx
+++ b/src/components/sync-wizard/common/SummaryStep.jsx
@@ -11,10 +11,9 @@ import { AggregatedSync } from "../../../logic/sync/aggregated";
 import { EventsSync } from "../../../logic/sync/events";
 import { MetadataSync } from "../../../logic/sync/metadata";
 import { getBaseUrl } from "../../../utils/d2";
-import { getMetadata } from "../../../utils/synchronization";
+import { availablePeriods, getMetadata } from "../../../utils/synchronization";
 import { getValidationMessages } from "../../../utils/validations";
 import { getInstances } from "./InstanceSelectionStep";
-import { availablePeriods } from "../data/PeriodSelectionStep";
 
 const LiEntry = ({ label, value, children }) => {
     return (
@@ -138,7 +137,7 @@ const SaveStep = ({ syncRule, classes, onCancel, loading }) => {
                 {syncRule.type !== "metadata" && (
                     <LiEntry
                         label={i18n.t("Period")}
-                        value={_.find(availablePeriods, { id: syncRule.dataSyncPeriod })?.name}
+                        value={availablePeriods[syncRule.dataSyncPeriod]?.name}
                     >
                         {syncRule.dataSyncPeriod === "FIXED" && (
                             <ul>

--- a/src/components/sync-wizard/data/PeriodSelectionStep.tsx
+++ b/src/components/sync-wizard/data/PeriodSelectionStep.tsx
@@ -1,8 +1,10 @@
 import i18n from "@dhis2/d2-i18n";
 import { makeStyles } from "@material-ui/core";
 import { DatePicker } from "d2-ui-components";
+import _ from "lodash";
 import React from "react";
 import { DataSyncPeriod } from "../../../types/synchronization";
+import { availablePeriods } from "../../../utils/synchronization";
 import Dropdown from "../../dropdown/Dropdown";
 import { SyncWizardStepProps } from "../Steps";
 
@@ -19,17 +21,6 @@ const useStyles = makeStyles({
         marginTop: -10,
     },
 });
-
-export const availablePeriods = [
-    { id: "ALL", name: i18n.t("All periods") },
-    { id: "FIXED", name: i18n.t("Fixed period") },
-    { id: "LAST_DAY", name: i18n.t("Last day") },
-    { id: "LAST_WEEK", name: i18n.t("Last week") },
-    { id: "LAST_MONTH", name: i18n.t("Last month") },
-    { id: "LAST_THREE_MONTHS", name: i18n.t("Last three months") },
-    { id: "LAST_SIX_MONTHS", name: i18n.t("Last six months") },
-    { id: "LAST_YEAR", name: i18n.t("Last year") },
-];
 
 const PeriodSelectionStep: React.FC<SyncWizardStepProps> = ({ syncRule, onChange }) => {
     const classes = useStyles();
@@ -52,12 +43,17 @@ const PeriodSelectionStep: React.FC<SyncWizardStepProps> = ({ syncRule, onChange
         onChange(syncRule.updateDataSyncEndDate(date ?? undefined).updateDataSyncEvents([]));
     };
 
+    const periodItems = _(availablePeriods)
+        .mapValues((value, key) => ({ ...value, id: key }))
+        .values()
+        .value();
+
     return (
         <React.Fragment>
             <div className={classes.dropdown}>
                 <Dropdown
                     label={i18n.t("Period")}
-                    items={availablePeriods}
+                    items={periodItems}
                     value={syncRule.dataSyncPeriod}
                     onValueChange={updatePeriod}
                     hideEmpty={true}

--- a/src/types/synchronization.d.ts
+++ b/src/types/synchronization.d.ts
@@ -1,15 +1,12 @@
 import { Ref } from "d2-api";
-
-import {
-    MetadataImportResponse,
-    MetadataImportStats,
-    MetadataImportParams,
-    DataImportParams,
-    DataImportResponse,
-    MetadataImportStatus,
-    DataImportStatus,
-} from "./d2";
 import SyncReport from "../models/syncReport";
+import {
+    DataImportParams,
+    DataImportStatus,
+    MetadataImportParams,
+    MetadataImportStats,
+    MetadataImportStatus,
+} from "./d2";
 
 export interface SynchronizationBuilder {
     targetInstances: string[];
@@ -177,9 +174,15 @@ export interface DataValue {
 export type DataSyncPeriod =
     | "ALL"
     | "FIXED"
-    | "LAST_DAY"
+    | "TODAY"
+    | "YESTERDAY"
+    | "LAST_7_DAYS"
+    | "LAST_14_DAYS"
+    | "THIS_WEEK"
     | "LAST_WEEK"
+    | "THIS_MONTH"
     | "LAST_MONTH"
-    | "LAST_THREE_MONTHS"
-    | "LAST_SIX_MONTHS"
+    | "THIS_QUARTER"
+    | "LAST_QUARTER"
+    | "THIS_YEAR"
     | "LAST_YEAR";


### PR DESCRIPTION
### :pushpin: References

* **Issue:** Work #289 
* **Issue:** Closes https://github.com/EyeSeeTea/metadata-synchronization-blessed/issues/28
* **Issue:** Closes https://github.com/EyeSeeTea/metadata-synchronization-blessed/issues/29

### :memo: Implementation

- Added more verbose periods

- **IMPORTANT**: I have removed the "last 6 months" and "this 6 months" options. MomentJS [does not have that periodicity](https://github.com/moment/moment/pull/1998) and it is not trivial to implement a solution bypassing MomentJS. If we deem necessary to have it we might discuss what rules could calculate the current half of the year and/or past half of the year without the library and maintaining valid dates.

### :art: Screenshots

![image](https://user-images.githubusercontent.com/2181866/71646035-4b407280-2ce1-11ea-96b8-dd88b2403695.png)
![image](https://user-images.githubusercontent.com/2181866/71646039-53001700-2ce1-11ea-8972-c17bd33fe76c.png)

### :fire: Is there anything the reviewer should know to test it?

I have executed a test method locally and returned this matrix for today.

```
[
    {
        "period": "ALL",
        "value": [
            "1970-01-01",
            "2030-12-31"
        ]
    },
    {
        "period": "TODAY",
        "value": [
            "2020-01-01",
            "2020-01-01"
        ]
    },
    {
        "period": "YESTERDAY",
        "value": [
            "2019-12-31",
            "2019-12-31"
        ]
    },
    {
        "period": "LAST_7_DAYS",
        "value": [
            "2019-12-25",
            "2020-01-01"
        ]
    },
    {
        "period": "LAST_14_DAYS",
        "value": [
            "2019-12-18",
            "2020-01-01"
        ]
    },
    {
        "period": "THIS_WEEK",
        "value": [
            "2019-12-30",
            "2020-01-05"
        ]
    },
    {
        "period": "LAST_WEEK",
        "value": [
            "2019-12-23",
            "2019-12-29"
        ]
    },
    {
        "period": "THIS_MONTH",
        "value": [
            "2020-01-01",
            "2020-01-31"
        ]
    },
    {
        "period": "LAST_MONTH",
        "value": [
            "2019-12-01",
            "2019-12-31"
        ]
    },
    {
        "period": "THIS_QUARTER",
        "value": [
            "2020-01-01",
            "2020-03-31"
        ]
    },
    {
        "period": "LAST_QUARTER",
        "value": [
            "2019-10-01",
            "2019-12-31"
        ]
    },
    {
        "period": "THIS_YEAR",
        "value": [
            "2020-01-01",
            "2020-12-31"
        ]
    },
    {
        "period": "LAST_YEAR",
        "value": [
            "2019-01-01",
            "2019-12-31"
        ]
    }
]
```

### :bookmark_tabs: Others

