### PR TITLE
fix create sync rule for event charts and reports

### DIFF
--- a/src/data/metadata/MetadataD2ApiRepository.ts
+++ b/src/data/metadata/MetadataD2ApiRepository.ts
@@ -33,7 +33,7 @@ import { D2Api, D2Model, Id, MetadataResponse, Model, Stats } from "../../types/
 import { Dictionary, isNotEmpty, Maybe } from "../../types/utils";
 import { cache } from "../../utils/cache";
 import { promiseMap } from "../../utils/common";
-import { getD2APiFromInstance } from "../../utils/d2-utils";
+import { getD2APiFromInstance, getInChunks } from "../../utils/d2-utils";
 import { debug } from "../../utils/debug";
 import { paginate } from "../../utils/pagination";
 import { metadataTransformations } from "../transformations/PackageTransformations";
@@ -555,7 +555,47 @@ export class MetadataD2ApiRepository implements MetadataRepository {
         const response = await Promise.all(promises);
         const results = _.deepMerge({}, ...response);
         if (results.system) delete results.system;
-        return results;
+
+        const metadata = await this.validateEventVisualizationsByIds(results, elements);
+        return metadata;
+    }
+
+    private async validateEventVisualizationsByIds(metadata: any, ids: Id[]) {
+        if (!metadata.eventCharts || !metadata.eventReports) return metadata;
+        const result = await getInChunks<D2EventVisualization>(ids, async idsInChunk => {
+            const d2Charts = await this.api.models.eventCharts
+                .get({ filter: { id: { in: idsInChunk } }, fields: { id: true }, paging: true })
+                .getData();
+
+            const d2EventReports = await this.api.models.eventReports
+                .get({ filter: { id: { in: idsInChunk } }, fields: { id: true }, paging: true })
+                .getData();
+
+            return [{ eventCharts: d2Charts.objects, eventReports: d2EventReports.objects }];
+        });
+
+        const allCharts = _(result)
+            .flatMap(visualization => visualization.eventCharts)
+            .value();
+        const allEvents = _(result)
+            .flatMap(visualization => visualization.eventReports)
+            .value();
+
+        const chartsMetadata = _(metadata.eventCharts)
+            .map(eventChart => {
+                return allCharts.find(d2Chart => d2Chart.id === eventChart.id) ? eventChart : undefined;
+            })
+            .compact()
+            .value();
+
+        const eventReportsMetadata = _(metadata.eventReports)
+            .map(eventReport => {
+                return allEvents.find(d2Chart => d2Chart.id === eventReport.id) ? eventReport : undefined;
+            })
+            .compact()
+            .value();
+
+        return { ...metadata, eventReports: eventReportsMetadata, eventCharts: chartsMetadata };
     }
 
     private getApiModel(type: keyof MetadataEntities): Model<any, any> {
@@ -660,3 +700,5 @@ function getFilterAsString(filter: FilterBase): string[] {
         )
     );
 }
+
+type D2EventVisualization = { eventCharts: Array<{ id: Id }>; eventReports: Array<{ id: Id }> };

