### PR TITLE
[Fix] Hide DISABLED mapping on overlaps

### DIFF
--- a/src/presentation/react/core/components/overlapped-mapping-dialog/OverlappedMappingDialog.tsx
+++ b/src/presentation/react/core/components/overlapped-mapping-dialog/OverlappedMappingDialog.tsx
@@ -23,10 +23,10 @@ export const OverlappedMappingDialog = (props: OverlappedMappingDialogProps) => 
     const overlappedMappings = useMemo(
         () =>
             _(mapping.programDataElements)
-                .pickBy((_value, key) => key !== EXCLUDED_KEY && key.startsWith(program))
+                .pickBy((_value, key) => key.startsWith(program))
                 .mapValues((value, key) => ({ ...value, key }))
                 .groupBy(item => item?.mappedId)
-                .pickBy(value => value.length > 1)
+                .pickBy((value, key) => key !== EXCLUDED_KEY && value.length > 1)
                 .mapValues(value => value?.map(({ key }) => key) ?? [])
                 .value(),
         [mapping, program]


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** https://app.clickup.com/t/1e6jy23

### :memo: Implementation

- Do not show DISABLED entries on overlapped mapping dialog

### :art: Screenshots

### :fire: Is there anything the reviewer should know to test it?

### :bookmark_tabs: Others

-   Any change in the [GUI library](https://github.com/EyeSeeTea/d2-ui-components)? If so, what branch/PR?

-   Any change in the [D2 Api](https://github.com/EyeSeeTea/d2-api)? If so, what branch/PR?
