### PR TITLE
[Feature] Allow bypassing migrations on development builds

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2020-07-20T06:29:54.001Z\n"
-"PO-Revision-Date: 2020-07-20T06:29:54.001Z\n"
+"POT-Creation-Date: 2020-07-27T07:32:59.493Z\n"
+"PO-Revision-Date: 2020-07-27T07:32:59.493Z\n"
 
 msgid "Field {{field}} cannot be blank"
 msgstr ""
@@ -384,6 +384,9 @@ msgid ""
 msgstr ""
 
 msgid "Error"
+msgstr ""
+
+msgid "Continue to app anyway"
 msgstr ""
 
 msgid ""

--- a/i18n/es.po
+++ b/i18n/es.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: i18next-conv\n"
-"POT-Creation-Date: 2020-07-20T06:29:27.821Z\n"
+"POT-Creation-Date: 2020-07-27T07:29:11.740Z\n"
 "PO-Revision-Date: 2020-07-10T06:53:30.625Z\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -385,6 +385,9 @@ msgid ""
 msgstr ""
 
 msgid "Error"
+msgstr ""
+
+msgid "Continue to app anyway"
 msgstr ""
 
 msgid ""

--- a/i18n/fr.po
+++ b/i18n/fr.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: i18next-conv\n"
-"POT-Creation-Date: 2020-07-20T06:29:27.821Z\n"
+"POT-Creation-Date: 2020-07-27T07:29:11.740Z\n"
 "PO-Revision-Date: 2020-07-10T06:53:30.625Z\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -385,6 +385,9 @@ msgid ""
 msgstr ""
 
 msgid "Error"
+msgstr ""
+
+msgid "Continue to app anyway"
 msgstr ""
 
 msgid ""

--- a/i18n/pt.po
+++ b/i18n/pt.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: i18next-conv\n"
-"POT-Creation-Date: 2020-07-20T06:29:27.821Z\n"
+"POT-Creation-Date: 2020-07-27T07:29:11.740Z\n"
 "PO-Revision-Date: 2020-07-10T06:53:30.625Z\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -385,6 +385,9 @@ msgid ""
 msgstr ""
 
 msgid "Error"
+msgstr ""
+
+msgid "Continue to app anyway"
 msgstr ""
 
 msgid ""

--- a/src/presentation/webapp/components/migrations/Migrations.tsx
+++ b/src/presentation/webapp/components/migrations/Migrations.tsx
@@ -1,8 +1,7 @@
+import { ConfirmationDialog } from "d2-ui-components";
 import React from "react";
 import i18n from "../../../../locales";
-import { ConfirmationDialog } from "d2-ui-components";
 import { MigrationsRunner } from "../../../../migrations";
-import { Dialog, DialogTitle, DialogContent } from "@material-ui/core";
 
 export interface MigrationsProps {
     runner: MigrationsRunner;
@@ -31,8 +30,10 @@ const Migrations: React.FC<MigrationsProps> = props => {
 
     const actionText = getActionText(state);
 
-    if (state.type === "app-out-of-date") return <MigrationsError runner={runner} />;
-
+    if (state.type === "app-out-of-date") {
+        return <MigrationsError runner={runner} onFinish={onFinish} />;
+    }
+    
     return (
         <ConfirmationDialog
             isOpen={true}
@@ -123,17 +124,25 @@ function getPendingMigrationsText(runner: MigrationsRunner): string {
     );
 }
 
-const MigrationsError: React.FC<{ runner: MigrationsRunner }> = ({ runner }) => (
-    <Dialog open={true}>
-        <DialogTitle>{i18n.t("Error")}</DialogTitle>
+const isDebug = process.env.NODE_ENV === "development";
 
-        <DialogContent style={{ paddingBottom: 30 }}>
-            {i18n.t(
-                "The database version (v{{instanceVersion}}) is greater than the app version (v{{appVersion}}), we cannot continue. Please contact the administrator to update the app.",
-                runner
-            )}
-        </DialogContent>
-    </Dialog>
+const MigrationsError: React.FC<{ runner: MigrationsRunner; onFinish: () => void }> = ({
+    runner,
+    onFinish,
+}) => (
+    <ConfirmationDialog
+        isOpen={true}
+        title={i18n.t("Error")}
+        onSave={isDebug ? onFinish : undefined}
+        saveText={i18n.t("Continue to app anyway")}
+        maxWidth="md"
+        fullWidth={true}
+    >
+        {i18n.t(
+            "The database version (v{{instanceVersion}}) is greater than the app version (v{{appVersion}}), we cannot continue. Please contact the administrator to update the app.",
+            runner
+        )}
+    </ConfirmationDialog>
 );
 
 export default Migrations;


### PR DESCRIPTION
### :pushpin: References

### :memo: Implementation

- When running on development (localhost:8081), if the dataStore is more up-to-date than the running application allow the developer to continue to the app anyway.

- On production the behavior is the same as always, error telling the application cannot be started

### :art: Screenshots

### :fire: Is there anything the reviewer should know to test it?

### :bookmark_tabs: Others