--- a/src/presentation/react/core/components/sync-wizard/common/SummaryStep.tsx
+++ b/src/presentation/react/core/components/sync-wizard/common/SummaryStep.tsx
@@ -217,6 +217,12 @@ export const SummaryStepContent = (props: SummaryStepContentProps) => {
             </LiEntry>
 
             {_.keys(metadata).map(metadataType => {
+                //@ts-ignore
+                const modelByMetadataType = api.models[metadataType];
+                if (!modelByMetadataType) {
+                    console.warn(`Metadata type "${metadataType}" not supported in d2-api`);
+                    return null;
+                }
                 const itemsByType = metadata[metadataType as keyof MetadataEntities] || [];
 
                 const items = itemsByType.filter(({ id }) => !syncRule.excludedIds.includes(id));
@@ -225,8 +231,7 @@ export const SummaryStepContent = (props: SummaryStepContentProps) => {
                     items.length > 0 && (
                         <LiEntry
                             key={metadataType}
-                            //@ts-ignore
-                            label={`${api.models[metadataType].schema.displayName} [${items.length}]`}
+                            label={`${modelByMetadataType.schema.displayName} [${items.length}]`}
                         >
                             <ul>
                                 {items.map(({ id, name }) => (

--- a/src/utils/d2-utils.ts
+++ b/src/utils/d2-utils.ts
@@ -1,6 +1,7 @@
 import _ from "lodash";
 import { D2Api } from "../types/d2-api";
 import { Instance } from "../domain/instance/entities/Instance";
+import { Id } from "../domain/common/entities/Schemas";
 
 export function getMajorVersion(version: string): number {
     const apiVersion = _.get(version.split("."), 1);
@@ -21,4 +22,24 @@ export function getD2APiFromInstance(instance: Instance) {
     https://developer.mozilla.org/en-US/docs/Web/API/Request/credentials
     */
     return new D2Api({ baseUrl: instance.url, auth: instance.auth, backend: "fetch" });
+}
+
+export async function getInChunks<T>(
+    ids: Id[],
+    getter: (idsGroup: Id[]) => Promise<T[]>,
+    chunkSize = 100
+): Promise<T[]> {
+    const objsCollection = await promiseMap(_.chunk(ids, chunkSize), idsGroup => getter(idsGroup));
+    return _.flatten(objsCollection);
+}
+
+export function promiseMap<T, S>(inputValues: T[], mapper: (value: T) => Promise<S>): Promise<S[]> {
+    const reducer = (acc$: Promise<S[]>, inputValue: T): Promise<S[]> =>
+        acc$.then((acc: S[]) =>
+            mapper(inputValue).then(result => {
+                acc.push(result);
+                return acc;
+            })
+        );
+    return inputValues.reduce(reducer, Promise.resolve([]));
 }

--- a/src/utils/d2-utils.ts
+++ b/src/utils/d2-utils.ts
@@ -1,7 +1,6 @@
 import _ from "lodash";
 import { D2Api } from "../types/d2-api";
 import { Instance } from "../domain/instance/entities/Instance";
-import { Id } from "../domain/common/entities/Schemas";
 
 export function getMajorVersion(version: string): number {
     const apiVersion = _.get(version.split("."), 1);
@@ -22,24 +21,4 @@ export function getD2APiFromInstance(instance: Instance) {
     https://developer.mozilla.org/en-US/docs/Web/API/Request/credentials
     */
     return new D2Api({ baseUrl: instance.url, auth: instance.auth, backend: "fetch" });
-}
-
-export async function getInChunks<T>(
-    ids: Id[],
-    getter: (idsGroup: Id[]) => Promise<T[]>,
-    chunkSize = 100
-): Promise<T[]> {
-    const objsCollection = await promiseMap(_.chunk(ids, chunkSize), idsGroup => getter(idsGroup));
-    return _.flatten(objsCollection);
-}
-
-export function promiseMap<T, S>(inputValues: T[], mapper: (value: T) => Promise<S>): Promise<S[]> {
-    const reducer = (acc$: Promise<S[]>, inputValue: T): Promise<S[]> =>
-        acc$.then((acc: S[]) =>
-            mapper(inputValue).then(result => {
-                acc.push(result);
-                return acc;
-            })
-        );
-    return inputValues.reduce(reducer, Promise.resolve([]));
 }


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/86947bw20

### :memo: Implementation

The `/api/metadata` endpoint returns 3 different types of results when you pass an event report id: `eventReports`, `eventCharts` and `eventVisualizations`.

![image](https://github.com/EyeSeeTea/metadata-synchronization/assets/461124/756c0a88-c990-46f8-bf98-5155554c8812)

which causes duplicating metadata results when you want to create a sync rule:

![image](https://github.com/EyeSeeTea/metadata-synchronization/assets/461124/1aee2e8e-4ad0-430f-ae80-fb04f1e2a45a)

~In order to avoid this after getting the metadata information I'm doing an extra request to the `eventReports/eventCharts` endpoint to determine where these metadata really belongs.~

**UPDATE:** @MiquelAdell  Instead doing an extra request I'm using the type attribute since `EventReports` only could be of type:  `PIVOT_TABLE` or `LINE_LIST`

![image](https://github.com/EyeSeeTea/metadata-synchronization/assets/461124/df43b50f-d0e5-41c3-af55-b6307c903135)

Also, since we don't have support for `eventVisualizations` in d2-api I'm ignoring this kind of metadata.

### :video_camera: Screenshots/Screen capture

Event Reports
[MetaData-Synchronization_EventReports.webm](https://github.com/EyeSeeTea/metadata-synchronization/assets/461124/457df3a4-526b-4b93-8aa2-331de9f20cc6)

Event Charts
[MetaData-Synchronization_EventCharts.webm](https://github.com/EyeSeeTea/metadata-synchronization/assets/461124/2f6a6b6b-dc8b-4a44-98a2-13d6104a7794)

### :fire: Is there anything the reviewer should know to test it?

Tested against the [dev server](https://dev.eyeseetea.com/who-dev-238), but it should work in any instance.

### :bookmark_tabs: Others

-   Any change in the [GUI library](https://github.com/EyeSeeTea/d2-ui-components)? If so, what branch/PR?

None

-   Any change in the [D2 Api](https://github.com/EyeSeeTea/d2-api)? If so, what branch/PR?

None

#86947bw20