### PR TITLE
Reduce dataElementGroups/dataSets to getAggregated call

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2021-04-16T06:46:12.943Z\n"
-"PO-Revision-Date: 2021-04-16T06:46:12.943Z\n"
+"POT-Creation-Date: 2021-04-28T13:44:50.473Z\n"
+"PO-Revision-Date: 2021-04-28T13:44:50.473Z\n"
 
 msgid ""
 "THIS NEW RELEASE INCLUDES SHARING SETTINGS PER INSTANCES. FOR THIS VERSION "
@@ -1875,6 +1875,9 @@ msgstr[0] ""
 msgstr[1] ""
 
 msgid "Synchronization History"
+msgstr ""
+
+msgid "Server error on aggregation"
 msgstr ""
 
 msgid "Aggregate Data For HMIS"

--- a/i18n/es.po
+++ b/i18n/es.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: i18next-conv\n"
-"POT-Creation-Date: 2021-04-16T06:46:12.943Z\n"
+"POT-Creation-Date: 2021-04-28T13:07:25.313Z\n"
 "PO-Revision-Date: 2020-07-10T06:53:30.625Z\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1879,6 +1879,9 @@ msgstr[0] ""
 msgstr[1] ""
 
 msgid "Synchronization History"
+msgstr ""
+
+msgid "Server error on aggregation"
 msgstr ""
 
 msgid "Aggregate Data For HMIS"

--- a/i18n/fr.po
+++ b/i18n/fr.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: i18next-conv\n"
-"POT-Creation-Date: 2021-04-16T06:46:12.943Z\n"
+"POT-Creation-Date: 2021-04-28T13:07:25.313Z\n"
 "PO-Revision-Date: 2020-07-10T06:53:30.625Z\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1879,6 +1879,9 @@ msgstr[0] ""
 msgstr[1] ""
 
 msgid "Synchronization History"
+msgstr ""
+
+msgid "Server error on aggregation"
 msgstr ""
 
 msgid "Aggregate Data For HMIS"

--- a/i18n/pt.po
+++ b/i18n/pt.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: i18next-conv\n"
-"POT-Creation-Date: 2021-04-16T06:46:12.943Z\n"
+"POT-Creation-Date: 2021-04-28T13:07:25.313Z\n"
 "PO-Revision-Date: 2020-07-10T06:53:30.625Z\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1879,6 +1879,9 @@ msgstr[0] ""
 msgstr[1] ""
 
 msgid "Synchronization History"
+msgstr ""
+
+msgid "Server error on aggregation"
 msgstr ""
 
 msgid "Aggregate Data For HMIS"

