### PR TITLE
Add new metadata objects

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ script:
     - PORT=8081 REACT_APP_DHIS2_BASE_URL=http://localhost:8080 REACT_APP_CYPRESS=true yarn start &
     - yarn wait-on http-get://localhost:8081
     - yarn wait-on http-get://localhost:8080
-    - CYPRESS_EXTERNAL_API=http://localhost:8080 CYPRESS_ROOT_URL=http://localhost:8081 yarn cy:e2e:run --record --key $CYPRESS_KEY
+    - CYPRESS_EXTERNAL_API=http://localhost:8080 CYPRESS_ROOT_URL=http://localhost:8081 yarn cy:e2e:run #--record --key $CYPRESS_KEY
     - kill $(jobs -p) || true
 addons:
     apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,44 +1,44 @@
 language: node_js
 node_js:
-  - 12.13.0
+    - 12.13.0
 dist: bionic
 cache:
-  directories:
-    - "$HOME/.cache"
+    directories:
+        - "$HOME/.cache"
 before_install:
-  - echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
-  # Install python dependencies
-  - sudo apt-get update
-  - sudo apt-get install python3 python python3-setuptools docker.io docker-compose
-  #  Install d2-docker
-  - git clone https://github.com/EyeSeeTea/d2-docker.git
-  - cd d2-docker/
-  - sudo python3 setup.py install
-  - d2-docker --help
-  # Hack to not be prompted in the terminal
-  - sudo apt-get remove golang-docker-credential-helpers
-  # Start docker service
-  - sudo systemctl unmask docker.service
-  - sudo systemctl unmask docker.socket
-  - sudo systemctl start docker.service
-  # Login to docker
-  - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-  # Start docker service
-  - d2-docker start eyeseetea/dhis2-data:2.30-datasync-sender -d
+    - echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
+    # Install python dependencies
+    - sudo apt-get update
+    - sudo apt-get install python3 python python3-setuptools docker.io docker-compose
+    #  Install d2-docker
+    - git clone https://github.com/EyeSeeTea/d2-docker.git
+    - cd d2-docker/
+    - sudo python3 setup.py install
+    - d2-docker --help
+    # Hack to not be prompted in the terminal
+    - sudo apt-get remove golang-docker-credential-helpers
+    # Start docker service
+    - sudo systemctl unmask docker.service
+    - sudo systemctl unmask docker.socket
+    - sudo systemctl start docker.service
+    # Login to docker
+    - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+    # Start docker service
+    - d2-docker start eyeseetea/dhis2-data:2.30-datasync-sender -d
 install:
-  - yarn install --frozen-lockfile
-  - yarn cy:verify
-  - yarn build
+    - yarn install --frozen-lockfile
+    - yarn cy:verify
+    - yarn build
 script:
-  - PORT=8081 REACT_APP_DHIS2_BASE_URL=http://localhost:8080 REACT_APP_CYPRESS=true yarn start &
-  - yarn wait-on http-get://localhost:8081
-  - yarn wait-on http-get://localhost:8080
-  - CYPRESS_EXTERNAL_API=http://localhost:8080 CYPRESS_ROOT_URL=http://localhost:8081 yarn cy:e2e:run
-  - kill $(jobs -p) || true
+    - PORT=8081 REACT_APP_DHIS2_BASE_URL=http://localhost:8080 REACT_APP_CYPRESS=true yarn start &
+    - yarn wait-on http-get://localhost:8081
+    - yarn wait-on http-get://localhost:8080
+    - CYPRESS_EXTERNAL_API=http://localhost:8080 CYPRESS_ROOT_URL=http://localhost:8081 yarn cy:e2e:run --record --key $CYPRESS_KEY
+    - kill $(jobs -p) || true
 addons:
-  apt:
-    packages:
-    - libgconf-2-4
+    apt:
+        packages:
+            - libgconf-2-4
 notifications:
