### PR TITLE
[Fix] Do not remove program relationship of a program indicator

### DIFF
--- a/src/models/dhis/metadata.ts
+++ b/src/models/dhis/metadata.ts
@@ -525,7 +525,7 @@ export class ProgramIndicatorModel extends D2Model {
     protected static collectionName = "programIndicators" as const;
     protected static groupFilterName = "programIndicatorGroups" as const;
 
-    protected static excludeRules = ["programs"];
+    protected static excludeRules = [];
     protected static includeRules = [
         "attributes",
         "legendSets",


### PR DESCRIPTION
### :pushpin: References

### :memo: Implementation

- We were removing the program relationship of program indicators as an exclude rule

### :art: Screenshots

### :fire: Is there anything the reviewer should know to test it?

### :bookmark_tabs: Others

