### PR TITLE
Feature/event sync rules cypress tests

### DIFF
--- a/cypress/fixtures/aggregated-sync-rules.json
+++ b/cypress/fixtures/aggregated-sync-rules.json
@@ -6,20 +6,14 @@
         "created": "2020-03-02T07:12:51.250Z",
         "description": "Aggregated sync rule description",
         "builder": {
-            "targetInstances": [
-                "Y5QsHDoD4I0"
-            ],
-            "metadataIds": [
-                "qNtxTrp56wV"
-            ],
+            "targetInstances": ["Y5QsHDoD4I0"],
+            "metadataIds": ["qNtxTrp56wV"],
             "excludedIds": [],
             "dataParams": {
                 "strategy": "NEW_AND_UPDATES",
                 "allAttributeCategoryOptions": true,
                 "dryRun": false,
-                "orgUnitPaths": [
-                    "/E4h5WBOg71F"
-                ],
+                "orgUnitPaths": ["/E4h5WBOg71F"],
                 "events": []
             },
             "syncParams": {
@@ -54,20 +48,14 @@
         "created": "2020-03-02T07:12:51.250Z",
         "description": "Aggregated sync rule description 2",
         "builder": {
-            "targetInstances": [
-                "Y5QsHDoD4I0"
-            ],
-            "metadataIds": [
-                "qNtxTrp56wV"
-            ],
+            "targetInstances": ["Y5QsHDoD4I0"],
+            "metadataIds": ["qNtxTrp56wV"],
             "excludedIds": [],
             "dataParams": {
                 "strategy": "NEW_AND_UPDATES",
                 "allAttributeCategoryOptions": true,
                 "dryRun": false,
-                "orgUnitPaths": [
-                    "/E4h5WBOg71F"
-                ],
+                "orgUnitPaths": ["/E4h5WBOg71F"],
                 "events": []
             },
             "syncParams": {

--- a/cypress/fixtures/event-sync-rules.json
+++ b/cypress/fixtures/event-sync-rules.json
@@ -1,6 +1,6 @@
 [
     {
-        "id": "dZ7aQ9Sq6m2",
+        "id": "ckJYe5gJTx7",
         "name": "Event sync rule name",
         "code": "Event sync rule code",
         "created": "2020-03-02T07:12:51.250Z",
@@ -14,8 +14,8 @@
                 "allAttributeCategoryOptions": true,
                 "dryRun": false,
                 "orgUnitPaths": ["/E4h5WBOg71F/RnDSNvg7zR2/KwLlNNoREes/GY1mRd2suuj/PzO3UvH7za0"],
-                "events": ["uEG2h3705XE"],
-                "metadataIncludeExcludeRules": {}
+                "events": ["PoKTdJQa8pV"],
+                "periods": "ALL"
             },
             "syncParams": {
                 "importStrategy": "CREATE_AND_UPDATE",
@@ -43,7 +43,7 @@
         "type": "events"
     },
     {
-        "id": "dZ7aQ9Sq6m1",
+        "id": "ebh61hsl3Ip",
         "name": "Event sync rule name 2",
         "code": "Event sync rule code 2",
         "created": "2020-03-02T07:12:51.250Z",
@@ -57,7 +57,8 @@
                 "allAttributeCategoryOptions": true,
                 "dryRun": false,
                 "orgUnitPaths": ["/E4h5WBOg71F/RnDSNvg7zR2/KwLlNNoREes/GY1mRd2suuj/PzO3UvH7za0"],
-                "events": ["uEG2h3705XE"]
+                "events": ["PoKTdJQa8pV"],
+                "periods": "ALL"
             },
             "syncParams": {
                 "importStrategy": "CREATE_AND_UPDATE",

--- a/cypress/fixtures/event-sync-rules.json
+++ b/cypress/fixtures/event-sync-rules.json
@@ -1,0 +1,87 @@
+[
+    {
+        "id": "dZ7aQ9Sq6m2",
+        "name": "Event sync rule name",
+        "code": "Event sync rule code",
+        "created": "2020-03-02T07:12:51.250Z",
+        "description": "Event sync rule description",
+        "builder": {
+            "targetInstances": ["Y5QsHDoD4I0"],
+            "metadataIds": ["uEG2h3705XE"],
+            "excludedIds": [],
+            "dataParams": {
+                "strategy": "NEW_AND_UPDATES",
+                "allAttributeCategoryOptions": true,
+                "dryRun": false,
+                "orgUnitPaths": ["/E4h5WBOg71F/RnDSNvg7zR2/KwLlNNoREes/GY1mRd2suuj/PzO3UvH7za0"],
+                "events": ["uEG2h3705XE"],
+                "period": "FIXED",
+                "startDate": "2019-01-01T19:32:00.000Z",
+                "endDate": "2019-12-31T19:32:02.733Z"
+            },
+            "syncParams": {
+                "importStrategy": "CREATE_AND_UPDATE",
+                "includeSharingSettings": true,
+                "atomicMode": "ALL",
+                "mergeMode": "MERGE",
+                "importMode": "COMMIT"
+            }
+        },
+        "enabled": false,
+        "lastUpdated": "2020-03-02T07:12:51.250Z",
+        "lastUpdatedBy": {
+            "id": "M5zQapPyTZI",
+            "name": "admin admin"
+        },
+        "publicAccess": "rw------",
+        "user": {
+            "id": "M5zQapPyTZI",
+            "name": "admin admin"
+        },
+        "userAccesses": [],
+        "userGroupAccesses": [],
+        "type": "events"
+    },
+    {
+        "id": "dZ7aQ9Sq6m1",
+        "name": "Event sync rule name 2",
+        "code": "Event sync rule code 2",
+        "created": "2020-03-02T07:12:51.250Z",
+        "description": "Event sync rule description 2",
+        "builder": {
+            "targetInstances": ["Y5QsHDoD4I0"],
+            "metadataIds": ["uEG2h3705XE"],
+            "excludedIds": [],
+            "dataParams": {
+                "strategy": "NEW_AND_UPDATES",
+                "allAttributeCategoryOptions": true,
+                "dryRun": false,
+                "orgUnitPaths": ["/E4h5WBOg71F/RnDSNvg7zR2/KwLlNNoREes/GY1mRd2suuj/PzO3UvH7za0"],
+                "events": ["uEG2h3705XE"]
+            },
+            "syncParams": {
+                "importStrategy": "CREATE_AND_UPDATE",
+                "includeSharingSettings": true,
+                "useDefaultIncludeExclude": true,
+                "atomicMode": "ALL",
+                "mergeMode": "MERGE",
+                "importMode": "COMMIT",
+                "metadataIncludeExcludeRules": {}
+            }
+        },
+        "enabled": false,
+        "lastUpdated": "2020-03-02T07:12:51.250Z",
+        "lastUpdatedBy": {
+            "id": "M5zQapPyTZI",
+            "name": "admin admin"
+        },
+        "publicAccess": "rw------",
+        "user": {
+            "id": "M5zQapPyTZI",
+            "name": "admin admin"
+        },
+        "userAccesses": [],
+        "userGroupAccesses": [],
+        "type": "events"
+    }
+]

--- a/cypress/fixtures/event-sync-rules.json
+++ b/cypress/fixtures/event-sync-rules.json
@@ -7,7 +7,7 @@
         "description": "Event sync rule description",
         "builder": {
             "targetInstances": ["Y5QsHDoD4I0"],
-            "metadataIds": ["uEG2h3705XE"],
+            "metadataIds": ["G9hvxFI8AYC"],
             "excludedIds": [],
             "dataParams": {
                 "strategy": "NEW_AND_UPDATES",
@@ -15,16 +15,16 @@
                 "dryRun": false,
                 "orgUnitPaths": ["/E4h5WBOg71F/RnDSNvg7zR2/KwLlNNoREes/GY1mRd2suuj/PzO3UvH7za0"],
                 "events": ["uEG2h3705XE"],
-                "period": "FIXED",
-                "startDate": "2019-01-01T19:32:00.000Z",
-                "endDate": "2019-12-31T19:32:02.733Z"
+                "metadataIncludeExcludeRules": {}
             },
             "syncParams": {
                 "importStrategy": "CREATE_AND_UPDATE",
                 "includeSharingSettings": true,
+                "useDefaultIncludeExclude": true,
                 "atomicMode": "ALL",
                 "mergeMode": "MERGE",
-                "importMode": "COMMIT"
+                "importMode": "COMMIT",
+                "metadataIncludeExcludeRules": {}
             }
         },
         "enabled": false,
@@ -50,7 +50,7 @@
         "description": "Event sync rule description 2",
         "builder": {
             "targetInstances": ["Y5QsHDoD4I0"],
-            "metadataIds": ["uEG2h3705XE"],
+            "metadataIds": ["G9hvxFI8AYC"],
             "excludedIds": [],
             "dataParams": {
                 "strategy": "NEW_AND_UPDATES",

--- a/cypress/fixtures/metadata-sync-rules.json
+++ b/cypress/fixtures/metadata-sync-rules.json
@@ -6,12 +6,8 @@
         "created": "2020-02-26T08:43:11.739Z",
         "description": "Metadata sync rule description",
         "builder": {
-            "targetInstances": [
-                "Y5QsHDoD4I0"
-            ],
-            "metadataIds": [
-                "t0ml4ZZpnu0"
-            ],
+            "targetInstances": ["Y5QsHDoD4I0"],
+            "metadataIds": ["t0ml4ZZpnu0"],
             "excludedIds": [],
             "dataParams": {
                 "strategy": "NEW_AND_UPDATES",
@@ -50,12 +46,8 @@
         "created": "2020-02-26T08:43:11.739Z",
         "description": "Metadata sync rule description 2",
         "builder": {
-            "targetInstances": [
-                "Y5QsHDoD4I0"
-            ],
-            "metadataIds": [
-                "t0ml4ZZpnu0"
-            ],
+            "targetInstances": ["Y5QsHDoD4I0"],
+            "metadataIds": ["t0ml4ZZpnu0"],
             "excludedIds": [],
             "dataParams": {
                 "strategy": "NEW_AND_UPDATES",

--- a/cypress/integration/aggregated-sync-rule-new.spec.js
+++ b/cypress/integration/aggregated-sync-rule-new.spec.js
@@ -1,6 +1,6 @@
 import AggregatedSyncRuleDetailPageObject from "../support/page-objects/AggregatedSyncRuleDetailPageObject";
 
-context("Metadata synchronization rule new", function() {
+context("Aggregated sync rule new", function() {
     const page = new AggregatedSyncRuleDetailPageObject(cy);
 
     const inputs = {

--- a/cypress/integration/event-sync-rule-edit.spec.js
+++ b/cypress/integration/event-sync-rule-edit.spec.js
@@ -1,0 +1,66 @@
+import EventSyncRuleDetailPageObject from "../support/page-objects/EventSyncRuleDetailPageObject";
+
+context("Event sync rule edit", function() {
+    const page = new EventSyncRuleDetailPageObject(cy);
+
+    beforeEach(() => {
+        const stubApiResponseName = "getRules";
+
+        cy.fixture("event-sync-rules.json").then(syncRules => {
+            this.syncRule = syncRules[0];
+            cy.server();
+            cy.route({
+                method: "GET",
+                url: `api/dataStore/metadata-synchronization/rules`,
+                response: syncRules,
+            }).as(stubApiResponseName);
+            page.open(this.syncRule.id, stubApiResponseName);
+        });
+    });
+
+    it("should have the correct title", () => {
+        page.assertTitle(title => title.contains("Edit events synchronization rule"));
+    });
+
+    it("should have the correct general info", () => {
+        page.assertName(name => name.should("have.value", this.syncRule.name))
+            .assertCode(name => name.should("have.value", this.syncRule.code))
+            .assertDescription(name => name.should("have.value", this.syncRule.description));
+    });
+
+    it("should have the correct selected program count", () => {
+        page.next()
+            .next()
+            .checkOnlySelectedItems()
+            .assertSelectedProgramsCountMessage(programCountMessage => {
+                programCountMessage.contains(
+                    `There are ${this.syncRule.builder.metadataIds.length} items selected in all pages.`
+                );
+            });
+    });
+
+    it("should have the correct selected event", () => {
+        page.next()
+            .next()
+            .next()
+            .next()
+            .assertSelectedEvent(`${this.syncRule.builder.dataParams.events[0]}`);
+    });
+
+    it("should have the correct selected org unit", () => {
+        page.next().assertSelectedOrgUnit(selectedOrgUnit => {
+            selectedOrgUnit.contains("Akrodie Health Centre");
+        });
+    });
+
+    it("should have the correct selected instances", () => {
+        page.next()
+            .next()
+            .next()
+            .next()
+            .next()
+            .assertSelectedInstances(selectedInstances =>
+                selectedInstances.select(this.syncRule.builder.targetInstances[0])
+            );
+    });
+});

--- a/cypress/integration/event-sync-rule-new.spec.js
+++ b/cypress/integration/event-sync-rule-new.spec.js
@@ -5,7 +5,6 @@ context("Event sync rule new", function() {
 
     const inputs = {
         name: "test",
-        orgUnit: "Ghana",
         instance: "Y5QsHDoD4I0",
         orgUnit: "Akrodie Health Centre",
         orgUnitLevel0: "Ghana",

--- a/cypress/integration/event-sync-rule-new.spec.js
+++ b/cypress/integration/event-sync-rule-new.spec.js
@@ -1,6 +1,6 @@
 import EventSyncRuleDetailPageObject from "../support/page-objects/EventSyncRuleDetailPageObject";
 
-context("Metadata synchronization rule new", function() {
+context("Event sync rule new", function() {
     const page = new EventSyncRuleDetailPageObject(cy);
 
     const inputs = {

--- a/cypress/integration/event-sync-rule-new.spec.js
+++ b/cypress/integration/event-sync-rule-new.spec.js
@@ -1,0 +1,108 @@
+import EventSyncRuleDetailPageObject from "../support/page-objects/EventSyncRuleDetailPageObject";
+
+context("Metadata synchronization rule new", function() {
+    const page = new EventSyncRuleDetailPageObject(cy);
+
+    const inputs = {
+        name: "test",
+        orgUnit: "Ghana",
+        instance: "Y5QsHDoD4I0",
+        orgUnit: "Akrodie Health Centre",
+        orgUnitLevel0: "Ghana",
+        orgUnitLevel1: "Ahafo",
+        orgUnitLevel2: "Asunafo North",
+        orgUnitLevel3: "Akrodie",
+        event: "PoKTdJQa8pV",
+        program: "ENTO- Discriminating concentration bioassay",
+    };
+
+    beforeEach(() => {
+        page.open();
+    });
+
+    it("should have the correct title", () => {
+        page.assertTitle(title => title.contains("New events synchronization rule"));
+    });
+
+    it("should show name step error if user try click on next without type a name", () => {
+        page.next().assertError(error => error.contains("Field name cannot be blank"));
+    });
+
+    it("should show metadata step error if user try click on next without selecting an metadata item", () => {
+        page.typeName(inputs.name)
+            .next()
+
+            .expandOrgUnit(inputs.orgUnitLevel0)
+            .expandOrgUnit(inputs.orgUnitLevel1)
+            .expandOrgUnit(inputs.orgUnitLevel2)
+            .expandOrgUnit(inputs.orgUnitLevel3)
+            .selectOrgUnit(inputs.orgUnit)
+            .next()
+
+            .next()
+            .assertError(error =>
+                error.contains("You need to select at least one metadata element")
+            );
+    });
+
+    it("should show the org unit step error if user try click on next without selecting the org unit", () => {
+        page.typeName(inputs.name)
+            .next()
+            .next()
+            .assertError(error =>
+                error.contains("You need to select at least one organisation unit")
+            );
+    });
+
+    it("should show the instance selection step error if user try click on next without selecting an instance", () => {
+        page.typeName(inputs.name)
+            .next()
+
+            .expandOrgUnit(inputs.orgUnitLevel0)
+            .expandOrgUnit(inputs.orgUnitLevel1)
+            .expandOrgUnit(inputs.orgUnitLevel2)
+            .expandOrgUnit(inputs.orgUnitLevel3)
+            .selectOrgUnit(inputs.orgUnit)
+            .next()
+
+            .selectRow(inputs.program)
+            .next()
+
+            .selectAllPeriods()
+            .next()
+
+            .selectEvent(inputs.event)
+            .next()
+
+            .next()
+            .assertError(error => error.contains("You need to select at least one instance"));
+    });
+
+    it("should create a new Sync Rule", () => {
+        page.typeName(inputs.name)
+            .next()
+
+            .expandOrgUnit(inputs.orgUnitLevel0)
+            .expandOrgUnit(inputs.orgUnitLevel1)
+            .expandOrgUnit(inputs.orgUnitLevel2)
+            .expandOrgUnit(inputs.orgUnitLevel3)
+            .selectOrgUnit(inputs.orgUnit)
+            .next()
+
+            .selectRow(inputs.program)
+            .next()
+
+            .selectAllPeriods()
+            .next()
+
+            .selectEvent(inputs.event)
+            .next()
+
+            .selectReceiverInstance(inputs.instance)
+            .next()
+
+            .next()
+            .save()
+            .assertSave();
+    });
+});

--- a/cypress/integration/event-sync-rules.spec.js
+++ b/cypress/integration/event-sync-rules.spec.js
@@ -1,0 +1,34 @@
+import EventSyncRuleListPageObject from "../support/page-objects/EventSyncRuleListPageObject";
+
+context("Event sync rules", function() {
+    const page = new EventSyncRuleListPageObject(cy);
+
+    beforeEach(() => {
+        const stubApiResponseName = "getRules";
+
+        cy.fixture("event-sync-rules.json").then(syncRules => {
+            this.syncRules = syncRules;
+            cy.server();
+            cy.route({
+                method: "GET",
+                url: `api/dataStore/metadata-synchronization/rules`,
+                response: syncRules,
+            }).as(stubApiResponseName);
+            page.open(stubApiResponseName);
+        });
+    });
+
+    it("should have the correct title", () => {
+        page.assertTitle(title => title.contains("Events Synchronization Rules"));
+    });
+
+    it("should contains expected rows count", () => {
+        page.assertRowsCount(this.syncRules.length);
+    });
+
+    it("should sync correctly a sync rule", () => {
+        page.openActionsMenu(0)
+            .synchronize()
+            .assertSyncResultsStatus(status => status.contains("Success"));
+    });
+});

--- a/cypress/support/page-objects/EventSyncRuleDetailPageObject.js
+++ b/cypress/support/page-objects/EventSyncRuleDetailPageObject.js
@@ -1,0 +1,62 @@
+import { dataTest } from "../utils";
+import SyncRuleDetailPageObject from "./common/SyncRuleDetailPageObject";
+import * as orgUnitStep from "../page-utils/orgUnitStep";
+import * as periodStep from "../page-utils/periodStep";
+import * as eventStep from "../page-utils/eventStep";
+
+class EventSyncRuleDetailPageObject extends SyncRuleDetailPageObject {
+    constructor(cy) {
+        super(cy);
+    }
+
+    open(uid, stubApiResponseName) {
+        if (uid) {
+            super.open(`/#/sync-rules/events/edit/${uid}`);
+
+            if (stubApiResponseName) {
+                this.cy.wait(`@${stubApiResponseName}`);
+            }
+        } else {
+            super.open("/#/sync-rules/events/new");
+        }
+
+        return this;
+    }
+
+    assertSelectedOrgUnit(assert) {
+        orgUnitStep.assertSelectedOrgUnit(assert);
+        return this;
+    }
+
+    assertSelectedDatasetCountMessage(assert) {
+        dataSetStep.assertSelectedDatasetCountMessage(assert);
+        return this;
+    }
+
+    selectOrgUnit(orgUnit) {
+        orgUnitStep.selectOrgUnit(".ou-root", orgUnit);
+        return this;
+    }
+
+    expandOrgUnit(orgUnit) {
+        orgUnitStep.expandOrgUnit(".ou-root", orgUnit);
+        return this;
+    }
+
+    selectEvent(event) {
+        eventStep.selectEvent(dataTest(`Paper`), event);
+        return this;
+    }
+
+    selectAllPeriods() {
+        periodStep.selectAllPeriods();
+        return this;
+    }
+
+    checkOnlySelectedItems() {
+        dataSetStep.checkOnlySelectedItems();
+        return this;
+    }
+}
+
+export default EventSyncRuleDetailPageObject;

--- a/cypress/support/page-objects/EventSyncRuleDetailPageObject.js
+++ b/cypress/support/page-objects/EventSyncRuleDetailPageObject.js
@@ -3,6 +3,7 @@ import SyncRuleDetailPageObject from "./common/SyncRuleDetailPageObject";
 import * as orgUnitStep from "../page-utils/orgUnitStep";
 import * as periodStep from "../page-utils/periodStep";
 import * as eventStep from "../page-utils/eventStep";
+import * as programStep from "../page-utils/programStep";
 
 class EventSyncRuleDetailPageObject extends SyncRuleDetailPageObject {
     constructor(cy) {
@@ -23,13 +24,18 @@ class EventSyncRuleDetailPageObject extends SyncRuleDetailPageObject {
         return this;
     }
 
+    assertSelectedEvent(event) {
+        eventStep.assertSelectedEvent(event);
+        return this;
+    }
+
     assertSelectedOrgUnit(assert) {
         orgUnitStep.assertSelectedOrgUnit(assert);
         return this;
     }
 
-    assertSelectedDatasetCountMessage(assert) {
-        dataSetStep.assertSelectedDatasetCountMessage(assert);
+    assertSelectedProgramsCountMessage(assert) {
+        programStep.assertSelectedProgramsCountMessage(assert);
         return this;
     }
 
@@ -54,7 +60,7 @@ class EventSyncRuleDetailPageObject extends SyncRuleDetailPageObject {
     }
 
     checkOnlySelectedItems() {
-        dataSetStep.checkOnlySelectedItems();
+        programStep.checkOnlySelectedItems();
         return this;
     }
 }

--- a/cypress/support/page-objects/EventSyncRuleListPageObject.js
+++ b/cypress/support/page-objects/EventSyncRuleListPageObject.js
@@ -1,0 +1,26 @@
+import SyncRuleListPageObject from "./common/SyncRuleListPageObject";
+
+class EventSyncRuleListPageObject extends SyncRuleListPageObject {
+    open(stubApiResponseName) {
+        super.open("/#/sync-rules/events");
+
+        this.cy.wait(`@${stubApiResponseName}`);
+
+        return this;
+    }
+
+    synchronize() {
+        this.cy
+            .route({
+                method: "POST",
+                url: "/api/events*",
+            })
+            .as("postEvents");
+
+        this.cy.contains("Execute").click();
+        this.cy.wait("@postEvents");
+        return this;
+    }
+}
+
+export default EventSyncRuleListPageObject;

--- a/cypress/support/page-objects/ManualEventSyncPageObject.js
+++ b/cypress/support/page-objects/ManualEventSyncPageObject.js
@@ -1,7 +1,8 @@
 import { dataTest } from "../utils";
 import ManualSyncPageObject from "./common/ManualSyncPageObject";
-import * as selectOrgUnitStep from "../page-utils/orgUnitStep";
-import * as selectPeriodStep from "../page-utils/periodStep";
+import * as orgUnitStep from "../page-utils/orgUnitStep";
+import * as periodStep from "../page-utils/periodStep";
+import * as eventStep from "../page-utils/eventStep";
 
 class ManualEventSyncPageObject extends ManualSyncPageObject {
     constructor(cy) {
@@ -14,29 +15,22 @@ class ManualEventSyncPageObject extends ManualSyncPageObject {
     }
 
     expandOrgUnit(orgUnit) {
-        this.cy.expandInOrgUnitTree(dataTest(`DialogContent-${this.key}-synchronization`), orgUnit);
+        orgUnitStep.expandOrgUnit(dataTest(`DialogContent-${this.key}-synchronization`), orgUnit);
         return this;
     }
 
     selectOrgUnit(orgUnit) {
-        selectOrgUnitStep.selectOrgUnit(
-            dataTest(`DialogContent-${this.key}-synchronization`),
-            orgUnit
-        );
+        orgUnitStep.selectOrgUnit(dataTest(`DialogContent-${this.key}-synchronization`), orgUnit);
         return this;
     }
 
     selectAllPeriods() {
-        selectPeriodStep.selectAllPeriods();
+        periodStep.selectAllPeriods();
         return this;
     }
 
     selectEvent(event) {
-        this.cy
-            .get(dataTest("DialogContent-events-synchronization"))
-            .contains(event)
-            .parent()
-            .click();
+        eventStep.selectEvent(dataTest(`DialogContent-${this.key}-synchronization`), event);
         return this;
     }
 

--- a/cypress/support/page-utils/eventStep.js
+++ b/cypress/support/page-utils/eventStep.js
@@ -1,0 +1,7 @@
+export function selectEvent(container, event) {
+    cy.get(container)
+        .contains(event)
+        .parent()
+        .click();
+    return this;
+}

--- a/cypress/support/page-utils/eventStep.js
+++ b/cypress/support/page-utils/eventStep.js
@@ -1,3 +1,22 @@
+export function assertSelectedEvent(event) {
+    const getEventsRouteName = "getEvents";
+
+    cy.route({
+        method: "GET",
+        url: "/api/events*",
+    }).as(getEventsRouteName);
+
+    cy.wait(`@${getEventsRouteName}`);
+
+    assert(
+        cy
+            .get('[data-test="Paper"]')
+            .contains(event)
+            .prev()
+            .find("[checked]")
+    );
+}
+
 export function selectEvent(container, event) {
     cy.get(container)
         .contains(event)

--- a/cypress/support/page-utils/orgUnitStep.js
+++ b/cypress/support/page-utils/orgUnitStep.js
@@ -7,7 +7,7 @@ export function assertSelectedOrgUnit(assert) {
     }).as(getOrgUnitsRouteName);
     cy.wait(`@${getOrgUnitsRouteName}`);
 
-    assert(cy.get(".ou-root .label > div[style*='color: orange;'"));
+    assert(cy.get(".ou-root * > div[style*='color: orange;'"));
 }
 
 export function selectOrgUnit(container, orgUnit) {

--- a/cypress/support/page-utils/orgUnitStep.js
+++ b/cypress/support/page-utils/orgUnitStep.js
@@ -15,3 +15,9 @@ export function selectOrgUnit(container, orgUnit) {
 
     return this;
 }
+
+export function expandOrgUnit(container, orgUnit) {
+    cy.get(container).expandInOrgUnitTree(container, orgUnit);
+    
+    return this;
+}

--- a/cypress/support/page-utils/orgUnitStep.js
+++ b/cypress/support/page-utils/orgUnitStep.js
@@ -18,6 +18,6 @@ export function selectOrgUnit(container, orgUnit) {
 
 export function expandOrgUnit(container, orgUnit) {
     cy.get(container).expandInOrgUnitTree(container, orgUnit);
-    
+
     return this;
 }

--- a/cypress/support/page-utils/programStep.js
+++ b/cypress/support/page-utils/programStep.js
@@ -1,0 +1,24 @@
+export const routeName = "programs";
+
+export function assertSelectedProgramsCountMessage(assert) {
+    cy.wait(`@${routeName}`);
+    assert(cy.contains("items selected in all pages"));
+}
+
+export function activeRouteToWait() {
+    cy.route({
+        method: "GET",
+        url: "/api/programs*",
+    }).as(routeName);
+}
+
+export function checkOnlySelectedItems() {
+    activeRouteToWait();
+
+    cy.contains("Only selected items")
+        .parent()
+        .find("input")
+        .click();
+
+    cy.contains("items selected in all pages");
+}


### PR DESCRIPTION
### :pushpin: References

* **Issue:** Closes #?

### :memo: Implementation

I have added tests for:

- Event sync rules new
- Event sync rules list
- Event sync rules edit

Following the strategy used by jorge in https://github.com/EyeSeeTea/metadata-synchronization/pull/406

I have created the programStep step, similar to the dataSet step, although they are only used in one test.
I think the reason to create dataSetStep is that could be common code and it is more readable to have it as a step file.

Following the same idea for the assertSelectedEvent function, which makes sense within eventStep.


### :art: Screenshots


### :fire: Is there anything the reviewer should know to test it?


### :bookmark_tabs: Others

- Any change in the [GUI library](https://github.com/EyeSeeTea/d2-ui-components)? If so, what branch/PR?
