### PR TITLE
Feature/review password hiding

### DIFF
--- a/src/models/instance.ts
+++ b/src/models/instance.ts
@@ -132,7 +132,14 @@ export default class Instance {
     }
 
     public async save(d2: D2): Promise<Response> {
-        const instance = await this.encryptPassword();
+        const lastInstance = await Instance.get(d2, this.id);
+
+        const instanceWithPassword =
+            lastInstance !== undefined && this.password === ""
+                ? this.setPassword(lastInstance.password)
+                : this;
+
+        const instance = instanceWithPassword.encryptPassword();
         const exists = !!instance.data.id;
         const element = exists ? instance.data : { ...instance.data, id: generateUid() };
 
@@ -241,7 +248,7 @@ export default class Instance {
                     : null,
             ]),
             password: _.compact([
-                !password
+                !password && !this.id
                     ? {
                           key: "cannot_be_blank",
                           namespace: { field: "password" },

--- a/src/pages/instance-creation/GeneralInfoForm.jsx
+++ b/src/pages/instance-creation/GeneralInfoForm.jsx
@@ -172,7 +172,7 @@ class GeneralInfoForm extends React.Component {
                     {
                         message: i18n.t("Field cannot be blank"),
                         validator(value) {
-                            return Validators.isRequired(value);
+                            return instance.id ? true : Validators.isRequired(value);
                         },
                     },
                 ],

--- a/src/pages/instance-creation/GeneralInfoForm.jsx
+++ b/src/pages/instance-creation/GeneralInfoForm.jsx
@@ -43,6 +43,7 @@ class GeneralInfoForm extends React.Component {
 
     state = {
         isSaving: false,
+        passwordChanged: false,
     };
 
     setFormReference = formReference => {
@@ -64,6 +65,7 @@ class GeneralInfoForm extends React.Component {
                 newInstance = instance.setUsername(newValue);
                 break;
             case "password":
+                this.setState({ passwordChanged: true });
                 newInstance = instance.setPassword(newValue);
                 break;
             case "description":
@@ -156,7 +158,7 @@ class GeneralInfoForm extends React.Component {
             },
             {
                 name: "password",
-                value: instance.password,
+                value: this.state.passwordChanged ? instance.password : "",
                 component: TextField,
                 props: {
                     floatingLabelText: `${i18n.t("Password")} (*)`,


### PR DESCRIPTION
### :pushpin: References

* **Issue:** Closes #374

### :memo: Implementation

- I have replicated the behaviour for password fields in dhis2 forms.

This behaviour is:
* **new mode**:  the empty field validations are enabled
* **edit mode**: the empty field validations are disabled and password is not rendered by default. If the user does not change the empty password field, the last saved password is maintained in the store and if the user changed the password field then the new password is saved.

### :art: Screenshots

### :fire: Is there anything the reviewer should know to test it?

**use case1**: to create a new instance if the password is empty then the empty password message validation should be visible to save.
**use case2**: to create a new instance and fill the password field then the password should be saved in the store.
**use case3**: to edit an instance the password should not be rendered by default.
**use case4**: to edit an instance if the user changes all fields but password the empty password message validation should not be visible and the instance should maintain the last saved password.
**use case5**: to edit an instance if the user changes the password then new password should be saved.

### :bookmark_tabs: Others

- Any change in the [GUI library](https://github.com/EyeSeeTea/d2-ui-components)? If so, what branch/PR?
