### PR TITLE
Feat/install multiple metadata sync flavours 2

### DIFF
--- a/scripts/run.ts
+++ b/scripts/run.ts
@@ -8,7 +8,7 @@ const variants = [
     {
         type: "app",
         name: "core-app",
-        title: "MetaData Sync App",
+        title: "MetaData Synchronization",
         file: "metadata-synchronization",
     },
     {

--- a/scripts/run.ts
+++ b/scripts/run.ts
@@ -139,6 +139,7 @@ function build(args: BuildArgs): void {
         run(`react-scripts build && cp -r i18n icon.png build`);
         run(`d2-manifest package.json build/manifest.webapp -t ${manifestType} -n '${variant.title}'`);
         updateManifestNamespace(`build/manifest.webapp`, variant.file);
+        updateManifestJsonFile(`build/manifest.json`, variant.title);
         run(`rm -f ${fileName}`);
         run(`cd build && zip -r ../${fileName} *`);
         console.info(`Written: ${fileName}`);
@@ -150,6 +151,14 @@ function updateManifestNamespace(manifestPath: string, variantFile: string) {
         const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
         manifest.activities.dhis.namespace = variantFile;
         fs.writeFileSync(manifestPath, JSON.stringify(manifest, null, 2));
+    }
+}
+
+function updateManifestJsonFile(manifestJsonPath: string, variantTitle: string) {
+    if (fs.existsSync(manifestJsonPath)) {
+        const manifestJson = JSON.parse(fs.readFileSync(manifestJsonPath, "utf8"));
+        Object.assign(manifestJson, { name: variantTitle, short_name: variantTitle });
+        fs.writeFileSync(manifestJsonPath, JSON.stringify(manifestJson, null, 2));
     }
 }
 

--- a/scripts/run.ts
+++ b/scripts/run.ts
@@ -8,7 +8,7 @@ const variants = [
     {
         type: "app",
         name: "core-app",
-        title: "MetaData Synchronization",
+        title: "MetaData Sync App",
         file: "metadata-synchronization",
     },
     {

--- a/scripts/run.ts
+++ b/scripts/run.ts
@@ -138,8 +138,10 @@ function build(args: BuildArgs): void {
 
         run(`react-scripts build && cp -r i18n icon.png build`);
         run(`d2-manifest package.json build/manifest.webapp -t ${manifestType} -n '${variant.title}'`);
+        if (variant.file === "metadata-synchronization") {
+            updateManifestJsonFile(`build/manifest.json`, variant.title);
+        }
         updateManifestNamespace(`build/manifest.webapp`, variant.file);
-        updateManifestJsonFile(`build/manifest.json`, variant.title);
         run(`rm -f ${fileName}`);
         run(`cd build && zip -r ../${fileName} *`);
         console.info(`Written: ${fileName}`);


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes [Install multiple metadata sync flavours](https://app.clickup.com/t/8694jx82y)
- CU-8694jx82y

### :memo: Implementation

- Revert to original name at variants first object and add function to update name in manifest.json

### :video_camera: Screenshots/Screen capture

### :fire: Is there anything the reviewer should know to test it?

### :bookmark_tabs: Others

-   Any change in the [GUI library](https://github.com/EyeSeeTea/d2-ui-components)? If so, what branch/PR?

-   Any change in the [D2 Api](https://github.com/EyeSeeTea/d2-api)? If so, what branch/PR?
