### PR TITLE
Feature/add five years and change title

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -794,7 +794,7 @@ msgstr ""
 msgid "Aggregated metadata mapping"
 msgstr ""
 
-msgid "Events metadata mapping"
+msgid "Program mapping"
 msgstr ""
 
 msgid "Organisation unit metadata mapping"
@@ -940,6 +940,9 @@ msgid "This year"
 msgstr ""
 
 msgid "Last year"
+msgstr ""
+
+msgid "Last 5 years"
 msgstr ""
 
 msgid "Field {{field}} cannot be blank"

--- a/src/components/sync-wizard/data/EventsSelectionStep.tsx
+++ b/src/components/sync-wizard/data/EventsSelectionStep.tsx
@@ -88,7 +88,12 @@ export default function EventsSelectionStep({ syncRule, onChange }: SyncWizardSt
         },
         { name: "orgUnitName" as const, text: i18n.t("Organisation unit"), sortable: true },
         { name: "eventDate" as const, text: i18n.t("Event date"), sortable: true },
-        { name: "lastUpdated" as const, text: i18n.t("Last updated"), sortable: true },
+        {
+            name: "lastUpdated" as const,
+            text: i18n.t("Last updated"),
+            sortable: true,
+            hidden: true,
+        },
         { name: "status" as const, text: i18n.t("Status"), sortable: true },
         { name: "storedBy" as const, text: i18n.t("Stored by"), sortable: true },
     ];

--- a/src/pages/instance-mapping/InstanceMappingPage.tsx
+++ b/src/pages/instance-mapping/InstanceMappingPage.tsx
@@ -20,7 +20,7 @@ const config = {
         models: [AggregatedDataElementModel],
     },
     tracker: {
-        title: i18n.t("Events metadata mapping"),
+        title: i18n.t("Program mapping"),
         models: [ProgramModel],
     },
     orgUnit: {

--- a/src/utils/synchronization.ts
+++ b/src/utils/synchronization.ts
@@ -267,6 +267,7 @@ export const availablePeriods: {
     LAST_QUARTER: { name: i18n.t("Last quarter"), start: [1, "quarter"] },
     THIS_YEAR: { name: i18n.t("This year"), start: [0, "year"] },
     LAST_YEAR: { name: i18n.t("Last year"), start: [1, "year"] },
+    LAST_FIVE_YEARS: { name: i18n.t("Last 5 years"), start: [5, "year"], end: [1, "year"] },
 };
 
 function buildPeriodFromParams(params: DataSynchronizationParams): [Moment, Moment] {


### PR DESCRIPTION
### :pushpin: References

* **Issue:** Closes #423 
* **Issue:** Closes #424 
* **Issue:** Closes #426

### :memo: Implementation

- I have checked the last 5 years period for event report and pivot table (with aggr). 
They do not include the current year, for example the last 5 years now is:
from 01-01-2015 to 12-12-2019

### :art: Screenshots


### :fire: Is there anything the reviewer should know to test it?

- You must verify that the event mapping title has changed.
- You should check that the last 5 years period takes events and datasets from 01-01-2015 until 12-31-2019 (I created the data, but it can be seen in the api call). And check that for event data and aggregate data.
- That the last updated column is hidden by default for events when you select in an event rule: program-> org unit-> period-> events

### :bookmark_tabs: Others

- Any change in the [GUI library](https://github.com/EyeSeeTea/d2-ui-components)? If so, what branch/PR?
