### PR TITLE
[Fix] Initialize correctly migrations

### DIFF
--- a/src/data/migrations/client/MigrationsRunner.ts
+++ b/src/data/migrations/client/MigrationsRunner.ts
@@ -30,9 +30,12 @@ export class MigrationsRunner<T> {
 
     static async init<T>(options: RunnerOptions<T>): Promise<MigrationsRunner<T>> {
         const { migrations, storage, storageKey = "config" } = options;
-        const config = await storage.getOrCreate<Config>(storageKey, {
-            version: getMaxMigrationVersion(migrations),
-        });
+
+        const storageKeys = await storage.listKeys();
+        const freshInstall = storageKeys.length === 0;
+
+        const version = freshInstall ? getMaxMigrationVersion(migrations) : 0;
+        const config = await storage.getOrCreate<Config>(storageKey, { version });
 
         return new MigrationsRunner(config, options);
     }


### PR DESCRIPTION
### :pushpin: References

- https://github.com/EyeSeeTea/Bulk-Load/pull/223

### :memo: Implementation

- With the change introduced to remove the dialog on fresh install we are false detecting other situations (like before migrations was introduced but storage already existed)

### :art: Screenshots

### :fire: Is there anything the reviewer should know to test it?

### :bookmark_tabs: Others

-   Any change in the [GUI library](https://github.com/EyeSeeTea/d2-ui-components)? If so, what branch/PR?

-   Any change in the [D2 Api](https://github.com/EyeSeeTea/d2-api)? If so, what branch/PR?
