### PR TITLE
Feature/refine permissions access

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "metadata-synchronization",
   "description": "Advanced metadata & data synchronization utility",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "license": "GPL-3.0",
   "author": "EyeSeeTea team",
   "homepage": ".",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "d2": "^31.1.1",
     "d2-api": "^0.1.0",
     "d2-manifest": "^1.0.0",
-    "d2-ui-components": "^1.1.0",
+    "d2-ui-components": "^1.1.1",
     "downshift": "^3.3.4",
     "enzyme": "^3.10.0",
     "enzyme-adapter-react-16": "^1.14.0",

--- a/src/pages/history/HistoryPage.tsx
+++ b/src/pages/history/HistoryPage.tsx
@@ -151,7 +151,7 @@ const HistoryPage: React.FC = () => {
             text: i18n.t("Sync Rule"),
             getValue: ({ syncRule: id }) => {
                 const syncRule = syncRules.find(e => e.id === id);
-                if (!syncRule) return null;
+                if (!appConfigurator || !syncRule) return null;
 
                 return (
                     <Link to={`/sync-rules/${type}/edit/${syncRule.id}`} target="_blank">

--- a/src/pages/history/HistoryPage.tsx
+++ b/src/pages/history/HistoryPage.tsx
@@ -29,6 +29,7 @@ import {
     SyncRuleType,
 } from "../../types/synchronization";
 import { getValueForCollection } from "../../utils/d2-ui-components";
+import { isAppConfigurator } from "../../utils/permissions";
 
 const config = {
     metadata: {
@@ -82,6 +83,7 @@ const HistoryPage: React.FC = () => {
         rows: SynchronizationReport[];
         pager: Partial<TablePagination>;
     }>({ rows: [], pager: initialState.pagination });
+    const [appConfigurator, setAppConfigurator] = useState(false);
 
     const [statusFilter, updateStatusFilter] = useState("");
     const [syncRuleFilter, updateSyncRuleFilter] = useState("");
@@ -105,6 +107,7 @@ const HistoryPage: React.FC = () => {
             setSyncRules(objects)
         );
         if (id) SyncReport.get(d2 as D2, id).then(setSyncReport);
+        isAppConfigurator(d2 as D2).then(setAppConfigurator);
     }, [d2, id, type]);
 
     useEffect(() => {
@@ -159,6 +162,10 @@ const HistoryPage: React.FC = () => {
         },
     ];
 
+    const verifyUserCanConfigure = () => {
+        return appConfigurator;
+    };
+
     const actions: TableAction<SynchronizationReport>[] = [
         {
             name: "details",
@@ -168,6 +175,7 @@ const HistoryPage: React.FC = () => {
         {
             name: "delete",
             text: i18n.t("Delete"),
+            isActive: verifyUserCanConfigure,
             icon: <DeleteIcon />,
             multiple: true,
             onClick: setToDelete,

--- a/src/pages/landing/LandingPage.tsx
+++ b/src/pages/landing/LandingPage.tsx
@@ -28,11 +28,11 @@ const LandingPage: React.FC = () => {
     const classes = useStyles();
     const history = useHistory();
     const [showDeletedObjects, setShowDeletedObjects] = useState(false);
-    const [showCreateLinks, setShowCreateLinks] = useState(false);
+    const [isConfiguratorRole, setIsConfiguratorRole] = useState(false);
 
     useEffect(() => {
         shouldShowDeletedObjects(d2 as D2).then(setShowDeletedObjects);
-        isAppConfigurator(d2 as D2).then(setShowCreateLinks);
+        isAppConfigurator(d2 as D2).then(setIsConfiguratorRole);
     }, [d2]);
 
     const cards: {
@@ -57,7 +57,7 @@ const LandingPage: React.FC = () => {
                     description: i18n.t(
                         "Create, modify, delete, execute and schedule sync rules for aggregated data by selecting the data sets, data elements or their groups and group sets together with the organisation unit, period and category options."
                     ),
-                    addAction: showCreateLinks
+                    addAction: isConfiguratorRole
                         ? () => history.push("/sync-rules/aggregated/new")
                         : undefined,
                     listAction: () => history.push("/sync-rules/aggregated"),
@@ -87,7 +87,7 @@ const LandingPage: React.FC = () => {
                     description: i18n.t(
                         "Create, modify, delete, execute and schedule sync rules for events by selecting the programs or events together with the organisation unit, period and category options."
                     ),
-                    addAction: showCreateLinks
+                    addAction: isConfiguratorRole
                         ? () => history.push("/sync-rules/events/new")
                         : undefined,
                     listAction: () => history.push("/sync-rules/events"),
@@ -117,7 +117,7 @@ const LandingPage: React.FC = () => {
                     description: i18n.t(
                         "Create, modify, delete, execute and schedule sync rules for metadata like data elements, organisation units and program indicators and groups and group sets."
                     ),
-                    addAction: showCreateLinks
+                    addAction: isConfiguratorRole
                         ? () => history.push("/sync-rules/metadata/new")
                         : undefined,
                     listAction: () => history.push("/sync-rules/metadata"),
@@ -152,7 +152,9 @@ const LandingPage: React.FC = () => {
                     description: i18n.t(
                         "Create, check connectivity, modify and delete DHIS2 destination instances. Map metadata objects between instances."
                     ),
-                    addAction: showCreateLinks ? () => history.push("/instances/new") : undefined,
+                    addAction: isConfiguratorRole
+                        ? () => history.push("/instances/new")
+                        : undefined,
                     listAction: () => history.push("/instances"),
                 },
             ],

--- a/src/pages/landing/LandingPage.tsx
+++ b/src/pages/landing/LandingPage.tsx
@@ -146,6 +146,7 @@ const LandingPage: React.FC = () => {
         {
             title: "Configuration",
             key: "configuration",
+            isVisible: isConfiguratorRole,
             children: [
                 {
                     name: i18n.t("Destination instance settings"),

--- a/src/pages/landing/LandingPage.tsx
+++ b/src/pages/landing/LandingPage.tsx
@@ -46,6 +46,7 @@ const LandingPage: React.FC = () => {
             key: "aggregated",
             children: [
                 {
+                    isVisible: isConfiguratorRole,
                     name: i18n.t("Manual sync"),
                     description: i18n.t(
                         "Manually synchronise aggregated data by selecting the data sets, data elements or their groups and group sets together with the organisation unit, period and category options."
@@ -76,6 +77,7 @@ const LandingPage: React.FC = () => {
             key: "events",
             children: [
                 {
+                    isVisible: isConfiguratorRole,
                     name: i18n.t("Manual sync"),
                     description: i18n.t(
                         "Manually synchronise events by selecting the programs or events together with the organisation unit, period and category options."
@@ -106,6 +108,7 @@ const LandingPage: React.FC = () => {
             key: "metadata",
             children: [
                 {
+                    isVisible: isConfiguratorRole,
                     name: i18n.t("Manual sync"),
                     description: i18n.t(
                         "Manually synchronise metadata like data elements, organisation units and program indicators and groups and group sets."

--- a/src/pages/landing/LandingPage.tsx
+++ b/src/pages/landing/LandingPage.tsx
@@ -28,11 +28,11 @@ const LandingPage: React.FC = () => {
     const classes = useStyles();
     const history = useHistory();
     const [showDeletedObjects, setShowDeletedObjects] = useState(false);
-    const [isConfiguratorRole, setIsConfiguratorRole] = useState(false);
+    const [appConfigurator, setAppConfigurator] = useState(false);
 
     useEffect(() => {
         shouldShowDeletedObjects(d2 as D2).then(setShowDeletedObjects);
-        isAppConfigurator(d2 as D2).then(setIsConfiguratorRole);
+        isAppConfigurator(d2 as D2).then(setAppConfigurator);
     }, [d2]);
 
     const cards: {
@@ -46,7 +46,7 @@ const LandingPage: React.FC = () => {
             key: "aggregated",
             children: [
                 {
-                    isVisible: isConfiguratorRole,
+                    isVisible: appConfigurator,
                     name: i18n.t("Manual sync"),
                     description: i18n.t(
                         "Manually synchronise aggregated data by selecting the data sets, data elements or their groups and group sets together with the organisation unit, period and category options."
@@ -58,7 +58,7 @@ const LandingPage: React.FC = () => {
                     description: i18n.t(
                         "Create, modify, delete, execute and schedule sync rules for aggregated data by selecting the data sets, data elements or their groups and group sets together with the organisation unit, period and category options."
                     ),
-                    addAction: isConfiguratorRole
+                    addAction: appConfigurator
                         ? () => history.push("/sync-rules/aggregated/new")
                         : undefined,
                     listAction: () => history.push("/sync-rules/aggregated"),
@@ -77,7 +77,7 @@ const LandingPage: React.FC = () => {
             key: "events",
             children: [
                 {
-                    isVisible: isConfiguratorRole,
+                    isVisible: appConfigurator,
                     name: i18n.t("Manual sync"),
                     description: i18n.t(
                         "Manually synchronise events by selecting the programs or events together with the organisation unit, period and category options."
@@ -89,7 +89,7 @@ const LandingPage: React.FC = () => {
                     description: i18n.t(
                         "Create, modify, delete, execute and schedule sync rules for events by selecting the programs or events together with the organisation unit, period and category options."
                     ),
-                    addAction: isConfiguratorRole
+                    addAction: appConfigurator
                         ? () => history.push("/sync-rules/events/new")
                         : undefined,
                     listAction: () => history.push("/sync-rules/events"),
@@ -108,7 +108,7 @@ const LandingPage: React.FC = () => {
             key: "metadata",
             children: [
                 {
-                    isVisible: isConfiguratorRole,
+                    isVisible: appConfigurator,
                     name: i18n.t("Manual sync"),
                     description: i18n.t(
                         "Manually synchronise metadata like data elements, organisation units and program indicators and groups and group sets."
@@ -120,7 +120,7 @@ const LandingPage: React.FC = () => {
                     description: i18n.t(
                         "Create, modify, delete, execute and schedule sync rules for metadata like data elements, organisation units and program indicators and groups and group sets."
                     ),
-                    addAction: isConfiguratorRole
+                    addAction: appConfigurator
                         ? () => history.push("/sync-rules/metadata/new")
                         : undefined,
                     listAction: () => history.push("/sync-rules/metadata"),
@@ -149,16 +149,14 @@ const LandingPage: React.FC = () => {
         {
             title: "Configuration",
             key: "configuration",
-            isVisible: isConfiguratorRole,
+            isVisible: appConfigurator,
             children: [
                 {
                     name: i18n.t("Destination instance settings"),
                     description: i18n.t(
                         "Create, check connectivity, modify and delete DHIS2 destination instances. Map metadata objects between instances."
                     ),
-                    addAction: isConfiguratorRole
-                        ? () => history.push("/instances/new")
-                        : undefined,
+                    addAction: appConfigurator ? () => history.push("/instances/new") : undefined,
                     listAction: () => history.push("/instances"),
                 },
             ],

--- a/src/pages/landing/MenuCard.tsx
+++ b/src/pages/landing/MenuCard.tsx
@@ -13,6 +13,7 @@ import React from "react";
 export interface MenuCardProps {
     name: string;
     description?: string;
+    isVisible?: boolean;
     addAction?: () => void;
     listAction?: () => void;
 }
@@ -44,8 +45,16 @@ const useStyles = makeStyles({
     },
 });
 
-const MenuCard: React.FC<MenuCardProps> = ({ name, description, addAction, listAction }) => {
+const MenuCard: React.FC<MenuCardProps> = ({
+    name,
+    description,
+    isVisible,
+    addAction,
+    listAction,
+}) => {
     const classes = useStyles();
+
+    if (isVisible === false) return null;
 
     return (
         <Card className={classes.card}>

--- a/src/pages/sync-rules-list/SyncRulesListPage.tsx
+++ b/src/pages/sync-rules-list/SyncRulesListPage.tsx
@@ -448,7 +448,7 @@ const SyncRulesPage: React.FC = () => {
                 columns={columns}
                 details={details}
                 actions={actions}
-                onActionButtonClick={appConfigurator ? createRule : _.noop}
+                onActionButtonClick={appConfigurator ? createRule : undefined}
                 filterComponents={renderCustomFilters}
                 onChange={handleTableChange}
                 searchBoxLabel={i18n.t("Search by name")}

--- a/src/pages/sync-rules-list/SyncRulesListPage.tsx
+++ b/src/pages/sync-rules-list/SyncRulesListPage.tsx
@@ -308,11 +308,15 @@ const SyncRulesPage: React.FC = () => {
     };
 
     const verifyUserCanEditSharingSettings = (rules: SyncRule[]) => {
-        return verifyUserHasAccess(rules, appConfigurator || appExecutor);
+        return verifyUserHasAccess(rules, appConfigurator);
     };
 
     const verifyUserCanExecute = () => {
         return appExecutor;
+    };
+
+    const verifyUserCanConfigure = () => {
+        return appConfigurator;
     };
 
     const actions: TableAction<SyncRule>[] = [
@@ -358,6 +362,7 @@ const SyncRulesPage: React.FC = () => {
             name: "replicate",
             text: i18n.t("Replicate"),
             multiple: false,
+            isActive: verifyUserCanConfigure,
             onClick: replicateRule,
             icon: <Icon>content_copy</Icon>,
         },

--- a/yarn.lock
+++ b/yarn.lock
@@ -4842,10 +4842,10 @@ d2-manifest@^1.0.0:
     minimist "^1.1.0"
     readline-sync "^1.4.1"
 
-d2-ui-components@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/d2-ui-components/-/d2-ui-components-1.1.0.tgz#1170c4f26a47c1f7d983165557a5c3d5b4153ef8"
-  integrity sha512-GU+yp7u6k6SgTvOPsjsyUifPbDhjQ67KbBHzM/Dd5k/WXpkQGz8kR9s4mVWcXVT9sHN1draymuhw8nw3fzO6Dw==
+d2-ui-components@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/d2-ui-components/-/d2-ui-components-1.1.1.tgz#bd06ff7496f9935176a63bc064e5dfae5adbec23"
+  integrity sha512-5MzZYofQqEjCgB8r2QbfbC5v/56buWgJ7Jj/llm+zr1AGJoq61ZrfGMkZnJqoO93J8lD5Pag8FJ3GJate1v4KQ==
   dependencies:
     "@date-io/core" "^1.3.6"
     "@date-io/moment" "^1.0.2"


### PR DESCRIPTION
* **Issue:** close #361 

### :memo: Implementation

- I have renamed current showCreateLinks to AppConfigurator to use in other scenarios
- I have disabled configuration section for executor role (visible for configurator and admin)
- I have hidden manual accesses for executor role (visible for configurator and admin)
- I have disabled replicate and share settings for executor role (visible for configurator and admin)
- I have hidden delete action  in the History for executor role (visible for configurator and admin)
- I have hidden edit link in the details panel of History for executor role (visible for configurator and admin)
- I have hidden '+' from sync rule page for executor role (visible for configurator and admin)

### :art: Screenshots

### :fire: Is there anything the reviewer should know to test it?

#### Executor
**Use case 1**: configuration section should be hidden for executor role
**Use case 2**: manual accesses in the landing page should be hidden for executor role
**Use case 3**: replicate and share settings actions in the sync rules pages should be hidden for executor role
**Use case 4**: delete action in the History pages should be hidden for executor role
**Use case 5**:  edit link in the details panel of History should be hidden for executor role
**Use case 5**:  add float button in the sync rule pages should be hidden for executor role


#### Configurator
**Use case 1**: configuration section should be visible for configurator role
**Use case 2**: manual accesses in the landing page should be visible for configurator role
**Use case 3**: replicate and share settings actions in the sync rules pages should be visible for configurator role
**Use case 4**: delete action in the History pages should be visible for configurator role
**Use case 5**:  edit link in the details panel of History should be visible for configurator role
**Use case 5**:  add float button in the sync rule pages should be visible for configurator role

#### Admin
**Use case 1**: configuration section should be visible for admin
**Use case 2**: manual accesses in the landing page should be visible for admin
**Use case 3**: replicate and share settings actions in the sync rules pages should be visible for admin
**Use case 4**: delete action in the History pages should be visible for admin
**Use case 5**:  edit link in the details panel of History should be visible for admin
**Use case 5**:  add float button in the sync rule pages should be visible for admin
aggregates
### :bookmark_tabs: Others
