### PR TITLE
Schedule update does not reflect in scheduling

### DIFF
--- a/src/domain/rules/entities/SynchronizationRule.ts
+++ b/src/domain/rules/entities/SynchronizationRule.ts
@@ -34,6 +34,7 @@ export class SynchronizationRule {
             "builder",
             "targetInstances",
             "enabled",
+            "needsUpdateSchedulingFrequency",
             "frequency",
             "lastExecuted",
             "lastExecutedBy",
@@ -181,6 +182,10 @@ export class SynchronizationRule {
         return this.syncRule.enabled ?? false;
     }
 
+    public get needsUpdateSchedulingFrequency(): boolean {
+        return this.syncRule.needsUpdateSchedulingFrequency ?? false;
+    }
+
     public get frequency(): string | undefined {
         return this.syncRule.frequency;
     }
@@ -267,6 +272,7 @@ export class SynchronizationRule {
             builder: defaultSynchronizationBuilder,
             targetInstances: [],
             enabled: false,
+            needsUpdateSchedulingFrequency: false,
             lastUpdated: new Date(),
             lastUpdatedBy: {
                 id: "",
@@ -599,6 +605,10 @@ export class SynchronizationRule {
         return this.update({ enabled });
     }
 
+    public updateNeedsUpdateSchedulingFrequency(needsUpdateSchedulingFrequency: boolean): SynchronizationRule {
+        return this.update({ needsUpdateSchedulingFrequency });
+    }
+
     public updateFrequency(frequency: string): SynchronizationRule {
         return this.update({ frequency });
     }
@@ -765,6 +775,7 @@ export interface SynchronizationRuleData extends SharedRef {
     builder: SynchronizationBuilder;
     targetInstances: string[];
     enabled: boolean;
+    needsUpdateSchedulingFrequency?: boolean;
     lastExecuted?: Date;
     lastExecutedBy?: NamedRef;
     lastSuccessfulSync?: Date;

--- a/src/presentation/react/core/components/sync-wizard/Steps.ts
+++ b/src/presentation/react/core/components/sync-wizard/Steps.ts
@@ -23,6 +23,7 @@ export interface SyncWizardStep extends WizardStep {
 
 export interface SyncWizardStepProps {
     syncRule: SynchronizationRule;
+    originalSyncRule?: SynchronizationRule;
     onChange: (syncRule: SynchronizationRule) => void;
     onCancel: () => void;
 }

--- a/src/presentation/react/core/components/sync-wizard/SyncWizard.tsx
+++ b/src/presentation/react/core/components/sync-wizard/SyncWizard.tsx
@@ -10,6 +10,7 @@ import { aggregatedSteps, deletedSteps, eventsSteps, metadataSteps } from "./Ste
 
 interface SyncWizardProps {
     syncRule: SynchronizationRule;
+    originalSyncRule?: SynchronizationRule;
     isDialog?: boolean;
     onChange?(syncRule: SynchronizationRule): void;
     onCancel?(): void;
@@ -24,6 +25,7 @@ const config = {
 
 const SyncWizard: React.FC<SyncWizardProps> = ({
     syncRule,
+    originalSyncRule,
     isDialog = false,
     onChange = _.noop,
     onCancel = _.noop,
@@ -39,6 +41,7 @@ const SyncWizard: React.FC<SyncWizardProps> = ({
             ...step,
             props: {
                 syncRule,
+                originalSyncRule,
                 onCancel,
                 onChange,
             },

--- a/src/presentation/react/core/components/sync-wizard/common/SchedulerStep.tsx
+++ b/src/presentation/react/core/components/sync-wizard/common/SchedulerStep.tsx
@@ -7,6 +7,7 @@ import { Toggle } from "../../toggle/Toggle";
 import { SyncWizardStepProps } from "../Steps";
 import TextFieldOnBlur from "../../text-field-on-blur/TextFieldOnBlur";
 import { SynchronizationRule } from "../../../../../../domain/rules/entities/SynchronizationRule";
+import { areCronExpressionsEqual } from "../../../../../../utils/areCronExpressionsEqual";
 
 const cronExpressions = [
     { name: i18n.t("Every day"), id: "0 0 0 ? * *" },
@@ -16,8 +17,8 @@ const cronExpressions = [
     { name: i18n.t("Every year"), id: "0 0 0 1 1 ?" },
 ];
 
-const SchedulerStep = ({ syncRule, onChange }: SyncWizardStepProps) => {
-    const form = useSchedulerForm({ syncRule, onChange });
+const SchedulerStep = ({ syncRule, onChange, originalSyncRule }: SyncWizardStepProps) => {
+    const form = useSchedulerForm({ syncRule, onChange, originalSyncRule });
     const selectedCron = cronExpressions.find(({ id }) => id === form.syncRuleForm.frequency);
 
     return (
@@ -47,18 +48,18 @@ const SchedulerStep = ({ syncRule, onChange }: SyncWizardStepProps) => {
 
 function useSchedulerForm(options: {
     syncRule: SynchronizationRule;
+    originalSyncRule?: SynchronizationRule;
     onChange: (syncRule: SynchronizationRule) => void;
 }) {
-    const { syncRule, onChange } = options;
+    const { syncRule, onChange, originalSyncRule } = options;
 
-    const [syncRuleForm, setsyncRuleForm] = React.useState(syncRule);
-
+    const [syncRuleForm, setSyncRuleForm] = React.useState(syncRule);
     const [errors, setErrors] = React.useState<{ frequency?: string }>({});
 
     const setEnabled = React.useCallback(
         (ev: { target: { value: boolean } }) => {
             const syncRuleUpdated = syncRule.updateEnabled(ev.target.value);
-            setsyncRuleForm(syncRuleUpdated);
+            setSyncRuleForm(syncRuleUpdated);
             onChange(syncRuleUpdated);
         },
         [syncRule, onChange]
@@ -66,28 +67,40 @@ function useSchedulerForm(options: {
 
     const setUpdateFrequency = React.useCallback(
         (value: string) => {
-            const syncRuleUpdated = syncRule.updateFrequency(value);
-            setsyncRuleForm(syncRuleUpdated);
-            onChange(syncRuleUpdated);
+            const hasFrequencyChanged =
+                !!originalSyncRule?.frequency && !areCronExpressionsEqual(value, originalSyncRule.frequency);
+
+            const syncRuleNewFrequencyUpdated = syncRule.updateFrequency(value);
+            const syncRuleAllUpdated =
+                syncRuleNewFrequencyUpdated.updateNeedsUpdateSchedulingFrequency(hasFrequencyChanged);
+            setSyncRuleForm(syncRuleAllUpdated);
+
+            setSyncRuleForm(syncRuleAllUpdated);
+            onChange(syncRuleAllUpdated);
             setErrors(prev => ({ ...prev, frequency: undefined }));
         },
-        [syncRule, onChange]
+        [originalSyncRule?.frequency, syncRule, onChange]
     );
 
     const setCronExpression = React.useCallback(
         (value: string) => {
             const isValid = !value || isValidCronExpression(value);
-            const syncRuleUpdated = syncRule.updateFrequency(value);
-            setsyncRuleForm(syncRuleUpdated);
+            const hasFrequencyChanged =
+                !!originalSyncRule?.frequency && !areCronExpressionsEqual(value, originalSyncRule.frequency);
+
+            const syncRuleNewFrequencyUpdated = syncRule.updateFrequency(value);
+            const syncRuleAllUpdated =
+                syncRuleNewFrequencyUpdated.updateNeedsUpdateSchedulingFrequency(hasFrequencyChanged);
+            setSyncRuleForm(syncRuleAllUpdated);
 
             if (isValid) {
-                onChange(syncRuleUpdated);
+                onChange(syncRuleAllUpdated);
                 setErrors(prev => ({ ...prev, frequency: undefined }));
             } else {
                 setErrors({ frequency: i18n.t("Cron expression must be valid") });
             }
         },
-        [syncRule, onChange]
+        [originalSyncRule?.frequency, syncRule, onChange]
     );
 
     return { errors, setErrors, syncRuleForm, setEnabled, setUpdateFrequency, setCronExpression };

--- a/src/presentation/webapp/core/pages/sync-rules-creation/SyncRulesCreationPage.tsx
+++ b/src/presentation/webapp/core/pages/sync-rules-creation/SyncRulesCreationPage.tsx
@@ -24,6 +24,8 @@ const SyncRulesCreation: React.FC = () => {
 
     const [dialogOpen, updateDialogOpen] = useState(false);
     const [syncRule, updateSyncRule] = useState(location.state?.syncRule ?? SynchronizationRule.create(type));
+    const [originalSyncRule, setOriginalSyncRule] = useState<SynchronizationRule | undefined>(undefined);
+
     const isEdit = action === "edit" && !!id;
 
     const title = !isEdit
@@ -47,6 +49,7 @@ const SyncRulesCreation: React.FC = () => {
             loading.show(true, "Loading sync rule");
             compositionRoot.rules.get(id).then(syncRule => {
                 updateSyncRule(syncRule ?? SynchronizationRule.create(type));
+                setOriginalSyncRule(syncRule ?? SynchronizationRule.create(type));
                 loading.reset();
             });
         }
@@ -65,7 +68,12 @@ const SyncRulesCreation: React.FC = () => {
 
             <PageHeader title={title} onBackClick={openDialog} />
 
-            <SyncWizard syncRule={syncRule} onChange={updateSyncRule} onCancel={exit} />
+            <SyncWizard
+                syncRule={syncRule}
+                originalSyncRule={originalSyncRule}
+                onChange={updateSyncRule}
+                onCancel={exit}
+            />
         </TestWrapper>
     );
 };

--- a/src/scheduler/SchedulerCLI/__tests__/SchedulerCLI.spec.ts
+++ b/src/scheduler/SchedulerCLI/__tests__/SchedulerCLI.spec.ts
@@ -51,15 +51,24 @@ describe("SchedulerCLI", () => {
         it("should call compositionRoot.rules.list with correct params and return correct SyncRuleJobConfig[]", async () => {
             const spyListRules = jest.spyOn(mockCompositionRoot.rules, "list");
 
-            const expectedConfigs: SyncRuleJobConfig[] = [getSyncRuleJobConfig()];
+            const expectedSyncRules: SynchronizationRule[] = [getSynchronizationRule(true)];
 
-            const result = await schedulerCLI["getSyncRuleJobConfigs"]();
+            const result = await schedulerCLI["getEnabledSyncRules"]();
 
             expect(spyListRules).toHaveBeenCalledWith({
                 paging: false,
                 filters: { schedulerEnabledFilter: "enabled" },
             });
-            expect(result).toEqual(expectedConfigs);
+            expect(result).toEqual(expectedSyncRules);
+        });
+
+        it("should call getSyncRuleJobConfigs and return correct SyncRuleJobConfig", async () => {
+            const syncRulesEnabled: SynchronizationRule[] = [getSynchronizationRule(true)];
+            const expectedSyncRuleJobConfigs: SyncRuleJobConfig[] = [getSyncRuleJobConfig()];
+
+            const result = await schedulerCLI["getSyncRuleJobConfigs"](syncRulesEnabled);
+
+            expect(result).toEqual(expectedSyncRuleJobConfigs);
         });
     });
 });
@@ -69,6 +78,7 @@ function getSyncRuleJobConfig(): SyncRuleJobConfig {
         id: "sync-rule-id",
         name: "Sync Rule",
         frequency: "0 */2 * * * *",
+        needsUpdateFrequency: false,
     };
 }
 

--- a/src/scheduler/SchedulerCLI/__tests__/data/getSynchronizationRule.ts
+++ b/src/scheduler/SchedulerCLI/__tests__/data/getSynchronizationRule.ts
@@ -9,6 +9,7 @@ export function getSynchronizationRule(isSchedulerEnabled = false): Synchronizat
         user: { id: "user-id", name: "User Name" },
         created: new Date(),
         enabled: isSchedulerEnabled,
+        needsUpdateSchedulingFrequency: false,
         frequency: "0 */2 * * * *",
         description: "Sync Rule",
         lastUpdated: new Date(),

--- a/src/utils/__tests__/areCronExpressionsEqual.spec.ts
+++ b/src/utils/__tests__/areCronExpressionsEqual.spec.ts
@@ -1,0 +1,13 @@
+import { areCronExpressionsEqual } from "../areCronExpressionsEqual";
+
+describe("areCronExpressionsEqual", () => {
+    it("should return true for identical cron expressions", () => {
+        const result = areCronExpressionsEqual("0 0 0 1 1/1 ?", "0 0 0 1 1/1 ?");
+        expect(result).toBe(true);
+    });
+
+    it("should return false if fields differ", () => {
+        const result = areCronExpressionsEqual("0 0 0 1 1/1 ?", "0 0 0 ? * *");
+        expect(result).toBe(false);
+    });
+});

--- a/src/utils/areCronExpressionsEqual.ts
+++ b/src/utils/areCronExpressionsEqual.ts
@@ -1,0 +1,12 @@
+export const areCronExpressionsEqual = (cron1: string, cron2: string): boolean => {
+    const normalize = (field: string) => field.trim().toUpperCase();
+
+    const fields1 = cron1.trim().split(/\s+/).map(normalize);
+    const fields2 = cron2.trim().split(/\s+/).map(normalize);
+
+    if (fields1.length !== fields2.length) {
+        return false;
+    }
+
+    return fields1.every((field, index) => field === fields2[index]);
+};


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes #869844gja [Schedule update does not reflect in scheduling](https://app.clickup.com/t/869844gja)

### :memo: Implementation

- Add needsUpdateSchedulingFrequency to SynchronizationRule and enable/disable according conditions
- Update scheduler when needsUpdateSchedulingFrequency is enabled, and then disable it

### :video_camera: Screenshots/Screen capture

[Screencast from 2025-03-15 18-24-05.webm](https://github.com/user-attachments/assets/86254d24-92dd-4ead-9d44-53d732c1cb57)

![image](https://github.com/user-attachments/assets/6df156a9-e70a-4363-8a5d-e690b272ed05)


### :fire: Is there anything the reviewer should know to test it?

1. Create or edit a sync rule having the scheduler enabled
2. Run scheduler using the corresponding config: `yarn start-scheduler -c config.json`
3. Check if data is sync correctly and logs

### :bookmark_tabs: Others

-   Any change in the [GUI library](https://github.com/EyeSeeTea/d2-ui-components)? If so, what branch/PR?

-   Any change in the [D2 Api](https://github.com/EyeSeeTea/d2-api)? If so, what branch/PR?
