### PR TITLE
Exclude field avatar from users metadata sync

### DIFF
--- a/src/models/dhis/metadata.ts
+++ b/src/models/dhis/metadata.ts
@@ -708,7 +708,7 @@ export class UserModel extends D2Model {
     protected static metadataType = "user";
     protected static collectionName = "users" as const;
 
-    protected static excludeRules = ["userRoles.users", "userGroups.users"];
+    protected static excludeRules = ["userRoles.users", "userGroups.users", "avatar"];
     protected static includeRules = ["attributes", "userRoles", "userGroups", "userGroups.attributes"];
 }
 


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/865cgezdq

### :memo: Implementation

- Reason: Syncing with avatar failed as the associated avatar entity does not exist on remote
- Added to `src/models/dhis/metadata.ts -> `UserModel.excludeRules`
- Tested creating a sync rule on platform-test development and syncing to platform-test