### PR TITLE
[Feature] Add missing properties in wizard's summary step

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2020-01-02T17:19:20.540Z\n"
-"PO-Revision-Date: 2020-01-02T17:19:20.540Z\n"
+"POT-Creation-Date: 2020-01-06T10:43:29.235Z\n"
+"PO-Revision-Date: 2020-01-06T10:43:29.235Z\n"
 
 msgid "Search by name"
 msgstr ""
@@ -309,6 +309,18 @@ msgid ""
 msgstr ""
 
 msgid "Yes"
+msgstr ""
+
+msgid "All events"
+msgstr ""
+
+msgid "{{total}} selected events"
+msgstr ""
+
+msgid "Category Option Combo"
+msgstr ""
+
+msgid "All attribute category options"
 msgstr ""
 
 msgid "Start date"

--- a/src/components/sync-wizard/common/SummaryStep.jsx
+++ b/src/components/sync-wizard/common/SummaryStep.jsx
@@ -11,7 +11,7 @@ import { AggregatedSync } from "../../../logic/sync/aggregated";
 import { EventsSync } from "../../../logic/sync/events";
 import { MetadataSync } from "../../../logic/sync/metadata";
 import { getBaseUrl } from "../../../utils/d2";
-import { availablePeriods, getMetadata } from "../../../utils/synchronization";
+import { availablePeriods, cleanOrgUnitPaths, getMetadata } from "../../../utils/synchronization";
 import { getValidationMessages } from "../../../utils/validations";
 import { getInstances } from "./InstanceSelectionStep";
 
@@ -97,7 +97,12 @@ const SaveStep = ({ syncRule, classes, onCancel, loading }) => {
     };
 
     useEffect(() => {
-        getMetadata(getBaseUrl(d2), syncRule.metadataIds, "id,name").then(updateMetadata);
+        const ids = [
+            ...syncRule.metadataIds,
+            ...syncRule.dataSyncAttributeCategoryOptions,
+            ...cleanOrgUnitPaths(syncRule.dataSyncOrgUnitPaths),
+        ];
+        getMetadata(getBaseUrl(d2), ids, "id,name").then(updateMetadata);
         getInstances(d2).then(setInstanceOptions);
     }, [d2, syncRule]);
 
@@ -133,6 +138,26 @@ const SaveStep = ({ syncRule, classes, onCancel, loading }) => {
                         </ul>
                     </LiEntry>
                 ))}
+
+                {syncRule.type === "events" && (
+                    <LiEntry
+                        label={i18n.t("Events")}
+                        value={
+                            !!syncRule.dataSyncAllEvents
+                                ? i18n.t("All events")
+                                : i18n.t("{{total}} selected events", {
+                                      total: syncRule.dataSyncEvents.length,
+                                  })
+                        }
+                    />
+                )}
+
+                {syncRule.dataSyncAllAttributeCategoryOptions && (
+                    <LiEntry
+                        label={i18n.t("Category Option Combo")}
+                        value={i18n.t("All attribute category options")}
+                    />
+                )}
 
                 {syncRule.type !== "metadata" && (
                     <LiEntry

--- a/src/utils/synchronization.ts
+++ b/src/utils/synchronization.ts
@@ -276,7 +276,7 @@ export async function getAggregatedData(
 
     if (dataSet.length === 0 && dataElementGroup.length === 0) return {};
 
-    const orgUnit = _.compact(orgUnitPaths.map(path => _.last(path.split("/"))));
+    const orgUnit = cleanOrgUnitPaths(orgUnitPaths);
     const attributeOptionCombo = !allAttributeCategoryOptions
         ? attributeCategoryOptions
         : undefined;
@@ -322,6 +322,10 @@ export function cleanObjectDefault(object: ProgramEvent, defaults: string[]) {
     return _.pickBy(object, value => !defaults.includes(String(value))) as ProgramEvent;
 }
 
+export function cleanOrgUnitPaths(orgUnitPaths: string[]): string[] {
+    return _.compact(orgUnitPaths.map(path => _.last(path.split("/"))));
+}
+
 export async function getEventsData(
     api: D2Api,
     params: DataSynchronizationParams,
@@ -333,7 +337,7 @@ export async function getEventsData(
 
     if (programs.length === 0) return [];
 
-    const orgUnits = _.compact(orgUnitPaths.map(path => _.last(path.split("/"))));
+    const orgUnits = cleanOrgUnitPaths(orgUnitPaths);
 
     const result = [];
 


### PR DESCRIPTION
### :pushpin: References

* **Issue:** Closes #284 

### :memo: Implementation

- Add organisation units, category options and events to ``SummaryStep``

### :art: Screenshots

![image](https://user-images.githubusercontent.com/2181866/71813460-f18dce80-3079-11ea-8d5c-5363c6848c3e.png)
![image](https://user-images.githubusercontent.com/2181866/71813492-010d1780-307a-11ea-9010-0a05032e77a0.png)
![image](https://user-images.githubusercontent.com/2181866/71813500-09655280-307a-11ea-9c60-e83a19512112.png)

### :fire: Is there anything the reviewer should know to test it?


### :bookmark_tabs: Others
