### PR TITLE
Fix bug generating multiple package versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
         "d2": "31.8.1",
         "d2-api": "1.4.1",
         "d2-manifest": "1.0.0",
-        "d2-ui-components": "2.2.0",
+        "d2-ui-components": "2.4.0-beta.2",
         "file-saver": "2.0.2",
         "font-awesome": "4.7.0",
         "husky": "4.2.5",

--- a/src/presentation/react/components/module-list-table/ModuleListTable.tsx
+++ b/src/presentation/react/components/module-list-table/ModuleListTable.tsx
@@ -32,6 +32,7 @@ import { ModulePackageListPageProps } from "../../../webapp/pages/module-package
 import { useAppContext } from "../../contexts/AppContext";
 import { NewPackageDialog } from "./NewPackageDialog";
 import { getValidationsByVersionFeedback } from "./utils";
+import { generateUid } from "d2/uid";
 
 export const ModulesListTable: React.FC<ModulePackageListPageProps> = ({
     remoteInstance,
@@ -117,7 +118,7 @@ export const ModulesListTable: React.FC<ModulePackageListPageProps> = ({
 
                         const validations = await compositionRoot.packages.create(
                             remoteInstance?.id ?? "LOCAL",
-                            item,
+                            item.update({ id: generateUid() }),
                             module,
                             dhisVersion
                         );

--- a/yarn.lock
+++ b/yarn.lock
@@ -5252,10 +5252,10 @@ d2-manifest@1.0.0:
     minimist "^1.1.0"
     readline-sync "^1.4.1"
 
-d2-ui-components@2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/d2-ui-components/-/d2-ui-components-2.2.0.tgz#ab09f17caeda144803bbbee9dc0814395ee1b587"
-  integrity sha512-SCkp7RzLJHbys1E8THD8fxF0VdPexGSb3tYqqPHp4jw1dN+GOS3VqBlYWaz3riSUd22NLkK+ntmmgmfWGn4hdw==
+d2-ui-components@2.4.0-beta.2:
+  version "2.4.0-beta.2"
+  resolved "https://registry.yarnpkg.com/d2-ui-components/-/d2-ui-components-2.4.0-beta.2.tgz#7842ba3e115ce1b1156db4d335776bda94878230"
+  integrity sha512-1ehBAvoBoZKFW/UzTmzzy8FO8Z2TOf0RxBeMiHYZssjxXKQwejH2UeQgpuxU6zxXvaEmvCOHabgUMv7uUuk+vQ==
   dependencies:
     "@date-io/core" "^1.3.6"
     "@date-io/moment" "^1.0.2"


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes #760

### :memo: Implementation

- [x] Fix bug generating multiple package versions

We use the same package object generated in the dialog to save the package in the different versions, then we need to generate a new uid for every package to save. This uid generation can not be realized in the CreatePackageUseCase because we would be modifying the created object from the outside and this a potential problem in other parts of the application.
The uid modification must be in the presentation layer.

### :art: Screenshots

### :fire: Is there anything the reviewer should know to test it?

### :bookmark_tabs: Others

-   Any change in the [GUI library](https://github.com/EyeSeeTea/d2-ui-components)? If so, what branch/PR?

-   Any change in the [D2 Api](https://github.com/EyeSeeTea/d2-api)? If so, what branch/PR?
