### PR TITLE
add dataStore support

### DIFF
--- a/src/data/common/D2ApiDataStore.ts
+++ b/src/data/common/D2ApiDataStore.ts
@@ -1,0 +1,65 @@
+import { D2Api } from "../../types/d2-api";
+import { DataSource, isDhisInstance } from "../../domain/instance/entities/DataSource";
+import { getD2APiFromInstance } from "../../utils/d2-utils";
+import { DataStore, DataStoreKey } from "../../domain/metadata/entities/MetadataEntities";
+import { promiseMap } from "../../utils/common";
+import { DataStoreMetadata } from "../../domain/data-store/DataStoreMetadata";
+
+export class D2ApiDataStore {
+    private api: D2Api;
+
+    constructor(instance: DataSource) {
+        if (!isDhisInstance(instance)) {
+            throw new Error("Invalid instance type for MetadataD2ApiRepository");
+        }
+        this.api = getD2APiFromInstance(instance);
+    }
+
+    async getDataStore(): Promise<DataStore[]> {
+        const response = await this.api.request<string[]>({ method: "get", url: "/dataStore" }).getData();
+        const namespacesWithKeys = await this.getAllKeysFromNamespaces(response);
+        return namespacesWithKeys;
+    }
+
+    private async getAllKeysFromNamespaces(namespaces: string[]): Promise<DataStore[]> {
+        const result = await promiseMap<string, DataStore>(namespaces, async namespace => {
+            const keys = await this.getKeysPaginated([], namespace);
+            return {
+                code: namespace,
+                displayName: namespace,
+                externalAccess: false,
+                favorites: [],
+                id: `${namespace}${DataStoreMetadata.NS_SEPARATOR}`,
+                keys: keys,
+                name: namespace,
+                translations: [],
+            };
+        });
+        return result;
+    }
+
+    private async getKeysPaginated(keysState: DataStoreKey[], namespace: string): Promise<DataStoreKey[]> {
+        const keyResponse = await this.getKeysByNameSpace(namespace);
+        const newKeys = [...keysState, ...keyResponse];
+        return newKeys;
+    }
+
+    private async getKeysByNameSpace(namespace: string): Promise<DataStoreKey[]> {
+        const response = await this.api
+            .request<string[]>({
+                method: "get",
+                url: `/dataStore/${namespace}`,
+                // Since v38 we can use the fields parameter to get keys and values in the same request
+                // Empty fields returns a paginated response
+                // https://docs.dhis2.org/en/full/develop/dhis-core-version-240/developer-manual.html#query-api
+                // params: { fields: "", page: page, pageSize: 200 },
+            })
+            .getData();
+
+        return this.buildArrayDataStoreKey(response, namespace);
+    }
+
+    private buildArrayDataStoreKey(keys: string[], namespace: string): DataStoreKey[] {
+        return keys.map(key => ({ id: `${namespace}${DataStoreMetadata.NS_SEPARATOR}${key}`, displayName: key }));
+    }
+}

--- a/src/data/common/D2ApiDataStore.ts
+++ b/src/data/common/D2ApiDataStore.ts
@@ -63,6 +63,6 @@ export class D2ApiDataStore {
     }
 
     private buildArrayDataStoreKey(keys: string[], namespace: string): DataStoreKey[] {
-        return keys.map(key => ({ id: [namespace, DataStoreMetadata.NS_SEPARATOR, key].join(""), displayName: key }));
+        return keys.map(key => ({ id: DataStoreMetadata.generateKeyId(namespace, key), displayName: key }));
     }
 }

--- a/src/data/common/D2ApiDataStore.ts
+++ b/src/data/common/D2ApiDataStore.ts
@@ -1,4 +1,3 @@
-import _ from "lodash";
 import { D2Api } from "../../types/d2-api";
 import { DataSource, isDhisInstance } from "../../domain/instance/entities/DataSource";
 import { getD2APiFromInstance } from "../../utils/d2-utils";
