### PR TITLE
Fix Translations

### DIFF
--- a/package.json
+++ b/package.json
@@ -142,7 +142,8 @@
     },
     "resolutions": {
         "@types/react": "17.0.30",
-        "@types/react-dom": "17.0.9"
+        "@types/react-dom": "17.0.9",
+        "@dhis2/d2-i18n": "1.1.3"
     },
     "manifest.webapp": {
         "name": "MetaData Synchronization",

--- a/src/presentation/react/core/contexts/AppContext.ts
+++ b/src/presentation/react/core/contexts/AppContext.ts
@@ -1,6 +1,7 @@
 import React, { useContext } from "react";
 import { CompositionRoot } from "../../../CompositionRoot";
 import { D2Api } from "../../../../types/d2-api";
+import i18n from "../../../../locales";
 
 export interface AppContextState {
     api: D2Api;
@@ -11,6 +12,8 @@ export interface AppContextState {
 export const AppContext = React.createContext<AppContextState | null>(null);
 
 export function useAppContext() {
+    i18n.setDefaultNamespace("metadata-synchronization");
+
     const context = useContext(AppContext);
     if (context) {
         return context;

--- a/src/types/global/index.d.ts
+++ b/src/types/global/index.d.ts
@@ -11,6 +11,7 @@ declare module "@dhis2/d2-i18n" {
     export function t(value: string): string;
     export function t(value: string, options?: { [key: string]: any }): string;
     export function changeLanguage(locale: string);
+    export function setDefaultNamespace(namespace: string);
 }
 
 declare module "nano-memoize" {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2924,15 +2924,7 @@
     moment "^2.22.1"
     rimraf "^2.6.2"
 
-"@dhis2/d2-i18n@1.0.6":
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/@dhis2/d2-i18n/-/d2-i18n-1.0.6.tgz#2914be8acf296f3a6bf7b51c76c46da6a120b0ff"
-  integrity sha512-7YdA4ppFosjuyf7ZMm47BrdsA5TWLM9lmS0lUPgjcCVeeWfUgagqzf4W5JGB9XQ3w1vzK+yy5zH2Ij8IgRAGhA==
-  dependencies:
-    i18next "^10.3"
-    moment "^2.24.0"
-
-"@dhis2/d2-i18n@1.1.3", "@dhis2/d2-i18n@^1.0.5":
+"@dhis2/d2-i18n@1.0.6", "@dhis2/d2-i18n@1.1.3", "@dhis2/d2-i18n@^1.0.5":
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/@dhis2/d2-i18n/-/d2-i18n-1.1.3.tgz#ad73030f7cfceeed1b5bcaad86a9b336130bdfb1"
   integrity sha512-vOu6RDNumOJM396mHt35bETk9ai9b6XJyAwlUy1HstUZNvfET61F8rjCmMuXZU6zJ8ELux8kMFqlH8IG0vDJmA==


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes #8697u2abb [Translations not working](https://app.clickup.com/t/8697u2abb)
related to [check all apps for conflicts between translations and feedback component](https://app.clickup.com/t/8694ubx3x)

### :memo: Implementation
- i18n instance was being overwritten due to multiple versions. Resolved version in package.json to use `1.1.3`
- might need to delete `node_modules` then rerun yarn install

### :video_camera: Screenshots/Screen capture

### :fire: Is there anything the reviewer should know to test it?
- manually setting default namespace in app context caused some dependencies to locate their translations in the app's translations. This seems to be an issue in other apps that use this approach as well.
- I updated the translations in es.po (not pushed) and we'll see feedback component and the account menu using these translations
```
msgid "Aggregated Data Sync"
msgstr "Aggregated Data Sync MS"

msgid "Cancel"
msgstr "Cancel MS"

msgid "Settings"
msgstr "Settings MS"
```

![image](https://github.com/user-attachments/assets/47c35055-0fee-4135-882a-1254ec1b58c0) ![image](https://github.com/user-attachments/assets/a7b80a9e-9dd3-4d67-8d9e-63300e667262)


### :bookmark_tabs: Others

-   Any change in the [GUI library](https://github.com/EyeSeeTea/d2-ui-components)? If so, what branch/PR?

-   Any change in the [D2 Api](https://github.com/EyeSeeTea/d2-api)? If so, what branch/PR?