--- a/src/data/aggregated/AggregatedD2ApiRepository.ts
+++ b/src/data/aggregated/AggregatedD2ApiRepository.ts
@@ -153,8 +153,8 @@ export class AggregatedD2ApiRepository implements AggregatedRepository {
         if (dimensionIds.length === 0 || orgUnits.length === 0) {
             return { dataValues: [] };
         } else if (aggregationType) {
-            const result = await promiseMap(_.chunk(periods, 300), period =>
-                promiseMap(_.chunk(dimensionIds, Math.max(10, 300 - period.length)), ids => {
+            const result = await promiseMap(_.chunk(periods, 5), period =>
+                promiseMap(_.chunk(dimensionIds, Math.max(10, 100 - period.length)), ids => {
                     return this.api
                         .get<AggregatedPackage>("/analytics/dataValueSet.json", {
                             dimension: _.compact([

--- a/src/data/metadata/MetadataD2ApiRepository.ts
+++ b/src/data/metadata/MetadataD2ApiRepository.ts
@@ -512,8 +512,10 @@ export class MetadataD2ApiRepository implements MetadataRepository {
         includeDefaults: boolean
     ): Promise<Record<string, T[]>> {
         const promises = [];
-        for (let i = 0; i < elements.length; i += 100) {
-            const requestElements = elements.slice(i, i + 100).toString();
+        const chunkSize = 50;
+
+        for (let i = 0; i < elements.length; i += chunkSize) {
+            const requestElements = elements.slice(i, i + chunkSize).toString();
             promises.push(
                 this.api
                     .get("/metadata", {

--- a/src/data/reports/ReportsD2ApiRepository.ts
+++ b/src/data/reports/ReportsD2ApiRepository.ts
@@ -54,6 +54,11 @@ export class ReportsD2ApiRepository implements ReportsRepository {
         );
     }
 
+    public async clean(): Promise<void> {
+        const storageClient = await this.getStorageClient();
+        await storageClient.clean();
+    }
+
     public async delete(id: string): Promise<void> {
         const storageClient = await this.getStorageClient();
         await storageClient.removeObjectInCollection(Namespace.HISTORY, id);

--- a/src/data/reports/ReportsD2ApiRepository.ts
+++ b/src/data/reports/ReportsD2ApiRepository.ts
@@ -50,7 +50,7 @@ export class ReportsD2ApiRepository implements ReportsRepository {
         // We do not store payload on the data store
         await storageClient.saveObject<SynchronizationResult[]>(
             `${Namespace.HISTORY}-${report.id}`,
-            report.getResults().map(({ payload: _payload, ...rest }) => ({ ...rest }))
+            report.getResults()
         );
     }
 

--- a/src/data/reports/ReportsD2ApiRepository.ts
+++ b/src/data/reports/ReportsD2ApiRepository.ts
@@ -50,7 +50,7 @@ export class ReportsD2ApiRepository implements ReportsRepository {
         // We do not store payload on the data store
         await storageClient.saveObject<SynchronizationResult[]>(
             `${Namespace.HISTORY}-${report.id}`,
-            report.getResults()
+            report.getResultsForSave()
         );
     }
 

--- a/src/data/storage/StorageConstantClient.ts
+++ b/src/data/storage/StorageConstantClient.ts
@@ -3,7 +3,7 @@ import { generateUid } from "d2/uid";
 import _ from "lodash";
 import { Instance } from "../../domain/instance/entities/Instance";
 import { ObjectSharing, StorageClient } from "../../domain/storage/repositories/StorageClient";
-import { D2Api, SelectedPick } from "../../types/d2-api";
+import { D2Api, SelectedPick, FieldsOf } from "../../types/d2-api";
 import { Dictionary } from "../../types/utils";
 import { promiseMap } from "../../utils/common";
 import { getD2APiFromInstance } from "../../utils/d2-utils";
@@ -32,19 +32,25 @@ export class StorageConstantClient extends StorageClient {
         return value ?? defaultValue;
     }
 
+    private async getConstants<Fields extends FieldsOf<D2ConstantSchema>>(fields: Fields) {
+        const { objects: constants } = await this.api.models.constants
+            .get({
+                paging: false,
+                fields,
+                filter: { code: { $like: CONSTANT_PREFIX } },
+            })
+            .getData();
+
+        return constants;
+    }
+
     public async saveObject<T extends object>(key: string, keyValue: T): Promise<void> {
         const { id } = await this.getConstant<T>(key);
         await this.updateConstant(id, key, keyValue);
 
         // Special scenario, clean history entries
         if (key.startsWith("history")) {
-            const { objects } = await this.api.models.constants
-                .get({
-                    paging: false,
-                    fields: { id: true, code: true, name: true },
-                    filter: { code: { $like: CONSTANT_PREFIX } },
-                })
-                .getData();
+            const objects = await this.getConstants({ id: true, code: true, name: true });
 
             const toDelete = _(objects)
                 .filter(({ code }) => cleanCode(code).startsWith("history"))
@@ -70,13 +76,7 @@ export class StorageConstantClient extends StorageClient {
 
     public async clearStorage(): Promise<void> {
         try {
-            const { objects } = await this.api.models.constants
-                .get({
-                    paging: false,
-                    fields: { id: true, code: true, name: true },
-                    filter: { code: { $like: CONSTANT_PREFIX } },
-                })
-                .getData();
+            const objects = await this.getConstants({ id: true, code: true, name: true });
 
             await this.api.metadata
                 .post({ constants: objects }, { importStrategy: "DELETE" })
@@ -87,13 +87,7 @@ export class StorageConstantClient extends StorageClient {
     }
 
     public async clone(): Promise<Dictionary<unknown>> {
-        const { objects } = await this.api.models.constants
-            .get({
-                paging: false,
-                fields: apiFields,
-                filter: { code: { $like: CONSTANT_PREFIX } },
-            })
-            .getData();
+        const objects = await this.getConstants(apiFields);
 
         // Remove constant prefix key
         return _(objects)
@@ -112,13 +106,7 @@ export class StorageConstantClient extends StorageClient {
     }
 
     public async listKeys(): Promise<string[]> {
-        const { objects } = await this.api.models.constants
-            .get({
-                paging: false,
-                fields: { code: true },
-                filter: { code: { $like: CONSTANT_PREFIX } },
-            })
-            .getData();
+        const objects = await this.getConstants({ code: true });
 
         return _(objects)
             .map(({ code }) => code.replace(new RegExp(`^${CONSTANT_PREFIX}`, ""), ""))

--- a/src/domain/aggregated/usecases/AggregatedSyncUseCase.ts
+++ b/src/domain/aggregated/usecases/AggregatedSyncUseCase.ts
@@ -23,6 +23,7 @@ import {
 } from "../../synchronization/utils";
 import { AggregatedPackage } from "../entities/AggregatedPackage";
 import { DataValue } from "../entities/DataValue";
+import { getMinimumParents } from "../utils";
 
 export class AggregatedSyncUseCase extends GenericSyncUseCase {
     public readonly type = "aggregated";
@@ -69,10 +70,18 @@ export class AggregatedSyncUseCase extends GenericSyncUseCase {
         );
 
         // Retrieve candidate data values from dataElements
+        const dataSetIdsFromDataElements = getMinimumParents(
+            new Map(dataElements.map(de => [de.id, de.dataSetElements.map(dse => dse.dataSet.id)]))
+        );
+
+        const dataElementGroupIdsFromDataElements = getMinimumParents(
+            new Map(dataElements.map(de => [de.id, de.dataElementGroups.map(deg => deg.id)]))
+        );
+
         const { dataValues: candidateDataValues = [] } = await aggregatedRepository.getAggregated(
             dataParams,
-            dataElements.flatMap(de => de.dataSetElements.map(({ dataSet }) => dataSet?.id)),
-            dataElements.flatMap(de => de.dataElementGroups.map(({ id }) => id))
+            dataSetIdsFromDataElements,
+            dataElementGroupIdsFromDataElements
         );
 
         // Retrieve indirect data values from dataElements

--- a/src/domain/aggregated/utils.ts
+++ b/src/domain/aggregated/utils.ts
@@ -3,11 +3,11 @@ import _ from "lodash";
 import { availablePeriods } from "../../utils/synchronization";
 import { DataSynchronizationParams } from "./types";
 
-/* For a map of relationship (child -> parent[]), return the minimum array of parents
+/* For a map of relationships (child -> parent[]), return the minimum array of parents
    that include all of the children.
 
-   Implementation: Invert the original relationship to parent -> child[], and, for every
-   iteration, sort the pairs by length of children, until all children are seen.
+   Implementation: Invert the original relationship and, on every iteration,
+   sort the pairs by the length of children, until all children have been seen.
 */
 export function getMinimumParents(relationships: Map<string, string[]>): string[] {
     const relationshipPairs = _(Array.from(relationships))
@@ -19,29 +19,32 @@ export function getMinimumParents(relationships: Map<string, string[]>): string[
 
     const outputParents: string[] = [];
     const childrenSeen = new Set<string>();
+    let maximum: { parent: string; children: string[] } | undefined;
 
-    // eslint-disable-next-line no-constant-condition
-    while (true) {
-        const maximum = _.maxBy(relationshipPairs, ([_parent, children]) => children.size);
-        if (!maximum) break;
-
-        const [maxParent, maxChildren] = maximum;
-        if (maxChildren.size === 0) break;
-
-        const maxChildrenArray = Array.from(maxChildren);
+    while ((maximum = getRelationshipWithLongestChildren(relationshipPairs))) {
+        const { parent: maxParent, children: maxChildren } = maximum;
 
         outputParents.push(maxParent);
-        maxChildrenArray.forEach(child => childrenSeen.add(child));
+        maxChildren.forEach(child => childrenSeen.add(child));
 
         // Remove seen children from all the relationships
         relationshipPairs.forEach(([_parent, children]) => {
-            maxChildrenArray.forEach(maxChild => {
+            maxChildren.forEach(maxChild => {
                 children.delete(maxChild);
             });
         });
     }
 
     return outputParents;
+}
+
+function getRelationshipWithLongestChildren(
+    relationshipPairs: Array<[string, Set<string>]>
+): { parent: string; children: string[] } | undefined {
+    const maximum = _.maxBy(relationshipPairs, ([_parent, children]) => children.size);
+    if (!maximum) return;
+    const [parent, children] = maximum;
+    return children.size > 0 ? { parent, children: Array.from(children) } : undefined;
 }
 
 export function buildPeriodFromParams(

--- a/src/domain/aggregated/utils.ts
+++ b/src/domain/aggregated/utils.ts
@@ -1,6 +1,48 @@
 import moment, { Moment } from "moment";
+import _ from "lodash";
 import { availablePeriods } from "../../utils/synchronization";
 import { DataSynchronizationParams } from "./types";
+
+/* For a map of relationship (child -> parent[]), return the minimum array of parents
+   that include all of the children.
+
+   Implementation: Invert the original relationship to parent -> child[], and, for every
+   iteration, sort the pairs by length of children, until all children are seen.
+*/
+export function getMinimumParents(relationships: Map<string, string[]>): string[] {
+    const relationshipPairs = _(Array.from(relationships))
+        .flatMap(([child, parent]) => parent.map(parent => ({ child, parent })))
+        .groupBy(obj => obj.parent)
+        .mapValues(objs => new Set(objs.map(obj => obj.child)))
+        .toPairs()
+        .value();
+
+    const outputParents: string[] = [];
+    const childrenSeen = new Set<string>();
+
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+        const maximum = _.maxBy(relationshipPairs, ([_parent, children]) => children.size);
+        if (!maximum) break;
+
+        const [maxParent, maxChildren] = maximum;
+        if (maxChildren.size === 0) break;
+
+        const maxChildrenArray = Array.from(maxChildren);
+
+        outputParents.push(maxParent);
+        maxChildrenArray.forEach(child => childrenSeen.add(child));
+
+        // Remove seen children from all the relationships
+        relationshipPairs.forEach(([_parent, children]) => {
+            maxChildrenArray.forEach(maxChild => {
+                children.delete(maxChild);
+            });
+        });
+    }
+
+    return outputParents;
+}
 
 export function buildPeriodFromParams(
     params: Pick<DataSynchronizationParams, "period" | "startDate" | "endDate">

--- a/src/domain/reports/entities/SynchronizationReport.ts
+++ b/src/domain/reports/entities/SynchronizationReport.ts
@@ -93,7 +93,7 @@ export class SynchronizationReport implements SynchronizationReportData {
         };
     }
 
-    public getResults(): SynchronizationResult[] {
+    public getResultsForSave(): SynchronizationResult[] {
         return (this.results || []).map(({ payload: _payload, instance, origin, ...rest }) => {
             const originValue =
                 origin && (origin as Store).token
@@ -108,6 +108,10 @@ export class SynchronizationReport implements SynchronizationReportData {
                 origin: originValue,
             };
         });
+    }
+
+    public getResults(): SynchronizationResult[] {
+        return this.results ?? [];
     }
 }
 

--- a/src/domain/reports/entities/SynchronizationReport.ts
+++ b/src/domain/reports/entities/SynchronizationReport.ts
@@ -3,6 +3,8 @@ import _ from "lodash";
 import { PartialBy } from "../../../types/utils";
 import { SynchronizationType } from "../../synchronization/entities/SynchronizationType";
 import { SynchronizationResult } from "./SynchronizationResult";
+import { Store } from "../../stores/entities/Store";
+import { PublicInstance } from "../../instance/entities/Instance";
 
 export class SynchronizationReport implements SynchronizationReportData {
     private results: SynchronizationResult[] | null;
@@ -92,7 +94,20 @@ export class SynchronizationReport implements SynchronizationReportData {
     }
 
     public getResults(): SynchronizationResult[] {
-        return this.results ?? [];
+        return (this.results || []).map(({ payload: _payload, instance, origin, ...rest }) => {
+            const originValue =
+                origin && (origin as Store).token
+                    ? origin
+                    : origin && (origin as PublicInstance).name
+                    ? { id: origin.id, name: (origin as PublicInstance).name }
+                    : undefined;
+
+            return {
+                ...rest,
+                instance: { id: instance.id, name: instance.name },
+                origin: originValue,
+            };
+        });
     }
 }
 

--- a/src/domain/reports/entities/SynchronizationResult.ts
+++ b/src/domain/reports/entities/SynchronizationResult.ts
@@ -1,5 +1,4 @@
 import { NamedRef } from "../../common/entities/Ref";
-import { PublicInstance } from "../../instance/entities/Instance";
 import { Store } from "../../stores/entities/Store";
 import { SynchronizationPayload } from "../../synchronization/entities/SynchronizationPayload";
 import { SynchronizationType } from "../../synchronization/entities/SynchronizationType";
@@ -24,8 +23,8 @@ export interface ErrorMessage {
 
 export interface SynchronizationResult {
     status: SynchronizationStatus;
-    origin?: PublicInstance | Store;
-    instance: PublicInstance;
+    origin?: NamedRef | Store; // TODO: Create union
+    instance: NamedRef;
     originPackage?: NamedRef;
     date: Date;
     type: SynchronizationType;

--- a/src/domain/reports/repositories/ReportsRepository.ts
+++ b/src/domain/reports/repositories/ReportsRepository.ts
@@ -11,5 +11,6 @@ export interface ReportsRepository {
     getSyncResults(id: string): Promise<SynchronizationResult[]>;
     list(): Promise<SynchronizationReport[]>;
     save(report: SynchronizationReport): Promise<void>;
+    clean(): Promise<void>;
     delete(id: string): Promise<void>;
 }

--- a/src/domain/reports/usecases/CleanSyncReporstUseCase.ts
+++ b/src/domain/reports/usecases/CleanSyncReporstUseCase.ts
@@ -1,0 +1,11 @@
+import { UseCase } from "../../common/entities/UseCase";
+import { RepositoryFactory } from "../../common/factories/RepositoryFactory";
+import { Instance } from "../../instance/entities/Instance";
+
+export class CleanSyncReportsUseCase implements UseCase {
+    constructor(private repositoryFactory: RepositoryFactory, private localInstance: Instance) {}
+
+    public execute(): Promise<void> {
+        return this.repositoryFactory.reportsRepository(this.localInstance).clean();
+    }
+}

--- a/src/domain/storage/repositories/StorageClient.ts
+++ b/src/domain/storage/repositories/StorageClient.ts
@@ -34,6 +34,7 @@ export abstract class StorageClient {
     public abstract listKeys(): Promise<string[]>;
     public abstract getObjectSharing(key: string): Promise<ObjectSharing | undefined>;
     public abstract saveObjectSharing(key: string, object: ObjectSharing): Promise<void>;
+    public async clean(): Promise<void> {}
 
     public async listObjectsInCollection<T extends Ref>(key: string): Promise<T[]> {
         const collection = await this.getObject<T[]>(key);

--- a/src/presentation/CompositionRoot.ts
+++ b/src/presentation/CompositionRoot.ts
@@ -101,6 +101,7 @@ import { cache } from "../utils/cache";
 import { GetMetadataByIdsUseCase } from "../domain/metadata/usecases/GetMetadataByIdsUseCase";
 import { DownloadPayloadFromSyncRuleUseCase } from "../domain/synchronization/usecases/DownloadPayloadFromSyncRuleUseCase";
 import { UserD2ApiRepository } from "../data/user/UserD2ApiRepository";
+import { CleanSyncReportsUseCase } from "../domain/reports/usecases/CleanSyncReporstUseCase";
 
 export class CompositionRoot {
     private repositoryFactory: RepositoryFactory;
@@ -354,6 +355,7 @@ export class CompositionRoot {
         return getExecute({
             list: new ListSyncReportUseCase(this.repositoryFactory, this.localInstance),
             save: new SaveSyncReportUseCase(this.repositoryFactory, this.localInstance),
+            clean: new CleanSyncReportsUseCase(this.repositoryFactory, this.localInstance),
             delete: new DeleteSyncReportUseCase(this.repositoryFactory, this.localInstance),
             get: new GetSyncReportUseCase(this.repositoryFactory, this.localInstance),
             getSyncResults: new GetSyncResultsUseCase(this.repositoryFactory, this.localInstance),

--- a/src/presentation/react/core/components/sync-summary/SyncSummary.tsx
+++ b/src/presentation/react/core/components/sync-summary/SyncSummary.tsx
@@ -17,7 +17,6 @@ import { ConfirmationDialog, useLoading } from "d2-ui-components";
 import _ from "lodash";
 import React, { useEffect, useState } from "react";
 import ReactJson from "react-json-view";
-import { PublicInstance } from "../../../../../domain/instance/entities/Instance";
 import { SynchronizationReport } from "../../../../../domain/reports/entities/SynchronizationReport";
 import {
     ErrorMessage,
@@ -28,6 +27,7 @@ import { Store } from "../../../../../domain/stores/entities/Store";
 import { SynchronizationType } from "../../../../../domain/synchronization/entities/SynchronizationType";
 import i18n from "../../../../../locales";
 import { useAppContext } from "../../contexts/AppContext";
+import { NamedRef } from "../../../../../domain/common/entities/Ref";
 
 const useStyles = makeStyles(theme => ({
     accordionHeading1: {
@@ -176,12 +176,12 @@ interface SyncSummaryProps {
     onClose: () => void;
 }
 
-const getOriginName = (source: PublicInstance | Store) => {
+const getOriginName = (source: NamedRef | Store) => {
     if ((source as Store).token) {
         const store = source as Store;
         return store.account + " - " + store.repository;
     } else {
-        const instance = source as PublicInstance;
+        const instance = source as NamedRef;
         return instance.name;
     }
 };

--- a/src/presentation/webapp/msf-aggregate-data/pages/MSFHomePagePresenter.ts
+++ b/src/presentation/webapp/msf-aggregate-data/pages/MSFHomePagePresenter.ts
@@ -2,7 +2,7 @@ import _ from "lodash";
 import moment from "moment";
 import { DataSyncAggregation, DataSyncPeriod } from "../../../../domain/aggregated/types";
 import { buildPeriodFromParams } from "../../../../domain/aggregated/utils";
-import { Instance, PublicInstance } from "../../../../domain/instance/entities/Instance";
+import { Instance } from "../../../../domain/instance/entities/Instance";
 import { ProgramIndicator } from "../../../../domain/metadata/entities/MetadataEntities";
 import { SynchronizationReport } from "../../../../domain/reports/entities/SynchronizationReport";
 import { SynchronizationRule } from "../../../../domain/rules/entities/SynchronizationRule";
@@ -17,6 +17,7 @@ import { formatDateLong } from "../../../../utils/date";
 import { availablePeriods } from "../../../../utils/synchronization";
 import { CompositionRoot } from "../../../CompositionRoot";
 import { AdvancedSettings, MSFSettings } from "./MSFEntities";
+import { NamedRef } from "../../../../domain/common/entities/Ref";
 
 type LoggerFunction = (event: string, userType?: "user" | "admin") => void;
 
@@ -377,12 +378,12 @@ async function getLastAnalyticsExecution(compositionRoot: CompositionRoot): Prom
         : i18n.t("never");
 }
 
-const getOriginName = (source: PublicInstance | Store) => {
+const getOriginName = (source: NamedRef | Store) => {
     if ((source as Store).token) {
         const store = source as Store;
         return store.account + " - " + store.repository;
     } else {
-        const instance = source as PublicInstance;
+        const instance = source as NamedRef;
         return instance.name;
     }
 };

--- a/src/presentation/webapp/msf-aggregate-data/pages/MSFHomePagePresenter.ts
+++ b/src/presentation/webapp/msf-aggregate-data/pages/MSFHomePagePresenter.ts
@@ -55,6 +55,8 @@ export async function executeAggregateData(
         return [];
     }
 
+    await compositionRoot.reports.clean();
+
     addEventToProgress(i18n.t(`Synchronizing aggregated data...`));
 
     if (isGlobalInstance() && msfSettings.runAnalytics === "false") {

--- a/src/presentation/webapp/msf-aggregate-data/pages/MSFHomePagePresenter.ts
+++ b/src/presentation/webapp/msf-aggregate-data/pages/MSFHomePagePresenter.ts
@@ -113,6 +113,8 @@ export async function executeAggregateData(
         onUpdateMsfSettings({ ...msfSettings, lastExecutions });
     }
 
+    await compositionRoot.reports.clean();
+
     return reports;
 }
 

--- a/src/presentation/webapp/msf-aggregate-data/pages/MSFHomePagePresenter.ts
+++ b/src/presentation/webapp/msf-aggregate-data/pages/MSFHomePagePresenter.ts
@@ -122,7 +122,7 @@ export async function executeAggregateData(
 }
 
 export function isGlobalInstance(): boolean {
-    return !window.location.host.includes("localhost");
+    return window.location.host.includes("hmisocba.msf.es");
 }
 
 async function validatePreviousDataValues(

--- a/src/types/d2-api.ts
+++ b/src/types/d2-api.ts
@@ -1,3 +1,12 @@
+import { GetOptionValue } from "d2-api/api/common";
+import { D2ApiDefinition } from "d2-api/2.30";
+import { D2ModelSchemaBase } from "d2-api/api/inference";
+
 export * from "d2-api/2.30";
 
 export const API_VERSION = 30;
+
+export type FieldsOf<ModelSchema extends D2ModelSchemaBase> = GetOptionValue<
+    D2ApiDefinition,
+    ModelSchema
+>["fields"];

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -3,7 +3,7 @@ export async function promiseMap<T, S>(
     inputValues: T[],
     mapper: (value: T) => Promise<S>
 ): Promise<S[]> {
-    let output: S[] = [];
+    const output: S[] = [];
     for (const value of inputValues) {
         const res = await mapper(value);
         output.push(res);

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -1,11 +1,12 @@
 /* Map sequentially over T[] with an asynchronous function and return array of mapped values */
-export function promiseMap<T, S>(inputValues: T[], mapper: (value: T) => Promise<S>): Promise<S[]> {
-    const reducer = (acc$: Promise<S[]>, inputValue: T): Promise<S[]> =>
-        acc$.then((acc: S[]) =>
-            mapper(inputValue).then(result => {
-                acc.push(result);
-                return acc;
-            })
-        );
-    return inputValues.reduce(reducer, Promise.resolve([]));
+export async function promiseMap<T, S>(
+    inputValues: T[],
+    mapper: (value: T) => Promise<S>
+): Promise<S[]> {
+    let output: S[] = [];
+    for (const value of inputValues) {
+        const res = await mapper(value);
+        output.push(res);
+    }
+    return output;
 }


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes #?

### :memo: Implementation

For a map of relationships (child -> parent[]), return the minimum array of parents that include all of the children. 

Code used for: dataElements->dataElementGroups and dataElements->dataSets

Implementation: Invert the original relationship to parent -> child[], and, for every iteration until all children are seen, sort the pairs by length of children, and update the relationship accordingly.