### PR TITLE
[Fix] Workaround 414-uri too long

### DIFF
--- a/src/data/metadata/MetadataD2ApiRepository.ts
+++ b/src/data/metadata/MetadataD2ApiRepository.ts
@@ -309,7 +309,7 @@ const defaultOrder = { field: "id", order: "asc" } as const;
 interface GetListAllOptions {
     type: ListMetadataParams["type"];
     fields: object;
-    filter: Dictionary<FilterValueBase>,
+    filter: Dictionary<FilterValueBase>;
     order?: ListMetadataParams["order"];
 }
 

--- a/src/data/metadata/MetadataD2ApiRepository.ts
+++ b/src/data/metadata/MetadataD2ApiRepository.ts
@@ -108,11 +108,9 @@ export class MetadataD2ApiRepository implements MetadataRepository {
     private async getListGeneric(options: GetListAllOptions): Promise<GetListGenericResponse> {
         const { type, fields, filter, order = defaultOrder } = options;
         const idFilter = getIdFilter(filter, maxIds);
-        console.log(idFilter)
 
         if (idFilter) {
             const objectsLists = await promiseMap(_.chunk(idFilter.inIds, maxIds), async ids => {
-                console.log("chunk", ids)
                 const newFilter = { ...filter, id: { ...idFilter.value, in: ids } };
                 const { objects } = await this.getApiModel(type)
                     .get({ paging: false, fields, filter: newFilter })
@@ -330,13 +328,7 @@ function getIdFilter(
 ): { inIds: string[]; value: object } | null {
     const inIds = filter?.id?.in;
 
-    if (
-        inIds &&
-        Array.isArray(inIds) &&
-        inIds.length > maxIds &&
-        typeof filter["id"] === "object" &&
-        filter["id"]
-    ) {
+    if (inIds && inIds.length > maxIds) {
         return { inIds, value: filter["id"] };
     } else {
         return null;

--- a/src/data/metadata/MetadataD2ApiRepository.ts
+++ b/src/data/metadata/MetadataD2ApiRepository.ts
@@ -108,9 +108,11 @@ export class MetadataD2ApiRepository implements MetadataRepository {
     private async getListGeneric(options: GetListAllOptions): Promise<GetListGenericResponse> {
         const { type, fields, filter, order = defaultOrder } = options;
         const idFilter = getIdFilter(filter, maxIds);
+        console.log(idFilter)
 
         if (idFilter) {
             const objectsLists = await promiseMap(_.chunk(idFilter.inIds, maxIds), async ids => {
+                console.log("chunk", ids)
                 const newFilter = { ...filter, id: { ...idFilter.value, in: ids } };
                 const { objects } = await this.getApiModel(type)
                     .get({ paging: false, fields, filter: newFilter })
@@ -326,7 +328,7 @@ function getIdFilter(
     filter: Dictionary<FilterValueBase>,
     maxIds: number
 ): { inIds: string[]; value: object } | null {
-    const inIds = filter ? filter["id"] : undefined;
+    const inIds = filter?.id?.in;
 
     if (
         inIds &&

--- a/src/data/metadata/MetadataD2ApiRepository.ts
+++ b/src/data/metadata/MetadataD2ApiRepository.ts
@@ -24,6 +24,8 @@ import {
     metadataTransformationsFromDhis2,
     metadataTransformationsToDhis2,
 } from "../transformations/PackageTransformations";
+import { promiseMap } from "../../utils/common";
+import { paginate } from "../../utils/pagination";
 
 export class MetadataD2ApiRepository implements MetadataRepository {
     private api: D2Api;
@@ -59,14 +61,13 @@ export class MetadataD2ApiRepository implements MetadataRepository {
         fields = { $owner: true },
         page,
         pageSize,
+        order,
         ...params
     }: ListMetadataParams): Promise<ListMetadataResponse> {
         const filter = this.buildListFilters(params);
         const { apiVersion } = this.instance;
-
-        const { objects, pager } = await this.getApiModel(type)
-            .get({ paging: true, fields, filter, page, pageSize })
-            .getData();
+        const options = { type, fields, filter, order, page, pageSize };
+        const { objects, pager } = await this.getListPaginated(options);
 
         const metadataPackage = this.transformationRepository.mapPackageFrom(
             apiVersion,
@@ -81,14 +82,12 @@ export class MetadataD2ApiRepository implements MetadataRepository {
     public async listAllMetadata({
         type,
         fields = { $owner: true },
+        order,
         ...params
     }: ListMetadataParams): Promise<MetadataEntity[]> {
         const filter = this.buildListFilters(params);
         const { apiVersion } = this.instance;
-
-        const { objects } = await this.getApiModel(type)
-            .get({ paging: false, fields, filter })
-            .getData();
+        const objects = await this.getListAll({ type, fields, filter, order });
 
         const metadataPackage = this.transformationRepository.mapPackageFrom(
             apiVersion,
@@ -97,6 +96,60 @@ export class MetadataD2ApiRepository implements MetadataRepository {
         );
 
         return metadataPackage[type as keyof MetadataEntities] ?? [];
+    }
+
+    /*
+        Problem: When using a filter `{ id: { in: [id1, id2, ...] } }`, the request URL may result
+        in a HTTP 414 URI Too Long (typically, the limit is 8Kb).
+
+        Solution: Perform N sequential request and concatenate (+ sort) the objects manually.
+    */
+    private async getListGeneric(options: GetListAllOptions): Promise<GetListGenericResponse> {
+        const { type, fields, filter, order = defaultOrder } = options;
+        const idFilter = getIdFilter(filter, maxIds);
+
+        if (idFilter) {
+            const objectsLists = await promiseMap(_.chunk(idFilter.inIds, maxIds), async ids => {
+                const newFilter = { ...filter, id: { ...idFilter.value, in: ids } };
+                const { objects } = await this.getApiModel(type)
+                    .get({ paging: false, fields, filter: newFilter })
+                    .getData();
+                return objects;
+            });
+
+            const objects = _(objectsLists).flatten().orderBy([order.field], [order.order]).value();
+            return { useSingleApiRequest: false, objects };
+        } else {
+            const apiOrder = `${order.field}:${order.order}`;
+            return { useSingleApiRequest: true, order: apiOrder };
+        }
+    }
+
+    private async getListAll(options: GetListAllOptions) {
+        const { type, fields, filter, order = defaultOrder } = options;
+        const list = await this.getListGeneric({ type, fields, filter, order });
+
+        if (list.useSingleApiRequest) {
+            const { objects } = await this.getApiModel(type)
+                .get({ paging: false, fields, filter, order: list.order })
+                .getData();
+            return objects;
+        } else {
+            return list.objects;
+        }
+    }
+
+    private async getListPaginated(options: GetListPaginatedOptions) {
+        const { type, fields, filter, order = defaultOrder, page = 1, pageSize = 50 } = options;
+        const list = await this.getListGeneric({ type, fields, filter, order });
+
+        if (list.useSingleApiRequest) {
+            return this.getApiModel(type)
+                .get({ paging: true, fields, filter, page, pageSize, order: list.order })
+                .getData();
+        } else {
+            return paginate(list.objects, { page, pageSize });
+        }
     }
 
     private buildListFilters({
@@ -247,3 +300,43 @@ const formatStats = (stats: Stats) => ({
     ..._.omit(stats, ["created"]),
     imported: stats.created,
 });
+
+// (max_size=8000 - rest_url=1000) / (id_length=11 + comma_encoded=3)
+const maxIds = 500;
+
+const defaultOrder = { field: "id", order: "asc" } as const;
+
+interface GetListAllOptions {
+    type: ListMetadataParams["type"];
+    fields: object;
+    filter: Record<string, unknown>;
+    order?: ListMetadataParams["order"];
+}
+
+interface GetListPaginatedOptions extends GetListAllOptions {
+    page?: number;
+    pageSize?: number;
+}
+
+type GetListGenericResponse =
+    | { useSingleApiRequest: false; objects: unknown[] }
+    | { useSingleApiRequest: true; order: string };
+
+function getIdFilter(
+    filter: Record<string, unknown>,
+    maxIds: number
+): { inIds: string[]; value: object } | null {
+    const inIds = filter && filter["id"] ? (filter["id"] as { in?: string[] })["in"] : undefined;
+
+    if (
+        inIds &&
+        Array.isArray(inIds) &&
+        inIds.length > maxIds &&
+        typeof filter["id"] === "object" &&
+        filter["id"]
+    ) {
+        return { inIds, value: filter["id"] };
+    } else {
+        return null;
+    }
+}

--- a/src/data/metadata/MetadataD2ApiRepository.ts
+++ b/src/data/metadata/MetadataD2ApiRepository.ts
@@ -309,7 +309,7 @@ const defaultOrder = { field: "id", order: "asc" } as const;
 interface GetListAllOptions {
     type: ListMetadataParams["type"];
     fields: object;
-    filter: Record<string, unknown>;
+    filter: Dictionary<FilterValueBase>,
     order?: ListMetadataParams["order"];
 }
 
@@ -323,10 +323,10 @@ type GetListGenericResponse =
     | { useSingleApiRequest: true; order: string };
 
 function getIdFilter(
-    filter: Record<string, unknown>,
+    filter: Dictionary<FilterValueBase>,
     maxIds: number
 ): { inIds: string[]; value: object } | null {
-    const inIds = filter && filter["id"] ? (filter["id"] as { in?: string[] })["in"] : undefined;
+    const inIds = filter ? filter["id"] : undefined;
 
     if (
         inIds &&

--- a/src/data/metadata/MetadataD2ApiRepository.ts
+++ b/src/data/metadata/MetadataD2ApiRepository.ts
@@ -301,8 +301,7 @@ const formatStats = (stats: Stats) => ({
     imported: stats.created,
 });
 
-// (max_size=8000 - rest_url=1000) / (id_length=11 + comma_encoded=3)
-const maxIds = 500;
+const maxIds = 300;
 
 const defaultOrder = { field: "id", order: "asc" } as const;
 

--- a/src/presentation/webapp/components/metadata-table/MetadataTable.tsx
+++ b/src/presentation/webapp/components/metadata-table/MetadataTable.tsx
@@ -184,6 +184,7 @@ const MetadataTable: React.FC<MetadataTableProps> = ({
             ...state,
             selectedIds: showOnlySelected ? selectedRows : undefined,
             showOnlySelected,
+            page: 1,
         }));
     };
 

--- a/src/utils/pagination.ts
+++ b/src/utils/pagination.ts
@@ -1,0 +1,16 @@
+import _ from "lodash";
+import { Pager } from "../types/d2-api";
+
+export function paginate<T>(
+    objects: T[],
+    options: { page: number; pageSize: number }
+): { objects: T[]; pager: Pager } {
+    const { page, pageSize } = options;
+    const total = objects.length;
+    const pageCount = Math.ceil(objects.length / pageSize);
+    const firstItem = (page - 1) * pageSize;
+    const lastItem = firstItem + pageSize;
+    const paginatedObjects = _.slice(objects, firstItem, lastItem);
+    const pager: Pager = { page, pageSize, pageCount, total };
+    return { objects: paginatedObjects, pager };
+}


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes #250 

### :memo: Implementation

- On `MetadataD2ApiRepository` there were 2 methods affected: `listMetadata` and `listAllMetadata`. I've added two new wrapper methods (`getListAll`, `getListPaginated`) that check the length of the filter `id->in:[ids]` and, if greater than a max value (500): 1) split the list, 2) perform N requests, 3) join the objects, 4) sort the objects (in both cases, api/manual), 4) paginate them (if needed)

- While testing, I noticed that the current page was not reset when filters changed. I don't know if that was the indented behaviour, but I found it problematic, at least for the "only selected items" so I force a `page: 1` for that filter. @SferaDev, can you confirm? Do we need this for the other filters? https://github.com/EyeSeeTea/metadata-synchronization/pull/575/files#diff-e52fd5e6cefafb73b3ea3210d73e7149R187

