### PR TITLE
Events do not get synced if period is "Since last successful"

### DIFF
--- a/src/domain/aggregated/entities/DataSynchronizationParams.ts
+++ b/src/domain/aggregated/entities/DataSynchronizationParams.ts
@@ -43,7 +43,7 @@ export function isDataSynchronizationRequired(params: DataSynchronizationParams,
     const { period } = params;
     const { startDate } = buildPeriodFromParams(params);
 
-    const isUpdatedAfterStartDate = lastUpdated && new Date(lastUpdated).toISOString() >= startDate.format();
+    const isUpdatedAfterStartDate = lastUpdated && new Date(lastUpdated).toISOString() >= startDate.toISOString();
     const isLastSuccessfulSync = period === "SINCE_LAST_SUCCESSFUL_SYNC";
 
     return isUpdatedAfterStartDate || !isLastSuccessfulSync;


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes #869847mre [Events do not get synced if period is "Since last successful"](https://app.clickup.com/t/869847mre)

### :memo: Implementation

- Fix comparing dates both in ISO when filtering events if period is `SINCE_LAST_SUCCESSFUL_SYNC`

### :video_camera: Screenshots/Screen capture

### :fire: Is there anything the reviewer should know to test it?
1. Create an event sync rule with period since "last successful execution"
2. Execute sync rule
3. Create an event in the program during same hour
4. Execute and check that event was sync

### :bookmark_tabs: Others

-   Any change in the [GUI library](https://github.com/EyeSeeTea/d2-ui-components)? If so, what branch/PR?

-   Any change in the [D2 Api](https://github.com/EyeSeeTea/d2-api)? If so, what branch/PR?
