### PR TITLE
Fix bug origin package not assigned from normal import

### DIFF
--- a/src/presentation/react/components/package-list-table/PackageListTable.tsx
+++ b/src/presentation/react/components/package-list-table/PackageListTable.tsx
@@ -369,6 +369,7 @@ export const PackagesListTable: React.FC<PackagesListTableProps> = ({
 
                         report.addSyncResult({
                             ...result,
+                            originPackage: originPackage.toRef(),
                             origin: remoteInstance?.toPublicObject(),
                         });
                         await report.save(api);


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes #705

### :memo: Implementation

- The source package was already showing in the sync summary, but it was only assigned from the package import wizard, but not from the normal import.

- Now it is also assigned from normal import.

### :art: Screenshots

<img width="1438" alt="Captura de pantalla 2020-11-24 a las 13 18 04" src="https://user-images.githubusercontent.com/5593590/100093799-4d12a780-2e58-11eb-92e6-37a0c47c2a91.png">

### :fire: Is there anything the reviewer should know to test it?

### :bookmark_tabs: Others

-   Any change in the [GUI library](https://github.com/EyeSeeTea/d2-ui-components)? If so, what branch/PR?

-   Any change in the [D2 Api](https://github.com/EyeSeeTea/d2-api)? If so, what branch/PR?
