### PR TITLE
[Fix] Clear selection in two different tables

### DIFF
--- a/src/presentation/webapp/pages/instance-list/InstanceListPage.tsx
+++ b/src/presentation/webapp/pages/instance-list/InstanceListPage.tsx
@@ -120,9 +120,7 @@ const InstanceListPage = () => {
         }
 
         loading.reset();
-        updateSelection((prevSelection: TableSelection[]) =>
-            _.differenceBy(prevSelection, toDelete, "id")
-        );
+        updateSelection([]);
         deleteInstances([]);
 
         if (_.some(results, [false])) {

--- a/src/presentation/webapp/pages/manual-sync/ManualSyncPage.tsx
+++ b/src/presentation/webapp/pages/manual-sync/ManualSyncPage.tsx
@@ -117,9 +117,13 @@ const ManualSyncPage: React.FC = () => {
 
     const updateSelection = useCallback(
         (selection: string[], exclusion: string[]) => {
-            updateSyncRule(syncRule.updateMetadataIds(selection).updateExcludedIds(exclusion));
+            const syncRule = SyncRule.createOnDemand(type)
+                .updateMetadataIds(selection)
+                .updateExcludedIds(exclusion);
+
+            updateSyncRule(syncRule);
         },
-        [syncRule]
+        [type]
     );
 
     const openSynchronizationDialog = () => {


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://github.com/EyeSeeTea/metadata-synchronization-blessed/issues/72

### :memo: Implementation

- Clear selection in two different pages

### :art: Screenshots

### :fire: Is there anything the reviewer should know to test it?

### :bookmark_tabs: Others
