### PR TITLE
Fix indicator model group set

### DIFF
--- a/src/models/d2Model.ts
+++ b/src/models/d2Model.ts
@@ -334,7 +334,7 @@ export class DataSetModel extends D2Model {
         "indicators.indicatorTypes",
         "indicators.indicatorGroups",
         "indicators.indicatorGroups.attributes",
-        "indicators.indicatorGroups.indicatorGroupSet",
+        "indicators.indicatorGroups.indicatorGroupSets",
         "dataElements",
         "dataElements.attributes",
         "dataElements.legendSets",
@@ -446,7 +446,7 @@ export class IndicatorModel extends D2Model {
         "indicatorTypes",
         "indicatorGroups",
         "indicatorGroups.attributes",
-        "indicatorGroups.indicatorGroupSet",
+        "indicatorGroups.indicatorGroupSets",
     ];
 }
 


### PR DESCRIPTION
### :pushpin: References

* **Issue:** Closes #

### :memo: Implementation

After testing with new servers build I have verified that metadata endpoint now returns indicatorGroupSets relationships for an indicatorGroup. Then I have modified include rules to the plural and now is indicators sync is working.

### :art: Screenshots


### :fire: Is there anything the reviewer should know to test it?

### :bookmark_tabs: Others

- Any change in the [GUI library](https://github.com/EyeSeeTea/d2-ui-components)? If so, what branch/PR?
