### PR TITLE
added sync/async mode for events

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2022-04-21T07:57:05.960Z\n"
-"PO-Revision-Date: 2022-04-21T07:57:05.960Z\n"
+"POT-Creation-Date: 2022-08-23T08:23:41.146Z\n"
+"PO-Revision-Date: 2022-08-23T08:23:41.146Z\n"
 
 msgid ""
 "THIS NEW RELEASE INCLUDES SHARING SETTINGS PER INSTANCES. FOR THIS VERSION "
@@ -1062,6 +1062,9 @@ msgstr ""
 msgid "Ignore data with same value on destination"
 msgstr ""
 
+msgid "Async mode"
+msgstr ""
+
 msgid "Sync rule {{idx}}: {{name}} ({{id}})"
 msgstr ""
 
@@ -1349,6 +1352,9 @@ msgid "Updates"
 msgstr ""
 
 msgid "Run Analytics before sync"
+msgstr ""
+
+msgid "{{async}}"
 msgstr ""
 
 msgid "Frequency"

--- a/i18n/es.po
+++ b/i18n/es.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: i18next-conv\n"
-"POT-Creation-Date: 2022-01-14T07:42:34.635Z\n"
+"POT-Creation-Date: 2022-08-22T10:48:03.128Z\n"
 "PO-Revision-Date: 2020-07-10T06:53:30.625Z\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1065,6 +1065,9 @@ msgstr ""
 msgid "Ignore data with same value on destination"
 msgstr ""
 
+msgid "Async mode"
+msgstr ""
+
 msgid "Sync rule {{idx}}: {{name}} ({{id}})"
 msgstr ""
 
@@ -1352,6 +1355,9 @@ msgid "Updates"
 msgstr ""
 
 msgid "Run Analytics before sync"
+msgstr ""
+
+msgid "{{async}}"
 msgstr ""
 
 msgid "Frequency"

--- a/i18n/fr.po
+++ b/i18n/fr.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: i18next-conv\n"
-"POT-Creation-Date: 2022-01-14T07:42:34.635Z\n"
+"POT-Creation-Date: 2022-08-22T10:48:03.128Z\n"
 "PO-Revision-Date: 2020-07-10T06:53:30.625Z\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1065,6 +1065,9 @@ msgstr ""
 msgid "Ignore data with same value on destination"
 msgstr ""
 
+msgid "Async mode"
+msgstr ""
+
 msgid "Sync rule {{idx}}: {{name}} ({{id}})"
 msgstr ""
 
@@ -1352,6 +1355,9 @@ msgid "Updates"
 msgstr ""
 
 msgid "Run Analytics before sync"
+msgstr ""
+
+msgid "{{async}}"
 msgstr ""
 
 msgid "Frequency"

--- a/i18n/pt.po
+++ b/i18n/pt.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: i18next-conv\n"
-"POT-Creation-Date: 2022-01-14T07:42:34.635Z\n"
+"POT-Creation-Date: 2022-08-22T10:48:03.128Z\n"
 "PO-Revision-Date: 2020-07-10T06:53:30.625Z\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1065,6 +1065,9 @@ msgstr ""
 msgid "Ignore data with same value on destination"
 msgstr ""
 
+msgid "Async mode"
+msgstr ""
+
 msgid "Sync rule {{idx}}: {{name}} ({{id}})"
 msgstr ""
 
@@ -1352,6 +1355,9 @@ msgid "Updates"
 msgstr ""
 
 msgid "Run Analytics before sync"
+msgstr ""
+
+msgid "{{async}}"
 msgstr ""
 
 msgid "Frequency"