@@ -18,15 +17,15 @@ export class D2ApiDataStore {
 
     async getDataStore(filter: { namespaces: string[] }): Promise<DataStore[]> {
         const response = await this.api.request<string[]>({ method: "get", url: "/dataStore" }).getData();
-        const namespacesWithKeys = await this.getAllKeysFromNamespaces(response);
-        return filter.namespaces.length === 0
-            ? namespacesWithKeys
-            : _(namespacesWithKeys)
-                  .map(namespace => {
-                      return filter.namespaces.includes(namespace.id) ? namespace : undefined;
+        const namespacesWithKeys = await this.getAllKeysFromNamespaces(
+            filter.namespaces.length === 0
+                ? response
+                : DataStoreMetadata.getDataStoreIds(filter.namespaces).map(ns => {
+                      const [namespace] = ns.split(DataStoreMetadata.NS_SEPARATOR);
+                      return namespace;
                   })
-                  .compact()
-                  .value();
+        );
+        return namespacesWithKeys;
     }
 
     private async getAllKeysFromNamespaces(namespaces: string[]): Promise<DataStore[]> {

--- a/src/data/common/D2ApiDataStore.ts
+++ b/src/data/common/D2ApiDataStore.ts
@@ -1,3 +1,4 @@
+import _ from "lodash";
 import { D2Api } from "../../types/d2-api";
 import { DataSource, isDhisInstance } from "../../domain/instance/entities/DataSource";
 import { getD2APiFromInstance } from "../../utils/d2-utils";
@@ -15,10 +16,17 @@ export class D2ApiDataStore {
         this.api = getD2APiFromInstance(instance);
     }
 
-    async getDataStore(): Promise<DataStore[]> {
+    async getDataStore(filter: { namespaces: string[] }): Promise<DataStore[]> {
         const response = await this.api.request<string[]>({ method: "get", url: "/dataStore" }).getData();
         const namespacesWithKeys = await this.getAllKeysFromNamespaces(response);
-        return namespacesWithKeys;
+        return filter.namespaces.length === 0
+            ? namespacesWithKeys
+            : _(namespacesWithKeys)
+                  .map(namespace => {
+                      return filter.namespaces.includes(namespace.id) ? namespace : undefined;
+                  })
+                  .compact()
+                  .value();
     }
 
     private async getAllKeysFromNamespaces(namespaces: string[]): Promise<DataStore[]> {

--- a/src/data/common/D2ApiDataStore.ts
+++ b/src/data/common/D2ApiDataStore.ts
@@ -12,15 +12,15 @@ export class D2ApiDataStore {
         this.api = getD2APiFromInstance(instance);
     }
 
-    async getDataStore(filter: { namespaces?: string[] }): Promise<DataStore[]> {
+    async getDataStores(filter: { namespaces?: string[] }): Promise<DataStore[]> {
         const response = await this.api.request<string[]>({ method: "get", url: "/dataStore" }).getData();
         const namespacesWithKeys = await this.getAllKeysFromNamespaces(
             filter.namespaces
-                ? response
-                : DataStoreMetadata.getDataStoreIds(filter.namespaces || []).map(ns => {
+                ? DataStoreMetadata.getDataStoreIds(filter.namespaces || []).map(ns => {
                       const [namespace] = ns.split(DataStoreMetadata.NS_SEPARATOR);
                       return namespace;
                   })
+                : response
         );
         return namespacesWithKeys;
     }

--- a/src/data/data-store/DataStoreMetadataD2Repository.ts
+++ b/src/data/data-store/DataStoreMetadataD2Repository.ts
@@ -94,11 +94,11 @@ export class DataStoreMetadataD2Repository implements DataStoreMetadataRepositor
 
             const existingRecords = await this.get([{ ...dataStore, keys: [] }]);
             const existingKeysIds = existingRecords.flatMap(dataStore => {
-                return dataStore.keys.map(key => `${dataStore.namespace}[NS]${key.id}`);
+                return dataStore.keys.map(key => DataStoreMetadata.generateKeyId(dataStore.namespace, key.id));
             });
 
             const keysIdsToSave = dataStores.flatMap(dataStore => {
-                return dataStore.keys.map(key => `${dataStore.namespace}[NS]${key.id}`);
+                return dataStore.keys.map(key => DataStoreMetadata.generateKeyId(dataStore.namespace, key.id));
             });
 
             const keysIdsToDelete = existingKeysIds.filter(id => !keysIdsToSave.includes(id));

--- a/src/data/data-store/DataStoreMetadataD2Repository.ts
+++ b/src/data/data-store/DataStoreMetadataD2Repository.ts
@@ -1,6 +1,6 @@
 import _ from "lodash";
 import { DataStoreMetadata } from "../../domain/data-store/DataStoreMetadata";
-import { DataStoreMetadataRepository, SaveOptions } from "../../domain/data-store/DataStoreMetadataRepository";
+import { DataStoreMetadataRepository } from "../../domain/data-store/DataStoreMetadataRepository";
 import { Instance } from "../../domain/instance/entities/Instance";
 import { Stats } from "../../domain/reports/entities/Stats";
 import { SynchronizationResult } from "../../domain/reports/entities/SynchronizationResult";
@@ -50,11 +50,8 @@ export class DataStoreMetadataD2Repository implements DataStoreMetadataRepositor
         return keys.map(key => ({ id: key, value: "" }));
     }
 
-    async save(
-        dataStores: DataStoreMetadata[],
-        options: SaveOptions = { mergeMode: "MERGE" }
-    ): Promise<SynchronizationResult> {
-        const keysIdsToDelete = await this.getKeysToDelete(dataStores, options);
+    async save(dataStores: DataStoreMetadata[]): Promise<SynchronizationResult> {
+        const keysIdsToDelete = await this.getKeysToDelete(dataStores);
 
         const resultStats = await promiseMap(dataStores, async dataStore => {
             const dataStoreClient = new StorageDataStoreClient(this.instance, dataStore.namespace);
@@ -91,19 +88,23 @@ export class DataStoreMetadataD2Repository implements DataStoreMetadataRepositor
         return result;
     }
 
-    private async getKeysToDelete(dataStores: DataStoreMetadata[], options: SaveOptions) {
-        if (options.mergeMode === "MERGE") return [];
+    private async getKeysToDelete(dataStores: DataStoreMetadata[]): Promise<string[]> {
+        const allKeysToDelete = await promiseMap(dataStores, async dataStore => {
+            if (dataStore.action === "MERGE") return [];
 
-        const existingRecords = await this.get(dataStores.map(x => ({ ...x, keys: [] })));
-        const existingKeysIds = existingRecords.flatMap(dataStore => {
-            return dataStore.keys.map(key => `${dataStore.namespace}[NS]${key.id}`);
+            const existingRecords = await this.get([{ ...dataStore, keys: [] }]);
+            const existingKeysIds = existingRecords.flatMap(dataStore => {
+                return dataStore.keys.map(key => `${dataStore.namespace}[NS]${key.id}`);
+            });
+
+            const keysIdsToSave = dataStores.flatMap(dataStore => {
+                return dataStore.keys.map(key => `${dataStore.namespace}[NS]${key.id}`);
+            });
+
+            const keysIdsToDelete = existingKeysIds.filter(id => !keysIdsToSave.includes(id));
+            return keysIdsToDelete;
         });
 
-        const keysIdsToSave = dataStores.flatMap(dataStore => {
-            return dataStore.keys.map(key => `${dataStore.namespace}[NS]${key.id}`);
-        });
-
-        const keysIdsToDelete = existingKeysIds.filter(id => !keysIdsToSave.includes(id));
-        return keysIdsToDelete;
+        return allKeysToDelete.flat();
     }
 }

--- a/src/data/data-store/DataStoreMetadataD2Repository.ts
+++ b/src/data/data-store/DataStoreMetadataD2Repository.ts
@@ -1,0 +1,109 @@
+import _ from "lodash";
+import { DataStoreMetadata } from "../../domain/data-store/DataStoreMetadata";
+import { DataStoreMetadataRepository, SaveOptions } from "../../domain/data-store/DataStoreMetadataRepository";
+import { Instance } from "../../domain/instance/entities/Instance";
+import { Stats } from "../../domain/reports/entities/Stats";
+import { SynchronizationResult } from "../../domain/reports/entities/SynchronizationResult";
+import { promiseMap } from "../../utils/common";
+import { StorageDataStoreClient } from "../storage/StorageDataStoreClient";
+
+export class DataStoreMetadataD2Repository implements DataStoreMetadataRepository {
+    private instance: Instance;
+
+    constructor(instance: Instance) {
+        this.instance = instance;
+    }
+
+    async get(dataStores: DataStoreMetadata[]): Promise<DataStoreMetadata[]> {
+        const result = await promiseMap(dataStores, async dataStore => {
+            const dataStoreClient = new StorageDataStoreClient(this.instance, dataStore.namespace);
+            const dataStoreWithValue = this.getValuesByDataStore(dataStoreClient, dataStore);
+            return dataStoreWithValue;
+        });
+        return result;
+    }
+
+    private async getValuesByDataStore(
+        dataStoreClient: StorageDataStoreClient,
+        dataStore: DataStoreMetadata
+    ): Promise<DataStoreMetadata> {
+        const keys = await this.getAllKeys(dataStoreClient, dataStore);
+        const keyWithValue = await promiseMap(keys, async key => {
+            const keyValue = await dataStoreClient.getObject(key.id);
+            return { id: key.id, value: keyValue };
+        });
+        const keyInNamespace = _(dataStore.keys).first()?.id;
+        const sharing = keyInNamespace ? await dataStoreClient.getObjectSharing(keyInNamespace) : undefined;
+        return new DataStoreMetadata({
+            namespace: dataStore.namespace,
+            keys: keyWithValue,
+            sharing,
+        });
+    }
+
+    private async getAllKeys(
+        dataStoreClient: StorageDataStoreClient,
+        dataStore: DataStoreMetadata
+    ): Promise<DataStoreMetadata["keys"]> {
+        if (dataStore.keys.length > 0) return dataStore.keys;
+        const keys = await dataStoreClient.listKeys();
+        return keys.map(key => ({ id: key, value: "" }));
+    }
+
+    async save(
+        dataStores: DataStoreMetadata[],
+        options: SaveOptions = { mergeMode: "MERGE" }
+    ): Promise<SynchronizationResult> {
+        const keysIdsToDelete = await this.getKeysToDelete(dataStores, options);
+
+        const resultStats = await promiseMap(dataStores, async dataStore => {
+            const dataStoreClient = new StorageDataStoreClient(this.instance, dataStore.namespace);
+            const stats = await promiseMap(dataStore.keys, async key => {
+                const exist = await dataStoreClient.getObject(key.id);
+                await dataStoreClient.saveObject(key.id, key.value);
+                if (dataStore.sharing) {
+                    await dataStoreClient.saveObjectSharing(key.id, dataStore.sharing);
+                }
+                return exist ? Stats.createOrEmpty({ updated: 1 }) : Stats.createOrEmpty({ imported: 1 });
+            });
+            return stats;
+        });
+
+        const deleteStats = await promiseMap(keysIdsToDelete, async keyId => {
+            const [namespace, key] = keyId.split(DataStoreMetadata.NS_SEPARATOR);
+            const dataStoreClient = new StorageDataStoreClient(this.instance, namespace);
+            await dataStoreClient.removeObject(key);
+            return Stats.createOrEmpty({ deleted: 1 });
+        });
+
+        const allStats = resultStats.flatMap(result => result).concat(deleteStats);
+        const dataStoreStats = { ...Stats.combine(allStats.map(stat => Stats.create(stat))), type: "DataStore Keys" };
+
+        const result: SynchronizationResult = {
+            date: new Date(),
+            instance: this.instance,
+            status: "SUCCESS",
+            type: "metadata",
+            stats: dataStoreStats,
+            typeStats: [dataStoreStats],
+        };
+
+        return result;
+    }
+
+    private async getKeysToDelete(dataStores: DataStoreMetadata[], options: SaveOptions) {
+        if (options.mergeMode === "MERGE") return [];
+
+        const existingRecords = await this.get(dataStores.map(x => ({ ...x, keys: [] })));
+        const existingKeysIds = existingRecords.flatMap(dataStore => {
+            return dataStore.keys.map(key => `${dataStore.namespace}[NS]${key.id}`);
+        });
+
+        const keysIdsToSave = dataStores.flatMap(dataStore => {
+            return dataStore.keys.map(key => `${dataStore.namespace}[NS]${key.id}`);
+        });
+
+        const keysIdsToDelete = existingKeysIds.filter(id => !keysIdsToSave.includes(id));
+        return keysIdsToDelete;
+    }
+}

--- a/src/data/metadata/MetadataD2ApiRepository.ts
+++ b/src/data/metadata/MetadataD2ApiRepository.ts
@@ -98,7 +98,7 @@ export class MetadataD2ApiRepository implements MetadataRepository {
             );
 
             if (dataStoreIds.length > 0) {
-                metadataPackage.dataStores = await d2ApiDataStore.getDataStore({ namespaces: ids });
+                metadataPackage.dataStores = await d2ApiDataStore.getDataStores({ namespaces: ids });
             }
             const dataStoresMetadata = await this.getDataStoresMetadata(ids);
             const responseWithDataStores = { ...metadataPackage, ...dataStoresMetadata } as T;
@@ -112,8 +112,8 @@ export class MetadataD2ApiRepository implements MetadataRepository {
         const dataStoreIds = DataStoreMetadata.getDataStoreIds(ids);
         if (dataStoreIds.length === 0) return {};
 
-        const result = await d2ApiDataStore.getDataStore({ namespaces: dataStoreIds });
-        return { dataStores: result };
+        const dataStores = await d2ApiDataStore.getDataStores({ namespaces: dataStoreIds });
+        return { dataStores: dataStores };
     }
 
     @cache()
@@ -125,7 +125,7 @@ export class MetadataD2ApiRepository implements MetadataRepository {
         const options = { type, fields, filter, order, page, pageSize, rootJunction };
         if (type === "dataStores") {
             const d2ApiDataStore = new D2ApiDataStore(this.instance);
-            const response = await d2ApiDataStore.getDataStore({ namespaces: [] });
+            const response = await d2ApiDataStore.getDataStores({ namespaces: undefined });
             // Hardcoded pagination since DHIS2 does not support pagination for namespaces
             return { objects: response, pager: { page: 1, total: response.length, pageSize: 100 } };
         } else {

--- a/src/data/metadata/MetadataD2ApiRepository.ts
+++ b/src/data/metadata/MetadataD2ApiRepository.ts
@@ -86,11 +86,10 @@ export class MetadataD2ApiRepository implements MetadataRepository {
                 metadataTransformations
             );
 
-            if (dataStoreIds.length > 0) {
-                metadataPackage.dataStores = await d2ApiDataStore.getDataStore({ namespaces: ids });
-            }
+            const dataStoresMetadata = await this.getDataStoresMetadata(ids);
+            const responseWithDataStores = { ...metadataPackage, ...dataStoresMetadata } as T;
 
-            return metadataPackage as T;
+            return responseWithDataStores;
         } else {
             const metadataPackage = this.transformationRepository.mapPackageFrom(
                 apiVersion,
@@ -101,9 +100,20 @@ export class MetadataD2ApiRepository implements MetadataRepository {
             if (dataStoreIds.length > 0) {
                 metadataPackage.dataStores = await d2ApiDataStore.getDataStore({ namespaces: ids });
             }
+            const dataStoresMetadata = await this.getDataStoresMetadata(ids);
+            const responseWithDataStores = { ...metadataPackage, ...dataStoresMetadata } as T;
 
-            return metadataPackage as T;
+            return responseWithDataStores;
         }
+    }
+
+    private async getDataStoresMetadata(ids: Id[]) {
+        const d2ApiDataStore = new D2ApiDataStore(this.instance);
+        const dataStoreIds = DataStoreMetadata.getDataStoreIds(ids);
+        if (dataStoreIds.length === 0) return {};
+
+        const result = await d2ApiDataStore.getDataStore({ namespaces: dataStoreIds });
+        return { dataStores: result };
     }
 
     @cache()

--- a/src/data/storage/StorageDataStoreClient.ts
+++ b/src/data/storage/StorageDataStoreClient.ts
@@ -14,10 +14,10 @@ export class StorageDataStoreClient extends StorageClient {
     private api: D2Api;
     private dataStore: DataStore;
 
-    constructor(instance: Instance) {
+    constructor(instance: Instance, namespace: string = dataStoreNamespace) {
         super();
         this.api = getD2APiFromInstance(instance);
-        this.dataStore = this.api.dataStore(dataStoreNamespace);
+        this.dataStore = this.api.dataStore(namespace);
     }
 
     public async getObject<T extends object>(key: string): Promise<T | undefined> {

--- a/src/domain/common/entities/Struct.ts
+++ b/src/domain/common/entities/Struct.ts
@@ -1,0 +1,45 @@
+/**
+ * Base class for typical classes with attributes. Features: create, update.
+ *
+ * ```
+ * class Counter extends Struct<{ id: Id; value: number }>() {
+ *     add(value: number): Counter {
+ *         return this._update({ value: this.value + value });
+ *     }
+ * }
+ *
+ * const counter1 = Counter.create({ id: "some-counter", value: 1 });
+ * const counter2 = counter1._update({ value: 2 });
+ * ```
+ */
+
+export function Struct<Attrs>() {
+    abstract class Base {
+        constructor(_attributes: Attrs) {
+            Object.assign(this, _attributes);
+        }
+
+        _getAttributes(): Attrs {
+            const entries = Object.getOwnPropertyNames(this).map(key => [key, (this as any)[key]]);
+            return Object.fromEntries(entries) as Attrs;
+        }
+
+        protected _update(partialAttrs: Partial<Attrs>): this {
+            const ParentClass = this.constructor as new (values: Attrs) => typeof this;
+            return new ParentClass({ ...this._getAttributes(), ...partialAttrs });
+        }
+
+        static create<U extends Base>(this: new (attrs: Attrs) => U, attrs: Attrs): U {
+            return new this(attrs);
+        }
+    }
+
+    return Base as {
+        new (values: Attrs): Attrs & Base;
+        create: typeof Base["create"];
+    };
+}
+
+const GenericStruct = Struct<unknown>();
+
+export type GenericStructInstance = InstanceType<typeof GenericStruct>;

--- a/src/domain/common/factories/RepositoryFactory.ts
+++ b/src/domain/common/factories/RepositoryFactory.ts
@@ -5,6 +5,7 @@ import {
 } from "../../aggregated/repositories/AggregatedRepository";
 import { ConfigRepositoryConstructor } from "../../config/repositories/ConfigRepository";
 import { CustomDataRepositoryConstructor } from "../../custom-data/repository/CustomDataRepository";
+import { DataStoreMetadataRepositoryConstructor } from "../../data-store/DataStoreMetadataRepository";
 import { EventsRepository, EventsRepositoryConstructor } from "../../events/repositories/EventsRepository";
 import { FileRepositoryConstructor } from "../../file/repositories/FileRepository";
 import { DataSource } from "../../instance/entities/DataSource";
@@ -121,6 +122,11 @@ export class RepositoryFactory {
     }
 
     @cache()
+    public dataStoreMetadataRepository(instance: Instance) {
+        return this.get<DataStoreMetadataRepositoryConstructor>(Repositories.DataStoreMetadataRepository, [instance]);
+    }
+
+    @cache()
     public teisRepository(instance: Instance): TEIRepository {
         return this.get<TEIRepositoryConstructor>(Repositories.TEIsRepository, [instance]);
     }
@@ -209,4 +215,5 @@ export const Repositories = {
     MappingRepository: "mappingRepository",
     SettingsRepository: "settingsRepository",
     SchedulerRepository: "schedulerRepository",
+    DataStoreMetadataRepository: "dataStoreMetadataRepository",
 } as const;

--- a/src/domain/data-store/DataStoreMetadata.ts
+++ b/src/domain/data-store/DataStoreMetadata.ts
@@ -133,4 +133,8 @@ export class DataStoreMetadata {
             .compact()
             .value();
     }
+
+    static generateKeyId(namespace: DataStoreNamespace, keyId: string) {
+        return [namespace, DataStoreMetadata.NS_SEPARATOR, keyId].join("");
+    }
 }

--- a/src/domain/data-store/DataStoreMetadata.ts
+++ b/src/domain/data-store/DataStoreMetadata.ts
@@ -22,7 +22,7 @@ export class DataStoreMetadata {
     }
 
     static buildFromKeys(keysWithNamespaces: string[]): DataStoreMetadata[] {
-        const dataStoreIds = keysWithNamespaces.filter(id => id.includes(DataStoreMetadata.NS_SEPARATOR));
+        const dataStoreIds = this.getDataStoreIds(keysWithNamespaces);
 
         const namespaceAndKey = dataStoreIds.map(dataStoreId => {
             const match = dataStoreId.split(DataStoreMetadata.NS_SEPARATOR);
@@ -41,7 +41,6 @@ export class DataStoreMetadata {
             .map((keys, namespace) => {
                 return new DataStoreMetadata({
                     namespace,
-
                     keys: _(keys)
                         .map(key => {
                             if (!key.key) return undefined;
@@ -94,5 +93,9 @@ export class DataStoreMetadata {
                 sharing: undefined,
             });
         });
+    }
+
+    static getDataStoreIds(keys: string[]): string[] {
+        return keys.filter(id => id.includes(DataStoreMetadata.NS_SEPARATOR));
     }
 }

--- a/src/domain/data-store/DataStoreMetadata.ts
+++ b/src/domain/data-store/DataStoreMetadata.ts
@@ -1,0 +1,98 @@
+import _ from "lodash";
+import { Maybe } from "../../types/utils";
+import { MetadataImportParams } from "../metadata/entities/MetadataSynchronizationParams";
+import { ObjectSharing } from "../storage/repositories/StorageClient";
+
+export type DataStoreNamespace = string;
+export type DataStoreKey = { id: string; value: any };
+
+export type DataStoreAttrs = { namespace: DataStoreNamespace; keys: DataStoreKey[]; sharing: Maybe<ObjectSharing> };
+
+export class DataStoreMetadata {
+    public readonly namespace: DataStoreNamespace;
+    public readonly keys: DataStoreKey[];
+    public readonly sharing: Maybe<ObjectSharing>;
+
+    static NS_SEPARATOR = "[NS]";
+
+    constructor(data: DataStoreAttrs) {
+        this.keys = data.keys;
+        this.namespace = data.namespace;
+        this.sharing = data.sharing;
+    }
+
+    static buildFromKeys(keysWithNamespaces: string[]): DataStoreMetadata[] {
+        const dataStoreIds = keysWithNamespaces.filter(id => id.includes(DataStoreMetadata.NS_SEPARATOR));
+
+        const namespaceAndKey = dataStoreIds.map(dataStoreId => {
+            const match = dataStoreId.split(DataStoreMetadata.NS_SEPARATOR);
+            if (!match) {
+                throw new Error(`dataStore value does not match expected format: ${dataStoreId}`);
+            }
+            const [namespace, key] = match;
+            return { namespace, key };
+        });
+
+        const groupByNamespace = _(namespaceAndKey)
+            .groupBy(record => record.namespace)
+            .value();
+
+        const result = _(groupByNamespace)
+            .map((keys, namespace) => {
+                return new DataStoreMetadata({
+                    namespace,
+
+                    keys: _(keys)
+                        .map(key => {
+                            if (!key.key) return undefined;
+                            return { id: key.key, value: "" };
+                        })
+                        .compact()
+                        .value(),
+                    sharing: undefined,
+                });
+            })
+            .value();
+
+        return result;
+    }
+
+    static combine(
+        origin: DataStoreMetadata[],
+        destination: DataStoreMetadata[],
+        action: MetadataImportParams["mergeMode"] = "MERGE"
+    ): DataStoreMetadata[] {
+        const destinationDataStore = _.keyBy(destination, "namespace");
+
+        return _(origin)
+            .map(originItem => {
+                const destItem = destinationDataStore[originItem.namespace];
+
+                if (!destItem) return originItem;
+
+                const combinedKeys =
+                    action === "MERGE"
+                        ? _(originItem.keys)
+                              .unionBy(destItem.keys, record => record.id)
+                              .value()
+                        : originItem.keys;
+
+                return new DataStoreMetadata({
+                    namespace: originItem.namespace,
+                    keys: combinedKeys,
+                    sharing: originItem.sharing,
+                });
+            })
+            .value();
+    }
+
+    static removeSharingSettings(dataStores: DataStoreMetadata[]): DataStoreMetadata[] {
+        return dataStores.map(dataStore => {
+            return new DataStoreMetadata({
+                namespace: dataStore.namespace,
+                keys: dataStore.keys,
+                sharing: undefined,
+            });
+        });
+    }
+}

--- a/src/domain/data-store/DataStoreMetadata.ts
+++ b/src/domain/data-store/DataStoreMetadata.ts
@@ -98,4 +98,8 @@ export class DataStoreMetadata {
     static getDataStoreIds(keys: string[]): string[] {
         return keys.filter(id => id.includes(DataStoreMetadata.NS_SEPARATOR));
     }
+
+    static isDataStoreId(id: string): boolean {
+        return id.includes(DataStoreMetadata.NS_SEPARATOR);
+    }
 }

--- a/src/domain/data-store/DataStoreMetadataRepository.ts
+++ b/src/domain/data-store/DataStoreMetadataRepository.ts
@@ -1,5 +1,4 @@
 import { Instance } from "../instance/entities/Instance";
-import { MetadataImportParams } from "../metadata/entities/MetadataSynchronizationParams";
 import { SynchronizationResult } from "../reports/entities/SynchronizationResult";
 import { DataStoreMetadata } from "./DataStoreMetadata";
 
@@ -9,7 +8,5 @@ export interface DataStoreMetadataRepositoryConstructor {
 
 export interface DataStoreMetadataRepository {
     get(namespaces: DataStoreMetadata[]): Promise<DataStoreMetadata[]>;
-    save(namespaces: DataStoreMetadata[], options: SaveOptions): Promise<SynchronizationResult>;
+    save(namespaces: DataStoreMetadata[]): Promise<SynchronizationResult>;
 }
-
-export type SaveOptions = { mergeMode: MetadataImportParams["mergeMode"] };

--- a/src/domain/data-store/DataStoreMetadataRepository.ts
+++ b/src/domain/data-store/DataStoreMetadataRepository.ts
@@ -1,0 +1,15 @@
+import { Instance } from "../instance/entities/Instance";
+import { MetadataImportParams } from "../metadata/entities/MetadataSynchronizationParams";
+import { SynchronizationResult } from "../reports/entities/SynchronizationResult";
+import { DataStoreMetadata } from "./DataStoreMetadata";
+
+export interface DataStoreMetadataRepositoryConstructor {
+    new (instance: Instance): DataStoreMetadataRepository;
+}
+
+export interface DataStoreMetadataRepository {
+    get(namespaces: DataStoreMetadata[]): Promise<DataStoreMetadata[]>;
+    save(namespaces: DataStoreMetadata[], options: SaveOptions): Promise<SynchronizationResult>;
+}
+
+export type SaveOptions = { mergeMode: MetadataImportParams["mergeMode"] };

--- a/src/domain/metadata/entities/MetadataEntities.ts
+++ b/src/domain/metadata/entities/MetadataEntities.ts
@@ -4992,6 +4992,19 @@ export type Visualization = {
     yearlySeries: string[];
 };
 
+export type DataStore = {
+    externalAccess: boolean;
+    id: Id;
+    code: string;
+    name: string;
+    displayName: string;
+    favorites: string[];
+    translations: Translation[];
+    keys: DataStoreKey[];
+};
+
+export type DataStoreKey = { id: Id; displayName: string };
+
 export type MetadataEntity =
     | UserAuthorityGroup
     | Attribute
@@ -5025,6 +5038,7 @@ export type MetadataEntity =
     | Section
     | DataApprovalLevel
     | DataApprovalWorkflow
+    | DataStore
     | ValidationRule
     | ValidationRuleGroup
     | ValidationNotificationTemplate
@@ -5076,6 +5090,7 @@ export type MetadataEntities = {
     dataEntryForms: DataEntryForm[];
     dataSets: DataSet[];
     dataSetNotificationTemplates: DataSetNotificationTemplate[];
+    dataStores: DataStore[];
     documents: Document[];
     eventCharts: EventChart[];
     eventReports: EventReport[];

--- a/src/domain/metadata/usecases/MetadataSyncUseCase.ts
+++ b/src/domain/metadata/usecases/MetadataSyncUseCase.ts
@@ -103,7 +103,8 @@ export class MetadataSyncUseCase extends GenericSyncUseCase {
         const metadataRepository = await this.getMetadataRepository();
         const filterRulesIds = await metadataRepository.getByFilterRules(filterRules);
         const allMetadataIds = _.union(metadataIds, filterRulesIds);
-        const metadata = await metadataRepository.getMetadataByIds<Ref>(allMetadataIds, "id,type"); //type is required to transform visualizations to charts and report tables
+        const idsWithoutDataStore = allMetadataIds.filter(id => !DataStoreMetadata.isDataStoreId(id));
+        const metadata = await metadataRepository.getMetadataByIds<Ref>(idsWithoutDataStore, "id,type"); //type is required to transform visualizations to charts and report tables
 
         const metadataWithSyncAll: Partial<Record<keyof MetadataEntities, Ref[]>> = await Promise.all(
             (syncParams?.metadataModelsSyncAll ?? []).map(

--- a/src/domain/packages/entities/MetadataPackageDiff.ts
+++ b/src/domain/packages/entities/MetadataPackageDiff.ts
@@ -110,7 +110,7 @@ function getStringValue(value: AttributeValue): string {
                 // On arrays, remove the ignored fields and apply a simple, best-effort sorting
                 // so the same items in different order are considered equal.
                 return stringify(
-                    _(value as Obj[])
+                    _(value as unknown as Obj[])
                         .map(obj => _.omit(obj, ignoredFields))
                         .sortBy(obj => obj.id || stringify(obj))
                         .value()

--- a/src/domain/reports/entities/Stats.ts
+++ b/src/domain/reports/entities/Stats.ts
@@ -1,14 +1,8 @@
+import { Maybe } from "../../../types/utils";
 import { Struct } from "../../common/entities/Struct";
+import { SynchronizationStats } from "./SynchronizationResult";
 
-type StatsAttrs = {
-    imported: number;
-    ignored: number;
-    updated: number;
-    deleted: number;
-    total: number;
-};
-
-export class Stats extends Struct<StatsAttrs>() {
+export class Stats extends Struct<SynchronizationStats>() {
     static combine(stats: Stats[]): Stats {
         return stats.reduce((acum, stat) => {
             return Stats.create({
@@ -16,12 +10,22 @@ export class Stats extends Struct<StatsAttrs>() {
                 ignored: acum.ignored + stat.ignored,
                 updated: acum.updated + stat.updated,
                 deleted: acum.deleted + stat.deleted,
-                total: acum.total + stat.imported + stat.deleted + stat.ignored + stat.updated,
+                total: (acum.total || 0) + stat.imported + stat.deleted + stat.ignored + stat.updated,
             });
         }, Stats.createOrEmpty());
     }
 
-    static createOrEmpty(stats?: Partial<StatsAttrs>): Stats {
+    static createOrEmpty(stats?: Partial<SynchronizationStats>): Stats {
         return Stats.create({ imported: 0, ignored: 0, updated: 0, total: 0, deleted: 0, ...stats });
+    }
+
+    static sumStats(stats1: SynchronizationStats, stats2: Maybe<SynchronizationStats>): Stats {
+        return Stats.create({
+            deleted: stats1.deleted + (stats2?.deleted || 0),
+            ignored: stats1.ignored + (stats2?.ignored || 0),
+            imported: stats1.imported + (stats2?.imported || 0),
+            updated: stats1.updated + (stats2?.updated || 0),
+            total: (stats1?.total || 0) + (stats2?.total || 0),
+        });
     }
 }

--- a/src/domain/reports/entities/Stats.ts
+++ b/src/domain/reports/entities/Stats.ts
@@ -1,0 +1,27 @@
+import { Struct } from "../../common/entities/Struct";
+
+type StatsAttrs = {
+    imported: number;
+    ignored: number;
+    updated: number;
+    deleted: number;
+    total: number;
+};
+
+export class Stats extends Struct<StatsAttrs>() {
+    static combine(stats: Stats[]): Stats {
+        return stats.reduce((acum, stat) => {
+            return Stats.create({
+                imported: acum.imported + stat.imported,
+                ignored: acum.ignored + stat.ignored,
+                updated: acum.updated + stat.updated,
+                deleted: acum.deleted + stat.deleted,
+                total: acum.total + stat.imported + stat.deleted + stat.ignored + stat.updated,
+            });
+        }, Stats.createOrEmpty());
+    }
+
+    static createOrEmpty(stats?: Partial<StatsAttrs>): Stats {
+        return Stats.create({ imported: 0, ignored: 0, updated: 0, total: 0, deleted: 0, ...stats });
+    }
+}

--- a/src/domain/synchronization/usecases/GenericSyncUseCase.ts
+++ b/src/domain/synchronization/usecases/GenericSyncUseCase.ts
@@ -95,6 +95,12 @@ export abstract class GenericSyncUseCase {
     }
 
     @cache()
+    protected async getDataStoreMetadataRepository(remoteInstance?: Instance) {
+        const defaultInstance = await this.getOriginInstance();
+        return this.repositoryFactory.dataStoreMetadataRepository(remoteInstance ?? defaultInstance);
+    }
+
+    @cache()
     protected async getTeisRepository(remoteInstance?: Instance) {
         const defaultInstance = await this.getOriginInstance();
         return this.repositoryFactory.teisRepository(remoteInstance ?? defaultInstance);

--- a/src/domain/synchronization/usecases/GenericSyncUseCase.ts
+++ b/src/domain/synchronization/usecases/GenericSyncUseCase.ts
@@ -8,6 +8,7 @@ import { getD2APiFromInstance } from "../../../utils/d2-utils";
 import { debug } from "../../../utils/debug";
 import { AggregatedSyncUseCase } from "../../aggregated/usecases/AggregatedSyncUseCase";
 import { RepositoryFactory } from "../../common/factories/RepositoryFactory";
+import { DataStoreMetadata } from "../../data-store/DataStoreMetadata";
 import { EventsSyncUseCase } from "../../events/usecases/EventsSyncUseCase";
 import { Instance } from "../../instance/entities/Instance";
 import { MetadataMapping, MetadataMappingDictionary } from "../../mapping/entities/MetadataMapping";
@@ -54,7 +55,8 @@ export abstract class GenericSyncUseCase {
 
     @cache()
     public async extractMetadata<T>(remoteInstance = this.localInstance) {
-        const cleanIds = this.builder.metadataIds.map(id => _.last(id.split("-")) ?? id);
+        const onlyMetadataIds = this.builder.metadataIds.filter(id => !DataStoreMetadata.isDataStoreId(id));
+        const cleanIds = onlyMetadataIds.map(id => _.last(id.split("-")) ?? id);
         const metadataRepository = await this.getMetadataRepository(remoteInstance);
         return metadataRepository.getMetadataByIds<T>(cleanIds, this.fields);
     }

--- a/src/models/dhis/factory.ts
+++ b/src/models/dhis/factory.ts
@@ -20,6 +20,7 @@ export const metadataModels = [
     metadataClasses.DataElementGroupSetModel,
     metadataClasses.DataEntryFormModel,
     metadataClasses.DataSetModel,
+    metadataClasses.DataStoreModel,
     metadataClasses.DocumentsModel,
     metadataClasses.EventChartModel,
     metadataClasses.EventReportModel,

--- a/src/models/dhis/metadata.ts
+++ b/src/models/dhis/metadata.ts
@@ -1,3 +1,4 @@
+import { DataStore } from "../../domain/metadata/entities/MetadataEntities";
 import {
     categoryOptionColumns,
     categoryOptionFields,
@@ -779,4 +780,22 @@ export class SqlView extends D2Model {
     protected static collectionName = "sqlViews" as const;
 
     protected static includeRules = ["attributes"];
+}
+
+export class DataStoreModel extends D2Model {
+    protected static metadataType = "dataStore";
+    protected static modelName = "Data Store";
+    protected static collectionName = "dataStores" as const;
+    protected static childrenKeys = ["keys"];
+
+    protected static modelTransform = (dataStores: DataStore[]) => {
+        return dataStores.map(({ keys = [], ...rest }) => ({
+            ...rest,
+            keys: keys.map(keyItem => ({ ...keyItem, model: DataStoreKeysModel })),
+        }));
+    };
+}
+
+export class DataStoreKeysModel extends D2Model {
+    protected static modelName = "Keys";
 }

--- a/src/presentation/CompositionRoot.ts
+++ b/src/presentation/CompositionRoot.ts
@@ -119,6 +119,7 @@ import { GetSystemInfoUseCase } from "../domain/system-info/usecases/GetSystemIn
 import { ListTEIsUseCase } from "../domain/tracked-entity-instances/usecases/ListTEIsUseCase";
 import { GetCurrentUserUseCase } from "../domain/user/usecases/GetCurrentUserUseCase";
 import { cache } from "../utils/cache";
+import { DataStoreMetadataD2Repository } from "../data/data-store/DataStoreMetadataD2Repository";
 
 export class CompositionRoot {
     private repositoryFactory: RepositoryFactory;
@@ -148,6 +149,7 @@ export class CompositionRoot {
         this.repositoryFactory.bind(Repositories.MappingRepository, MappingD2ApiRepository);
         this.repositoryFactory.bind(Repositories.SchedulerRepository, SchedulerD2ApiRepository);
         this.repositoryFactory.bind(Repositories.SettingsRepository, SettingsD2ApiRepository);
+        this.repositoryFactory.bind(Repositories.DataStoreMetadataRepository, DataStoreMetadataD2Repository);
     }
 
     @cache()

--- a/src/presentation/react/core/components/metadata-table/MetadataTable.tsx
+++ b/src/presentation/react/core/components/metadata-table/MetadataTable.tsx
@@ -722,7 +722,7 @@ const MetadataTable: React.FC<MetadataTableProps> = ({
                 rows={shownRows}
                 columns={columns}
                 details={details}
-                onChangeSearch={changeSearchFilter}
+                onChangeSearch={model.getMetadataType() !== "dataStore" ? changeSearchFilter : undefined}
                 initialState={initialState}
                 searchBoxLabel={i18n.t(`Search by name, code or id`)}
                 pagination={pager}

--- a/src/presentation/react/core/components/sync-wizard/common/MetadataSelectionStep.tsx
+++ b/src/presentation/react/core/components/sync-wizard/common/MetadataSelectionStep.tsx
@@ -24,6 +24,7 @@ import { useAppContext } from "../../../contexts/AppContext";
 import { getChildrenRows } from "../../mapping-table/utils";
 import MetadataTable from "../../metadata-table/MetadataTable";
 import { SyncWizardStepProps } from "../Steps";
+import { DataStoreMetadata } from "../../../../../../domain/data-store/DataStoreMetadata";
 
 const config = {
     metadata: {
@@ -89,7 +90,9 @@ export default function MetadataSelectionStep({ syncRule, onChange }: SyncWizard
                 );
             }
 
-            compositionRoot.metadata.getByIds(newMetadataIds, remoteInstance, "id").then(metadata => {
+            const onlyMetadataIds = newMetadataIds.filter(id => !id.includes(DataStoreMetadata.NS_SEPARATOR));
+
+            compositionRoot.metadata.getByIds(onlyMetadataIds, remoteInstance, "id").then(metadata => {
                 const types = _(metadata).keys().concat(metadataModelsSyncAll).uniq().value();
 
                 onChange(

--- a/src/presentation/react/core/components/sync-wizard/common/MetadataSelectionStep.tsx
+++ b/src/presentation/react/core/components/sync-wizard/common/MetadataSelectionStep.tsx
@@ -28,7 +28,7 @@ import { SyncWizardStepProps } from "../Steps";
 const config = {
     metadata: {
         models: metadataModels,
-        childrenKeys: undefined,
+        childrenKeys: ["keys"],
     },
     aggregated: {
         models: [

--- a/src/presentation/react/core/components/sync-wizard/common/SummaryStep.tsx
+++ b/src/presentation/react/core/components/sync-wizard/common/SummaryStep.tsx
@@ -530,12 +530,9 @@ export const DataStoreSectionContent = (props: { metadataIds: string[] }) => {
     const { metadataIds } = props;
 
     const dataStoreInfo = React.useMemo(() => {
-        return _(metadataIds)
-            .map(metadataId => {
-                return metadataId.includes(DataStoreMetadata.NS_SEPARATOR) ? metadataId : undefined;
-            })
-            .compact()
-            .value();
+        return metadataIds.filter(metadataId => {
+            return metadataId.includes(DataStoreMetadata.NS_SEPARATOR);
+        });
     }, [metadataIds]);
 
     if (dataStoreInfo.length === 0) return null;

--- a/src/presentation/react/core/components/sync-wizard/common/SummaryStep.tsx
+++ b/src/presentation/react/core/components/sync-wizard/common/SummaryStep.tsx
@@ -4,6 +4,7 @@ import _ from "lodash";
 import moment from "moment";
 import React, { useEffect, useMemo, useState } from "react";
 import { useHistory } from "react-router-dom";
+import { DataStoreMetadata } from "../../../../../../domain/data-store/DataStoreMetadata";
 import { filterRuleToString } from "../../../../../../domain/metadata/entities/FilterRule";
 import {
     MetadataEntities,
@@ -272,6 +273,8 @@ export const SummaryStepContent = (props: SummaryStepContentProps) => {
                     );
                 })}
 
+            <DataStoreSectionContent metadataIds={syncRule.metadataIds} />
+
             {syncRule.filterRules.length > 0 && (
                 <LiEntry
                     label={i18n.t("Filter rules [{{total}}]", {
@@ -518,5 +521,34 @@ export const SummaryStepContent = (props: SummaryStepContentProps) => {
 
             {syncRule.longFrequency && <LiEntry label={i18n.t("Frequency")} value={syncRule.longFrequency} />}
         </ul>
+    );
+};
+
+export const DataStoreSectionContent = (props: { metadataIds: string[] }) => {
+    const { metadataIds } = props;
+
+    const dataStoreInfo = React.useMemo(() => {
+        return _(metadataIds)
+            .map(metadataId => {
+                return metadataId.includes(DataStoreMetadata.NS_SEPARATOR) ? metadataId : undefined;
+            })
+            .compact()
+            .value();
+    }, [metadataIds]);
+
+    if (dataStoreInfo.length === 0) return null;
+
+    return (
+        <>
+            <LiEntry label={`DataStore [${dataStoreInfo.length}]`}>
+                <ul>
+                    {dataStoreInfo.map(dataStore => {
+                        const [namespace, key] = dataStore.split(DataStoreMetadata.NS_SEPARATOR);
+                        const keyName = key ? `${key}` : "All Keys";
+                        return <LiEntry key={`${namespace}-${key}`} label={`${namespace} - ${keyName}`} />;
+                    })}
+                </ul>
+            </LiEntry>
+        </>
     );
 };

--- a/src/presentation/react/core/components/sync-wizard/common/SummaryStep.tsx
+++ b/src/presentation/react/core/components/sync-wizard/common/SummaryStep.tsx
@@ -243,6 +243,8 @@ export const SummaryStepContent = (props: SummaryStepContentProps) => {
                         return null;
                     }
 
+                    if (modelByMetadataType.schema.displayName === "Key Json Value") return null;
+
                     if (syncRule.metadataModelsSyncAll.includes(metadataType)) {
                         const length = syncAllTypesLength[metadataType];
 

--- a/src/presentation/webapp/core/pages/manual-sync/ManualSyncPage.tsx
+++ b/src/presentation/webapp/core/pages/manual-sync/ManualSyncPage.tsx
@@ -37,6 +37,7 @@ import SyncSummary from "../../../../react/core/components/sync-summary/SyncSumm
 import { TestWrapper } from "../../../../react/core/components/test-wrapper/TestWrapper";
 import { useAppContext } from "../../../../react/core/contexts/AppContext";
 import InstancesSelectors from "./InstancesSelectors";
+import { DataStoreMetadata } from "../../../../../domain/data-store/DataStoreMetadata";
 
 const config: Record<
     SynchronizationType,
@@ -49,7 +50,7 @@ const config: Record<
     metadata: {
         title: i18n.t("Metadata Synchronization"),
         models: metadataModels,
-        childrenKeys: undefined,
+        childrenKeys: ["keys"],
     },
     aggregated: {
         title: i18n.t("Aggregated Data Synchronization"),
@@ -250,6 +251,8 @@ const ManualSyncPage: React.FC = () => {
             text: i18n.t("Metadata type"),
             hidden: config[type].childrenKeys === undefined,
             getValue: (row: MetadataType) => {
+                if (row.id.includes(DataStoreMetadata.NS_SEPARATOR)) return "";
+
                 return row.model.getModelName();
             },
         },


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/8694jg0zj

### :memo: Implementation

- [x] List all namespaces, then get all the keys for every namespace (we can improve this process by [using the query api (fetch keys and values in a single request)](https://docs.dhis2.org/en/full/develop/dhis-core-version-238/developer-manual.html#query-api)  once we don't need support for version 36 and 37)
- [x] Implemented merge/replace process
- [x] Process keys in destination server
- [x] generate synchronization result stats 

### :video_camera: Screenshots/Screen capture

[MetaData-Synchronization_keys (1).webm](https://github.com/user-attachments/assets/aac4ed78-780c-4b4c-a92f-af032ed68ddf)

**Executing rule/ Summary Results**

[MetaData-Synchronization_datastore_and_metadata.webm](https://github.com/user-attachments/assets/7d29ca9c-c25c-49df-b3df-b1202b6b65b9)

**DataStore in summary step**

![image](https://github.com/user-attachments/assets/afda7257-3a54-4ac3-918c-9891d912aab6)

**select individual keys**

![image](https://github.com/user-attachments/assets/e57afbca-be3a-4b0a-b8c6-09d740a8d5bf)


### :fire: Is there anything the reviewer should know to test it?

- DHIS2 does not support pagination for namespaces so I'm always adding all of them in one page.
- Since the API does not support processing everything in a single transaction, there might be cases where part of the data is processed, but another part is not (closing the browser before finishing the execution, destination server not being available, etc).

### :bookmark_tabs: Others
