### PR TITLE
avoid reloading app after loading feedback component

### DIFF
--- a/src/presentation/webapp/WebApp.tsx
+++ b/src/presentation/webapp/WebApp.tsx
@@ -5,7 +5,6 @@ import { LoadingProvider, SnackbarProvider } from "@eyeseetea/d2-ui-components";
 import { MuiThemeProvider } from "@material-ui/core/styles";
 import { createGenerateClassName, StylesProvider } from "@material-ui/styles";
 import { init } from "d2";
-import _ from "lodash";
 //@ts-ignore
 import OldMuiThemeProvider from "material-ui/styles/MuiThemeProvider";
 import { useEffect, useState } from "react";
@@ -33,7 +32,6 @@ const App = () => {
     const { baseUrl } = useConfig();
     const [appContext, setAppContext] = useState<AppContextState | null>(null);
     const [username, setUsername] = useState("");
-    const [showShareButton, setShowShareButton] = useState(false);
     const [appConfig, setAppConfig] = useState<Maybe<AppConfig>>();
     const migrations = useMigrations(appContext);
 
@@ -63,14 +61,15 @@ const App = () => {
             setAppContext({ d2: d2 as object, api, compositionRoot });
 
             Object.assign(window, { d2, api });
-            setShowShareButton(_(appConfig).get("appearance.showShareButton") || false);
             setUsername(currentUser.username);
             setAppConfig(configFromJson);
             await initializeAppRoles(baseUrl);
         };
 
         run();
-    }, [appConfig, baseUrl]);
+    }, [baseUrl]);
+
+    const showShareButton = appConfig?.appearance.showShareButton || false;
 
     if (migrations.state.type === "pending") {
         return (


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/8694rz1mc

### :memo: Implementation

### :video_camera: Screenshots/Screen capture

[MetaData-Synchronization_reload_bug.webm](https://github.com/EyeSeeTea/metadata-synchronization/assets/461124/01cf5097-d8b4-48d9-b06e-22326c7f50ff)

### :fire: Is there anything the reviewer should know to test it?

### :bookmark_tabs: Others

8694rz1mc