--- a/src/data/events/EventsD2ApiRepository.ts
+++ b/src/data/events/EventsD2ApiRepository.ts
@@ -1,4 +1,4 @@
-import { EventsPostResponse } from "@eyeseetea/d2-api/api/events";
+import { EventsPostParams, EventsPostResponse } from "@eyeseetea/d2-api/api/events";
 import _ from "lodash";
 import moment from "moment";
 import {
@@ -247,20 +247,17 @@ export class EventsD2ApiRepository implements EventsRepository {
     }
 
     private async push(params: DataImportParams, data: EventsPackage): Promise<SynchronizationResult> {
+        const eventsPostParams: EventsPostParams = {
+            idScheme: params.idScheme ?? "UID",
+            dataElementIdScheme: params.dataElementIdScheme ?? "UID",
+            orgUnitIdScheme: params.orgUnitIdScheme ?? "UID",
+            dryRun: params.dryRun ?? false,
+            preheatCache: params.preheatCache ?? false,
+            skipExistingCheck: params.skipExistingCheck ?? false,
+        };
+
         if (params.async || params.async === undefined) {
-            const { response } = await this.api.events
-                .postAsync(
-                    {
-                        idScheme: params.idScheme ?? "UID",
-                        dataElementIdScheme: params.dataElementIdScheme ?? "UID",
-                        orgUnitIdScheme: params.orgUnitIdScheme ?? "UID",
-                        dryRun: params.dryRun ?? false,
-                        preheatCache: params.preheatCache ?? false,
-                        skipExistingCheck: params.skipExistingCheck ?? false,
-                    },
-                    data
-                )
-                .getData();
+            const { response } = await this.api.events.postAsync(eventsPostParams, data).getData();
 
             const result = await this.api.system.waitFor(response.jobType, response.id).getData();
 
@@ -275,19 +272,7 @@ export class EventsD2ApiRepository implements EventsRepository {
 
             return this.cleanEventsImportResponse(result);
         } else {
-            const { response } = await this.api.events
-                .post(
-                    {
-                        idScheme: params.idScheme ?? "UID",
-                        dataElementIdScheme: params.dataElementIdScheme ?? "UID",
-                        orgUnitIdScheme: params.orgUnitIdScheme ?? "UID",
-                        dryRun: params.dryRun ?? false,
-                        preheatCache: params.preheatCache ?? false,
-                        skipExistingCheck: params.skipExistingCheck ?? false,
-                    },
-                    data
-                )
-                .getData();
+            const { response } = await this.api.events.post(eventsPostParams, data).getData();
 
             return this.cleanEventsImportResponse(response);
         }

--- a/src/domain/aggregated/entities/DataSynchronizationParams.ts
+++ b/src/domain/aggregated/entities/DataSynchronizationParams.ts
@@ -10,6 +10,7 @@ export interface DataImportParams {
     skipExistingCheck?: boolean;
     skipAudit?: boolean;
     strategy?: "NEW_AND_UPDATES" | "NEW" | "UPDATES" | "DELETES";
+    async?: boolean;
 }
 
 export interface DataSynchronizationParams extends DataImportParams {
@@ -31,4 +32,5 @@ export interface DataSynchronizationParams extends DataImportParams {
     includeAnalyticsZeroValues?: boolean;
     analyticsYears?: number;
     ignoreDuplicateExistingValues?: boolean;
+    async?: boolean;
 }

--- a/src/domain/aggregated/entities/DataSynchronizationParams.ts
+++ b/src/domain/aggregated/entities/DataSynchronizationParams.ts
@@ -32,5 +32,4 @@ export interface DataSynchronizationParams extends DataImportParams {
     includeAnalyticsZeroValues?: boolean;
     analyticsYears?: number;
     ignoreDuplicateExistingValues?: boolean;
-    async?: boolean;
 }

--- a/src/presentation/react/core/components/sync-params-selector/SyncParamsSelector.tsx
+++ b/src/presentation/react/core/components/sync-params-selector/SyncParamsSelector.tsx
@@ -21,7 +21,6 @@ const useStyles = makeStyles({
 const SyncParamsSelector: React.FC<SyncParamsSelectorProps> = ({ syncRule, onChange, generateNewUidDisabled }) => {
     const classes = useStyles();
     const { syncParams, dataParams } = syncRule;
-
     const changeSharingSettings = (includeSharingSettings: boolean) => {
         onChange(
             syncRule.updateSyncParams({
@@ -103,6 +102,15 @@ const SyncParamsSelector: React.FC<SyncParamsSelectorProps> = ({ syncRule, onCha
             syncRule.updateDataParams({
                 ...dataParams,
                 ignoreDuplicateExistingValues,
+            })
+        );
+    };
+
+    const changeAsyncMode = (async: boolean) => {
+        onChange(
+            syncRule.updateDataParams({
+                ...dataParams,
+                async,
             })
         );
     };
@@ -249,6 +257,16 @@ const SyncParamsSelector: React.FC<SyncParamsSelectorProps> = ({ syncRule, onCha
                         }
                         onValueChange={changeIgnoreDuplicateExistingValues}
                         value={dataParams.ignoreDuplicateExistingValues ?? false}
+                    />
+                </div>
+            )}
+
+            {syncRule.type === "events" && (
+                <div>
+                    <Toggle
+                        label={i18n.t("Async mode")}
+                        onValueChange={changeAsyncMode}
+                        value={dataParams.async ?? true}
                     />
                 </div>
             )}

--- a/src/presentation/react/core/components/sync-wizard/common/SummaryStep.tsx
+++ b/src/presentation/react/core/components/sync-wizard/common/SummaryStep.tsx
@@ -463,12 +463,7 @@ export const SummaryStepContent = (props: SummaryStepContentProps) => {
                         <LiEntry
                             label={i18n.t("Async mode")}
                             value={i18n.t("{{async}}", {
-                                async:
-                                    syncRule.dataParams.async === undefined
-                                        ? true
-                                        : syncRule.dataParams.async
-                                        ? true
-                                        : false,
+                                async: syncRule.dataParams.async !== false ? i18n.t("Yes") : i18n.t("No"),
                             })}
                         />
                     </ul>

--- a/src/presentation/react/core/components/sync-wizard/common/SummaryStep.tsx
+++ b/src/presentation/react/core/components/sync-wizard/common/SummaryStep.tsx
@@ -459,6 +459,19 @@ export const SummaryStepContent = (props: SummaryStepContentProps) => {
                             value={syncRule.dataParams.runAnalytics ? i18n.t("Yes") : i18n.t("No")}
                         />
                     </ul>
+                    <ul>
+                        <LiEntry
+                            label={i18n.t("Async mode")}
+                            value={i18n.t("{{async}}", {
+                                async:
+                                    syncRule.dataParams.async === undefined
+                                        ? true
+                                        : syncRule.dataParams.async
+                                        ? true
+                                        : false,
+                            })}
+                        />
+                    </ul>
                 </LiEntry>
             )}
 


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes #?
https://app.clickup.com/t/3banacm

### :memo: Implementation
I have added a setting for  the event synchronization to change the sync/async mode.
This feature was required to sync events from 2.35 to 2.36

-

### :art: Screenshots

### :fire: Is there anything the reviewer should know to test it?
to test you should create manual/rule sync with async mode on and off, and check the post endpoint in network.
### :bookmark_tabs: Others

-   Any change in the [GUI library](https://github.com/EyeSeeTea/d2-ui-components)? If so, what branch/PR?

-   Any change in the [D2 Api](https://github.com/EyeSeeTea/d2-api)? If so, what branch/PR?