-  slack:
-    secure: R/tguoSgiUOK5qYmRoSv4qVkgGaF26PVnjqefXGc8oMc4scbssjbhQt+qVC2RuhB3ErXmez+BfaKcLLR6cEFY4cm+puBD+mU6fP2rDCiQRnmfaZmvdT/MY1KTSKlT2JzQ/YU9IQfdUetr/7lUbdyTcJQ8r+QOMwQu/drSGUEOt+eTHO5HQFVfhHnmoYWJ4oWxAWUyJx7DbXgRy9K5JlYlv2Vesol5vpSzjdXNlcXV3EPOD009ODO2+EboKujZHvLJakAjy/sCgtqB0ys22WXPv5dOj8FCJRjFSKpe9s5pZYjvjJfjD7GnIcP6/AAe+m3OC9/fDxdFtXeppJ95FNEQKyWCVAS9QNY50G4W0sHlR6VZ3OUhLnIQLKeNncTWG5QaUc4+/vYmbeEYFahOATMUX8I4uUVuT+5jDS883kHQ6Z8XxUWy3PztuM3kOz/cv3zppd2icpPtqDTkIql5CdA4ZHmBElD3GiIJgEfUOaUqn4isivALv024UnQhwrHCK55ymcphotzjdnhRQSlY2MeywA+TqaAtcYwoqKOBbvHQ2c8QMfanbT9UvmAE7+X0VruF5hgvaKA5DgT51RZl8YQVuLBbrfcT8+XrTypl2fwpJ4/23wltR/Ex9K7wJtjQeM1oz37mzFUW7zfvlHsXgWy2WtTkM/icAlxLM7ZN5YGMxI=
+    slack:
+        secure: R/tguoSgiUOK5qYmRoSv4qVkgGaF26PVnjqefXGc8oMc4scbssjbhQt+qVC2RuhB3ErXmez+BfaKcLLR6cEFY4cm+puBD+mU6fP2rDCiQRnmfaZmvdT/MY1KTSKlT2JzQ/YU9IQfdUetr/7lUbdyTcJQ8r+QOMwQu/drSGUEOt+eTHO5HQFVfhHnmoYWJ4oWxAWUyJx7DbXgRy9K5JlYlv2Vesol5vpSzjdXNlcXV3EPOD009ODO2+EboKujZHvLJakAjy/sCgtqB0ys22WXPv5dOj8FCJRjFSKpe9s5pZYjvjJfjD7GnIcP6/AAe+m3OC9/fDxdFtXeppJ95FNEQKyWCVAS9QNY50G4W0sHlR6VZ3OUhLnIQLKeNncTWG5QaUc4+/vYmbeEYFahOATMUX8I4uUVuT+5jDS883kHQ6Z8XxUWy3PztuM3kOz/cv3zppd2icpPtqDTkIql5CdA4ZHmBElD3GiIJgEfUOaUqn4isivALv024UnQhwrHCK55ymcphotzjdnhRQSlY2MeywA+TqaAtcYwoqKOBbvHQ2c8QMfanbT9UvmAE7+X0VruF5hgvaKA5DgT51RZl8YQVuLBbrfcT8+XrTypl2fwpJ4/23wltR/Ex9K7wJtjQeM1oz37mzFUW7zfvlHsXgWy2WtTkM/icAlxLM7ZN5YGMxI=

