### PR TITLE
[fix]: Remove escape characters in instance mapping title

### DIFF
--- a/src/presentation/webapp/core/pages/instance-mapping/InstanceMappingLandingPage.tsx
+++ b/src/presentation/webapp/core/pages/instance-mapping/InstanceMappingLandingPage.tsx
@@ -62,7 +62,12 @@ const InstanceMappingLandingPage: React.FC = () => {
     };
 
     const mainTitle = i18n.t("Instance mapping");
-    const instanceTitle = instance ? i18n.t("Between this instance and {{name}}", instance) : null;
+    const instanceTitle = instance
+        ? i18n.t("Between this instance and {{name}}", {
+              name: instance.name,
+              interpolation: { escapeValue: false },
+          })
+        : null;
     const title = _.compact([mainTitle, instanceTitle]).join(" - ");
 
     return (

--- a/src/presentation/webapp/core/pages/instance-mapping/InstanceMappingPage.tsx
+++ b/src/presentation/webapp/core/pages/instance-mapping/InstanceMappingPage.tsx
@@ -124,7 +124,9 @@ export default function InstanceMappingPage() {
         await onChangeMapping(newMapping);
     };
 
-    const instanceTitle = instance ? i18n.t("Between this instance and {{name}}", instance) : null;
+    const instanceTitle = instance
+        ? i18n.t("Between this instance and {{name}}", { name: instance.name, interpolation: { escapeValue: false } })
+        : null;
     const title = _.compact([sectionTitle, instanceTitle]).join(" - ");
 
     return (


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/86996wz4q

### :memo: Implementation
- [x] Use `interpolations.escapeValue` property to remove escape characters

### :video_camera: Screenshots/Screen capture

https://github.com/user-attachments/assets/84991c90-7194-44cb-ae4b-88cf964597a4



### :bookmark_tabs: Others

#86996wz4q