### PR TITLE
Support to 2.41

### DIFF
--- a/src/data/transformations/PackageTransformations.ts
+++ b/src/data/transformations/PackageTransformations.ts
@@ -11,6 +11,37 @@ export const metadataTransformations: Transformation[] = [
             };
         },
     },
+    {
+        name: "eventCharts, eventReports missing in 2.41",
+        apiVersion: 41,
+        undo: ({ eventVisualizations, eventCharts, eventReports, ...rest }: any) => {
+            const isEventReport = (visualizationType: string) =>
+                visualizationType === "PIVOT_TABLE" || visualizationType === "LINE_LIST";
+
+            const finalEventCharts = eventCharts
+                ? eventCharts
+                : eventVisualizations?.filter((eventVisualization: any) => !isEventReport(eventVisualization.type)) ||
+                  [];
+            const finalEventReports = eventReports
+                ? eventReports
+                : eventVisualizations?.filter((eventVisualization: any) => isEventReport(eventVisualization.type)) ||
+                  [];
+
+            return {
+                ...rest,
+                eventCharts: finalEventCharts,
+                eventReports: finalEventReports,
+            };
+        },
+        apply: ({ eventCharts, eventReports, ...rest }: any) => {
+            const eventVisualizations = [...(eventCharts || []), ...(eventReports || [])];
+
+            return {
+                ...rest,
+                eventVisualizations,
+            };
+        },
+    },
 ];
 
 export const aggregatedTransformations: Transformation[] = [];

--- a/src/presentation/react/core/components/module-list-table/NewPackageDialog.tsx
+++ b/src/presentation/react/core/components/module-list-table/NewPackageDialog.tsx
@@ -120,7 +120,7 @@ export const NewPackageDialog: React.FC<NewPackageDialogProps> = ({ module, save
             <Autocomplete
                 className={classes.row}
                 multiple
-                options={["2.30", "2.31", "2.32", "2.33", "2.34"]}
+                options={["2.37", "2.38", "2.39", "2.40", "2.41"]}
                 value={versions}
                 onChange={(_event, value) => updateVersions(value)}
                 renderTags={(values: string[]) => values.sort().join(", ")}


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/8696arbge #8696arbge

### :memo: Implementation

- [x] Fix bug to sync eventCharts and eventReports from 2.4.1 to 2.41

 
### :video_camera: Screenshots/Screen capture

### :fire: Is there anything the reviewer should know to test it?

### :bookmark_tabs: Others

-   Any change in the [GUI library](https://github.com/EyeSeeTea/d2-ui-components)? If so, what branch/PR?

-   Any change in the [D2 Api](https://github.com/EyeSeeTea/d2-api)? If so, what branch/PR?