--- a/cypress/integration/manual-metadata-sync.spec.js
+++ b/cypress/integration/manual-metadata-sync.spec.js
@@ -4,6 +4,8 @@ context("Manual metadata sync", function() {
     const page = new ManualMetadataSyncPageObject(cy);
 
     const inputs = {
+        filterLabel: "Metadata type",
+        filterValue: "Data Element",
         dataElement: "ENTO-ADULT- Household Head Name",
         instance: "Y5QsHDoD4I0",
     };
@@ -23,7 +25,8 @@ context("Manual metadata sync", function() {
     // });
 
     it("should sync correctly one data element", () => {
-        page.selectRow(inputs.dataElement)
+        page.selectFilterInTable(inputs.filterLabel, inputs.filterValue)
+            .selectRow(inputs.dataElement)
             .openSyncDialog()
             .next()
             .selectReceiverInstance(inputs.instance)
@@ -33,7 +36,8 @@ context("Manual metadata sync", function() {
     });
 
     it("should show the instance selection step error if user try click on next without selecting an instance", () => {
-        page.selectRow(inputs.dataElement)
+        page.selectFilterInTable(inputs.filterLabel, inputs.filterValue)
+            .selectRow(inputs.dataElement)
             .openSyncDialog()
             .next()
             .next()
@@ -41,21 +45,24 @@ context("Manual metadata sync", function() {
     });
 
     it("should have synchronize button disabled to open sync dialog", () => {
-        page.selectRow(inputs.dataElement)
+        page.selectFilterInTable(inputs.filterLabel, inputs.filterValue)
+            .selectRow(inputs.dataElement)
             .openSyncDialog()
 
             .assertSyncButton(syncButton => syncButton.should("be.disabled"));
     });
 
     it("should have synchronize button disabled if only contains default include exclude", () => {
-        page.selectRow(inputs.dataElement)
+        page.selectFilterInTable(inputs.filterLabel, inputs.filterValue)
+            .selectRow(inputs.dataElement)
             .openSyncDialog()
             .next()
             .assertSyncButton(syncButton => syncButton.should("be.disabled"));
     });
 
     it("should have synchronize button enabled if contains org unit, periods, category options and one instance", () => {
-        page.selectRow(inputs.dataElement)
+        page.selectFilterInTable(inputs.filterLabel, inputs.filterValue)
+            .selectRow(inputs.dataElement)
             .openSyncDialog()
             .next()
             .selectReceiverInstance(inputs.instance)
@@ -63,7 +70,8 @@ context("Manual metadata sync", function() {
     });
 
     it("should sync correctly with dependencies with default include rule", () => {
-        page.selectRow(inputs.dataElement)
+        page.selectFilterInTable(inputs.filterLabel, inputs.filterValue)
+            .selectRow(inputs.dataElement)
             .openSyncDialog()
             .next()
 
@@ -75,7 +83,8 @@ context("Manual metadata sync", function() {
             .closeSyncResultsDialog();
     });
     it("should sync correctly without excluded dependencies if rules are customized", () => {
-        page.selectRow(inputs.dataElement)
+        page.selectFilterInTable(inputs.filterLabel, inputs.filterValue)
+            .selectRow(inputs.dataElement)
             .openSyncDialog()
 
             .changeUseDefaultConfiguration()

--- a/cypress/integration/manual-metadata-sync.spec.js
+++ b/cypress/integration/manual-metadata-sync.spec.js
@@ -142,4 +142,23 @@ context("Manual metadata sync", () => {
                 .closeSyncResultsDialog();
         });
     });
+    context("Data set", () => {
+        const dataSetInputs = {
+            filterLabel: "Metadata type",
+            filterValue: "Data Set",
+            dataElement: "Malaria annual data",
+            instance: targetInstance,
+        };
+
+        it("should sync correctly one user group", () => {
+            page.selectFilterInTable(dataSetInputs.filterLabel, dataSetInputs.filterValue)
+                .selectRow(dataSetInputs.dataElement)
+                .openSyncDialog()
+                .next()
+                .selectReceiverInstance(dataSetInputs.instance)
+                .synchronize()
+                .assertSyncResultsStatus(status => status.contains("Success"))
+                .closeSyncResultsDialog();
+        });
+    });
 });

--- a/cypress/integration/manual-metadata-sync.spec.js
+++ b/cypress/integration/manual-metadata-sync.spec.js
@@ -1,102 +1,125 @@
 import ManualMetadataSyncPageObject from "../support/page-objects/ManualMetadataSyncPageObject";
 
-context("Manual metadata sync", function() {
+context("Manual metadata sync", () => {
     const page = new ManualMetadataSyncPageObject(cy);
-
-    const inputs = {
-        filterLabel: "Metadata type",
-        filterValue: "Data Element",
-        dataElement: "ENTO-ADULT- Household Head Name",
-        instance: "Y5QsHDoD4I0",
-    };
 
     beforeEach(() => {
         page.open();
     });
 
-    it("should have the correct title", () => {
-        page.assertTitle(title => title.contains("Metadata Synchronization"));
+    context("Data element", () => {
+        const dataElementInputs = {
+            filterLabel: "Metadata type",
+            filterValue: "Data Element",
+            dataElement: "ENTO-ADULT- Household Head Name",
+            instance: "Y5QsHDoD4I0",
+        };
+
+        it("should have the correct title", () => {
+            page.assertTitle(title => title.contains("Metadata Synchronization"));
+        });
+
+        //TODO: this test is commented because some times on this page the search typing not working
+        //      in cypress there are a issue for this bug https://github.com/cypress-io/cypress/issues/5480
+        // it("should show correct rows after search", ()=>  {
+        //     page.search(anyDataElement).selectRow(anyDataElement);
+        // });
+
+        it("should sync correctly one data element", () => {
+            page.selectFilterInTable(dataElementInputs.filterLabel, dataElementInputs.filterValue)
+                .selectRow(dataElementInputs.dataElement)
+                .openSyncDialog()
+                .next()
+                .selectReceiverInstance(dataElementInputs.instance)
+                .synchronize()
+                .assertSyncResultsStatus(status => status.contains("Success"))
+                .closeSyncResultsDialog();
+        });
+
+        it("should show the instance selection step error if user try click on next without selecting an instance", () => {
+            page.selectFilterInTable(dataElementInputs.filterLabel, dataElementInputs.filterValue)
+                .selectRow(dataElementInputs.dataElement)
+                .openSyncDialog()
+                .next()
+                .next()
+                .assertError(error => error.contains("You need to select at least one instance"));
+        });
+
+        it("should have synchronize button disabled to open sync dialog", () => {
+            page.selectFilterInTable(dataElementInputs.filterLabel, dataElementInputs.filterValue)
+                .selectRow(dataElementInputs.dataElement)
+                .openSyncDialog()
+
+                .assertSyncButton(syncButton => syncButton.should("be.disabled"));
+        });
+
+        it("should have synchronize button disabled if only contains default include exclude", () => {
+            page.selectFilterInTable(dataElementInputs.filterLabel, dataElementInputs.filterValue)
+                .selectRow(dataElementInputs.dataElement)
+                .openSyncDialog()
+                .next()
+                .assertSyncButton(syncButton => syncButton.should("be.disabled"));
+        });
+
+        it("should have synchronize button enabled if contains org unit, periods, category options and one instance", () => {
+            page.selectFilterInTable(dataElementInputs.filterLabel, dataElementInputs.filterValue)
+                .selectRow(dataElementInputs.dataElement)
+                .openSyncDialog()
+                .next()
+                .selectReceiverInstance(dataElementInputs.instance)
+                .assertSyncButton(syncButton => syncButton.should("not.be.disabled"));
+        });
+
+        it("should sync correctly with dependencies with default include rule", () => {
+            page.selectFilterInTable(dataElementInputs.filterLabel, dataElementInputs.filterValue)
+                .selectRow(dataElementInputs.dataElement)
+                .openSyncDialog()
+                .next()
+
+                .selectReceiverInstance(dataElementInputs.instance)
+                .synchronize()
+
+                .assertSyncResultsStatus(status => status.contains("Success"))
+                .assertSyncResultsSummary(summary => summary.contains("Attribute"))
+                .closeSyncResultsDialog();
+        });
+        it("should sync correctly without excluded dependencies if rules are customized", () => {
+            page.selectFilterInTable(dataElementInputs.filterLabel, dataElementInputs.filterValue)
+                .selectRow(dataElementInputs.dataElement)
+                .openSyncDialog()
+
+                .changeUseDefaultConfiguration()
+                .selectMetadataType("Data Element")
+                .excludeRule("Attributes")
+                .next()
+
+                .selectReceiverInstance(dataElementInputs.instance)
+                .synchronize()
+
+                .assertSyncResultsStatus(status => status.contains("Success"))
+                .assertSyncResultsSummary(summary =>
+                    summary.contains("Attribute").should("not.exist")
+                )
+                .closeSyncResultsDialog();
+        });
     });
+    context("Dashboard", () => {
+        const dashboardInputs = {
+            filterLabel: "Metadata type",
+            filterValue: "Dashboard",
+            dataElement: "Malaria Quality Control",
+            instance: "Y5QsHDoD4I0",
+        };
 
-    //TODO: this test is commented because some times on this page the search typing not working
-    //      in cypress there are a issue for this bug https://github.com/cypress-io/cypress/issues/5480
-    // it("should show correct rows after search", ()=>  {
-    //     page.search(anyDataElement).selectRow(anyDataElement);
-    // });
-
-    it("should sync correctly one data element", () => {
-        page.selectFilterInTable(inputs.filterLabel, inputs.filterValue)
-            .selectRow(inputs.dataElement)
-            .openSyncDialog()
-            .next()
-            .selectReceiverInstance(inputs.instance)
-            .synchronize()
-            .assertSyncResultsStatus(status => status.contains("Success"))
-            .closeSyncResultsDialog();
-    });
-
-    it("should show the instance selection step error if user try click on next without selecting an instance", () => {
-        page.selectFilterInTable(inputs.filterLabel, inputs.filterValue)
-            .selectRow(inputs.dataElement)
-            .openSyncDialog()
-            .next()
-            .next()
-            .assertError(error => error.contains("You need to select at least one instance"));
-    });
-
-    it("should have synchronize button disabled to open sync dialog", () => {
-        page.selectFilterInTable(inputs.filterLabel, inputs.filterValue)
-            .selectRow(inputs.dataElement)
-            .openSyncDialog()
-
-            .assertSyncButton(syncButton => syncButton.should("be.disabled"));
-    });
-
-    it("should have synchronize button disabled if only contains default include exclude", () => {
-        page.selectFilterInTable(inputs.filterLabel, inputs.filterValue)
-            .selectRow(inputs.dataElement)
-            .openSyncDialog()
-            .next()
-            .assertSyncButton(syncButton => syncButton.should("be.disabled"));
-    });
-
-    it("should have synchronize button enabled if contains org unit, periods, category options and one instance", () => {
-        page.selectFilterInTable(inputs.filterLabel, inputs.filterValue)
-            .selectRow(inputs.dataElement)
-            .openSyncDialog()
-            .next()
-            .selectReceiverInstance(inputs.instance)
-            .assertSyncButton(syncButton => syncButton.should("not.be.disabled"));
-    });
-
-    it("should sync correctly with dependencies with default include rule", () => {
-        page.selectFilterInTable(inputs.filterLabel, inputs.filterValue)
-            .selectRow(inputs.dataElement)
-            .openSyncDialog()
-            .next()
-
-            .selectReceiverInstance(inputs.instance)
-            .synchronize()
-
-            .assertSyncResultsStatus(status => status.contains("Success"))
-            .assertSyncResultsSummary(summary => summary.contains("Attribute"))
-            .closeSyncResultsDialog();
-    });
-    it("should sync correctly without excluded dependencies if rules are customized", () => {
-        page.selectFilterInTable(inputs.filterLabel, inputs.filterValue)
-            .selectRow(inputs.dataElement)
-            .openSyncDialog()
-
-            .changeUseDefaultConfiguration()
-            .selectMetadataType("Data Element")
-            .excludeRule("Attributes")
-            .next()
-
-            .selectReceiverInstance(inputs.instance)
-            .synchronize()
-
-            .assertSyncResultsStatus(status => status.contains("Success"))
-            .assertSyncResultsSummary(summary => summary.contains("Attribute").should("not.exist"))
-            .closeSyncResultsDialog();
+        it("should sync correctly one dashboard", () => {
+            page.selectFilterInTable(dashboardInputs.filterLabel, dashboardInputs.filterValue)
+                .selectRow(dashboardInputs.dataElement)
+                .openSyncDialog()
+                .next()
+                .selectReceiverInstance(dashboardInputs.instance)
+                .synchronize()
+                .assertSyncResultsStatus(status => status.contains("Success"))
+                .closeSyncResultsDialog();
+        });
     });
 });

--- a/cypress/integration/manual-metadata-sync.spec.js
+++ b/cypress/integration/manual-metadata-sync.spec.js
@@ -2,6 +2,7 @@ import ManualMetadataSyncPageObject from "../support/page-objects/ManualMetadata
 
 context("Manual metadata sync", () => {
     const page = new ManualMetadataSyncPageObject(cy);
+    const targetInstance = "Y5QsHDoD4I0";
 
     beforeEach(() => {
         page.open();
@@ -12,7 +13,7 @@ context("Manual metadata sync", () => {
             filterLabel: "Metadata type",
             filterValue: "Data Element",
             dataElement: "ENTO-ADULT- Household Head Name",
-            instance: "Y5QsHDoD4I0",
+            instance: targetInstance,
         };
 
         it("should have the correct title", () => {
@@ -108,7 +109,7 @@ context("Manual metadata sync", () => {
             filterLabel: "Metadata type",
             filterValue: "Dashboard",
             dataElement: "Malaria Quality Control",
-            instance: "Y5QsHDoD4I0",
+            instance: targetInstance,
         };
 
         it("should sync correctly one dashboard", () => {
@@ -117,6 +118,25 @@ context("Manual metadata sync", () => {
                 .openSyncDialog()
                 .next()
                 .selectReceiverInstance(dashboardInputs.instance)
+                .synchronize()
+                .assertSyncResultsStatus(status => status.contains("Success"))
+                .closeSyncResultsDialog();
+        });
+    });
+    context("User group", () => {
+        const userGroupInputs = {
+            filterLabel: "Metadata type",
+            filterValue: "User Group",
+            dataElement: "Malaria access",
+            instance: targetInstance,
+        };
+
+        it("should sync correctly one user group", () => {
+            page.selectFilterInTable(userGroupInputs.filterLabel, userGroupInputs.filterValue)
+                .selectRow(userGroupInputs.dataElement)
+                .openSyncDialog()
+                .next()
+                .selectReceiverInstance(userGroupInputs.instance)
                 .synchronize()
                 .assertSyncResultsStatus(status => status.contains("Success"))
                 .closeSyncResultsDialog();

--- a/cypress/integration/metadata-sync-rule-edit.spec.js
+++ b/cypress/integration/metadata-sync-rule-edit.spec.js
@@ -28,6 +28,7 @@ context("Metadata sync rule edit", function() {
 
     it("should have the correct selected metadata", () => {
         page.next()
+            .selectFilterInTable("Metadata type", "Data Element")
             .checkOnlySelectedItems()
             .assertSelectedMetadata(selectedMetadata => {
                 selectedMetadata.contains(

--- a/cypress/integration/metadata-sync-rule-new.spec.js
+++ b/cypress/integration/metadata-sync-rule-new.spec.js
@@ -5,6 +5,8 @@ context("Metadata sync rule new", function() {
 
     const inputs = {
         name: "test",
+        filterLabel: "Metadata type",
+        filterValue: "Data Element",
         dataElement: "ENTO-ADULT- Household Head Name",
         instance: "Y5QsHDoD4I0",
     };
@@ -33,6 +35,7 @@ context("Metadata sync rule new", function() {
     it("should show the instance selection step error if user try click on next without selecting an instance", () => {
         page.typeName(inputs.name)
             .next()
+            .selectFilterInTable(inputs.filterLabel, inputs.filterValue)
             .selectRow(inputs.dataElement)
             .next()
             .next()

--- a/cypress/integration/metadata-sync-rule-new.spec.js
+++ b/cypress/integration/metadata-sync-rule-new.spec.js
@@ -46,6 +46,7 @@ context("Metadata sync rule new", function() {
     it("should create a new Sync Rule", () => {
         page.typeName(inputs.name)
             .next()
+            .selectFilterInTable(inputs.filterLabel, inputs.filterValue)
             .selectRow(inputs.dataElement)
             .next()
             .changeUseDefaultConfiguration()

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -112,6 +112,10 @@ Cypress.Commands.add("selectRowInTableByText", text => {
         .click();
 });
 
+Cypress.Commands.add("selectFilterInTable", (filterLabel, filterValue) => {
+    cy.selectInDropdown("#app", filterLabel, filterValue);
+});
+
 Cypress.Commands.add("selectInDropdown", (containerSelector, label, option) => {
     const parent = containerSelector ? cy.get(containerSelector) : cy;
 

--- a/cypress/support/page-objects/ManualMetadataSyncPageObject.js
+++ b/cypress/support/page-objects/ManualMetadataSyncPageObject.js
@@ -26,6 +26,11 @@ class ManualMetadataSyncPageObject extends ManualSyncPageObject {
         return this;
     }
 
+    selectFilterInTable(filterLabel, filterValue) {
+        cy.selectFilterInTable(filterLabel, filterValue);
+        return this;
+    }
+
     excludeRule(rule) {
         includeExcludeStep.excludeRule(dataTest(`DialogContent-metadata-synchronization`), rule);
         return this;

--- a/cypress/support/page-objects/common/SyncRuleDetailPageObject.js
+++ b/cypress/support/page-objects/common/SyncRuleDetailPageObject.js
@@ -51,6 +51,11 @@ export default class SyncRuleDetailPageObject extends PageObject {
         return this;
     }
 
+    selectFilterInTable(filterLabel, filterValue) {
+        cy.selectFilterInTable(filterLabel, filterValue);
+        return this;
+    }
+
     next() {
         this.cy.get('[data-test="Button-next-→"]').click();
         return this;

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "d2": "^31.8.1",
     "d2-api": "0.2.0",
     "d2-manifest": "^1.0.0",
-    "d2-ui-components": "1.3.0-beta.1",
+    "d2-ui-components": "1.3.0",
     "downshift": "^4.1.0",
     "file-saver": "^2.0.2",
     "font-awesome": "^4.7.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "metadata-synchronization",
   "description": "Advanced metadata & data synchronization utility",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "license": "GPL-3.0",
   "author": "EyeSeeTea team",
   "homepage": ".",

--- a/src/models/__tests__/syncRule.spec.ts
+++ b/src/models/__tests__/syncRule.spec.ts
@@ -5,7 +5,7 @@ const indicatorIncludeExcludeRules = {
     includeRules: [
         "attributes",
         "legendSets",
-        "indicatorType",
+        "indicatorTypes",
         "indicatorGroups",
         "indicatorGroups.attributes",
         "indicatorGroups.indicatorGroupSet",
@@ -109,7 +109,7 @@ describe("SyncRule", () => {
                     includeRules: [
                         "attributes",
                         "legendSets",
-                        "indicatorType",
+                        "indicatorTypes",
                         "indicatorGroups",
                         "indicatorGroups.attributes",
                         "indicatorGroups.indicatorGroupSet",

--- a/src/models/d2Model.ts
+++ b/src/models/d2Model.ts
@@ -557,7 +557,7 @@ export class DashboardModel extends D2Model {
         "eventReports",
         "maps",
         "reports",
-        "reportTables"
+        "reportTables",
     ];
 }
 

--- a/src/models/d2Model.ts
+++ b/src/models/d2Model.ts
@@ -307,6 +307,44 @@ export class DataSetModel extends D2Model {
     protected static fields = dataSetFields;
     protected static childrenKeys = ["dataElements"];
 
+    protected static excludeRules = [
+        "indicators.dataSets",
+        "indicators.programs",
+        "dataElements.dataSets",
+        "dataElements.dataElementGroups.dataElements",
+        "dataElements.dataElementGroups.dataElementGroupSets.dataElementGroups",
+    ];
+    protected static includeRules = [
+        "attributes",
+        "legendSets",
+        "categoryCombos",
+        "categoryCombos.attributes",
+        "categoryCombos.categoryOptionCombos",
+        "categoryCombos.categoryOptionCombos.categoryOptions",
+        "categoryCombos.categories",
+        "indicators",
+        "indicators.attributes",
+        "indicators.legendSets",
+        "indicators.indicatorTypes",
+        "indicators.indicatorGroups",
+        "indicators.indicatorGroups.attributes",
+        "indicators.indicatorGroups.indicatorGroupSet",
+        "dataElements",
+        "dataElements.attributes",
+        "dataElements.legendSets",
+        "dataElements.optionSets",
+        "dataElements.optionSets.options",
+        "dataElements.categoryCombos",
+        "dataElements.categoryCombos.attributes",
+        "dataElements.categoryCombos.categoryOptionCombos",
+        "dataElements.categoryCombos.categoryOptionCombos.categoryOptions",
+        "dataElements.categoryCombos.categories",
+        "dataElements.dataElementGroups",
+        "dataElements.dataElementGroups.attributes",
+        "dataElements.dataElementGroups.dataElementGroupSets",
+        "dataElements.dataElementGroups.dataElementGroupSets.attributes",
+    ];
+
     protected static modelTransform = (
         dataSets: SelectedPick<D2DataSetSchema, typeof dataSetFields>[]
     ) => {
@@ -381,7 +419,7 @@ export class IndicatorModel extends D2Model {
     protected static includeRules = [
         "attributes",
         "legendSets",
-        "indicatorType",
+        "indicatorTypes",
         "indicatorGroups",
         "indicatorGroups.attributes",
         "indicatorGroups.indicatorGroupSet",

--- a/src/models/d2Model.ts
+++ b/src/models/d2Model.ts
@@ -499,6 +499,14 @@ export class DashboardModel extends D2Model {
     ];
 }
 
+export class UserGroupModel extends D2Model {
+    protected static metadataType = "userGroup";
+    protected static collectionName = "userGroups" as const;
+
+    protected static excludeRules = [];
+    protected static includeRules = ["users"];
+}
+
 export function defaultModel(pascalCaseModelName: string): any {
     return class DefaultModel extends D2Model {
         protected static metadataType = pascalCaseModelName;

--- a/src/models/d2Model.ts
+++ b/src/models/d2Model.ts
@@ -481,6 +481,24 @@ export class ValidationRuleGroupModel extends D2Model {
     protected static includeRules = ["attributes", "validationRules", "validationRules.attributes"];
 }
 
+export class DashboardModel extends D2Model {
+    protected static metadataType = "dashboard";
+    protected static collectionName = "dashboards" as const;
+    //protected static groupFilterName = "indicatorGroups" as const;
+
+    protected static excludeRules = [];
+    protected static includeRules = [
+        "dashboardItems",
+        "charts",
+        "eventCharts",
+        "pivotTables",
+        "eventReports",
+        "maps",
+        "reports",
+        "reportTables"
+    ];
+}
+
 export function defaultModel(pascalCaseModelName: string): any {
     return class DefaultModel extends D2Model {
         protected static metadataType = pascalCaseModelName;

--- a/src/models/d2ModelFactory.ts
+++ b/src/models/d2ModelFactory.ts
@@ -22,7 +22,7 @@ export const metadataModels = [
     classes.ProgramIndicatorGroupModel,
     classes.ProgramRuleModel,
     classes.ProgramRuleVariableModel,
-    classes.UserGroupModel
+    classes.UserGroupModel,
 ];
 
 /**

--- a/src/models/d2ModelFactory.ts
+++ b/src/models/d2ModelFactory.ts
@@ -4,6 +4,7 @@ import * as classes from "./d2Model";
 import { D2Model, defaultModel } from "./d2Model";
 
 export const metadataModels = [
+    classes.DashboardModel,
     classes.DataElementModel,
     classes.DataElementGroupModel,
     classes.DataElementGroupSetModel,

--- a/src/models/d2ModelFactory.ts
+++ b/src/models/d2ModelFactory.ts
@@ -21,6 +21,7 @@ export const metadataModels = [
     classes.ProgramIndicatorGroupModel,
     classes.ProgramRuleModel,
     classes.ProgramRuleVariableModel,
+    classes.UserGroupModel
 ];
 
 /**

--- a/src/models/d2ModelFactory.ts
+++ b/src/models/d2ModelFactory.ts
@@ -8,6 +8,7 @@ export const metadataModels = [
     classes.DataElementModel,
     classes.DataElementGroupModel,
     classes.DataElementGroupSetModel,
+    classes.DataSetModel,
     classes.IndicatorModel,
     classes.IndicatorGroupModel,
     classes.IndicatorGroupSetModel,

--- a/yarn.lock
+++ b/yarn.lock
@@ -4577,10 +4577,10 @@ d2-manifest@^1.0.0:
     minimist "^1.1.0"
     readline-sync "^1.4.1"
 
-d2-ui-components@1.3.0-beta.1:
-  version "1.3.0-beta.1"
-  resolved "https://registry.yarnpkg.com/d2-ui-components/-/d2-ui-components-1.3.0-beta.1.tgz#9a00aab9d442ea4771ef0232ce0988cdd1693b64"
-  integrity sha512-r0pJla9uKYNaT5TFRzP3FFBV9zYFwphEq/LFXCAzOKUnm90+fSOecuU2yUwOAaU/h6fegug3dorx1hokLC+fmA==
+d2-ui-components@1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/d2-ui-components/-/d2-ui-components-1.3.0.tgz#1ab87580fc07fe57573c8eae475c9581e400aaa0"
+  integrity sha512-F7psGDnAnmMSk9fmz7tgakHYGLeD56+WJc/DkT4UMBbnuf59Fgg88KDRyEWr+QJ8bhvo/xBvRGYe8bl/ZfVbZg==
   dependencies:
     "@date-io/core" "^1.3.6"
     "@date-io/moment" "^1.0.2"


### PR DESCRIPTION
### :pushpin: References

* **Issue:** Closes #415 

### :memo: Implementation

- I have added the Dashboard model to metadata models 
- I have added the UserGroup model to metadata models
- I have added the DataSet model to metadata models
- I have created new tests

### :art: Screenshots


### :fire: Is there anything the reviewer should know to test it?

#### Dashboards
The sync process fails if the dashboards contain related metadata as org units and this metadata does not exist in the target instance.

#### UserGroup
The sync process fails if the dashboards contain related metadata as org units and this metadata does not exist in the target instance.

User roles can not be synced directly with UserGroup and users because roles are embedded under UserCredentials and current data sync logic not found user roles to add it in the package to upload.
A possible solution is to add the UserRole model to metadata models and sync it previously, another is created custom sync to this scenario.

#### Dataset
I have found a bug with related indicators if related IndicatorGroupSet does not exist in the target instance even if this model is in the include rule list, this include rule not working and sync fail. This bug occurs also when you sync indicator model directly.

IndicatorGroupSet bug I think is an API problem because the api/IndicatorGroups endpoint does not return the related IndicatorGroupSet.

### :bookmark_tabs: Others

- Any change in the [GUI library](https://github.com/EyeSeeTea/d2-ui-components)? If so, what branch/PR?
