### PR TITLE
Fix mapping dialog if previously  program has been mapped

### DIFF
--- a/src/presentation/react/core/components/mapping-dialog/MappingDialog.tsx
+++ b/src/presentation/react/core/components/mapping-dialog/MappingDialog.tsx
@@ -85,7 +85,9 @@ const MappingDialog: React.FC<MappingDialogProps> = ({
             const parentMappedId = mappingPath[2];
             compositionRoot.mapping.getValidIds(instance, parentMappedId).then(setFilterRows);
         } else if (mappingType === "programDataElements" && elements.length === 1) {
-            compositionRoot.mapping.getValidIds(instance, elements[0]).then(validIds => {
+            const programId = _.first(elements[0].split("-")) ?? elements[0];
+
+            compositionRoot.mapping.getValidIds(instance, programId).then(validIds => {
                 setFilterRows(buildDataElementFilterForProgram(validIds, elements[0], mapping));
             });
         }


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/cpw49m

### :memo: Implementation

- [x] Fix bug showing data elements in mapping dialog if previously its program has been mapped

### :art: Screenshots

### :fire: Is there anything the reviewer should know to test it?

### :bookmark_tabs: Others

-   Any change in the [GUI library](https://github.com/EyeSeeTea/d2-ui-components)? If so, what branch/PR?

-   Any change in the [D2 Api](https://github.com/EyeSeeTea/d2-api)? If so, what branch/PR?

