### PR TITLE
Sync rule metadata step - Fix back to page 1 after select item on page 2

### DIFF
--- a/src/presentation/react/core/components/sync-wizard/common/MetadataSelectionStep.tsx
+++ b/src/presentation/react/core/components/sync-wizard/common/MetadataSelectionStep.tsx
@@ -120,7 +120,7 @@ export default function MetadataSelectionStep({ syncRule, onChange }: SyncWizard
                 },
             });
         });
-    }, [compositionRoot, snackbar, syncRule]);
+    }, [compositionRoot, snackbar, syncRule.originInstance]);
 
     const notifyNewModel = useCallback(model => {
         setModel(() => model);


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/1h7vu1x

### :memo: Implementation

- [x] Fix back to page 1 after select item on page 2

### :art: Screenshots

### :fire: Is there anything the reviewer should know to test it?

The problem was the MetadataSelectionStep observe changes in the sync rule object when a change occurs in this object then retrieve the instance and update the state again. This provokes a re-render in the metadata table by the new remote instance object, and this occurs when any prop in the sync rule change as the selected metadata. The metadata table component observes changes in the remote instance prop and then refresh the filters assigning page 1.

The solution is to observe in the MetadataSelectionStep changes in the sync rule but only for the needed property in the useEffect, originInstance in this case, this avoids unnecessary rerender in MetadataTable.

### :bookmark_tabs: Others

-   Any change in the [GUI library](https://github.com/EyeSeeTea/d2-ui-components)? If so, what branch/PR?

-   Any change in the [D2 Api](https://github.com/EyeSeeTea/d2-api)? If so, what branch/PR?
