### PR TITLE
Fix bugs syncing visualizations in 2.36

### DIFF
--- a/src/data/transformations/PackageTransformations.ts
+++ b/src/data/transformations/PackageTransformations.ts
@@ -271,13 +271,13 @@ export const metadataTransformations: Transformation[] = [
 
                 const newCharts = charts.map((chart: any) => {
                     return {
-                        series: (chart.columnDimensions || [])[0],
                         category: (chart.rowDimensions || [])[0],
                         seriesItems: (chart.optionalAxes || []).map(({ dimensionalItem, axis }: any) => ({
                             series: dimensionalItem,
                             axis,
                         })),
                         ...chart,
+                        series: (chart.columnDimensions || [])[0],
                     };
                 });
 
@@ -488,7 +488,7 @@ function getPeriodDataFromYearlySeries(object: any) {
                 .fromPairs()
                 .value(),
         },
-        periods: years.map(year => ({ id: year })),
+        periods: object.periods?.length > 0 ? object.periods : years.map(year => ({ id: year })),
     };
 
     return periodsData;


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/24xgpdf

### :memo: Implementation

These visualization bugs exist on 2.34 also because columnDimensions and fixed periods has not changed between 2.34 and 2.36

- [x] Fix columnDimensions
- [x] Fix fixed periods

### :art: Screenshots

### :fire: Is there anything the reviewer should know to test it?

Create a visualization and add it to a new dashboard. Sync the dashboard between 2.36 instances and the sync should work and the visualization should be created successfully in the destination

### :bookmark_tabs: Others

-   Any change in the [GUI library](https://github.com/EyeSeeTea/d2-ui-components)? If so, what branch/PR?

-   Any change in the [D2 Api](https://github.com/EyeSeeTea/d2-api)? If so, what branch/PR?
