### PR TITLE
Fix: Show also tei sync report if rule has any TEI selected

### DIFF
--- a/src/data/events/EventsD2ApiRepository.ts
+++ b/src/data/events/EventsD2ApiRepository.ts
@@ -10,10 +10,7 @@ import { EventsPackage } from "../../domain/events/entities/EventsPackage";
 import { ProgramEvent } from "../../domain/events/entities/ProgramEvent";
 import { EventsRepository } from "../../domain/events/repositories/EventsRepository";
 import { Instance } from "../../domain/instance/entities/Instance";
-import {
-    getSuccessDefaultSyncReportByType,
-    SynchronizationResult,
-} from "../../domain/reports/entities/SynchronizationResult";
+import { SynchronizationResult } from "../../domain/reports/entities/SynchronizationResult";
 import { cleanObjectDefault, cleanOrgUnitPaths } from "../../domain/synchronization/utils";
 import { D2Api } from "../../types/d2-api";
 import { promiseMap } from "../../utils/common";
@@ -226,11 +223,7 @@ export class EventsD2ApiRepository implements EventsRepository {
 
     public async save(data: EventsPackage, params: DataImportParams = {}): Promise<SynchronizationResult> {
         try {
-            if (data.events.length === 0) {
-                return getSuccessDefaultSyncReportByType("events", this.instance);
-            } else {
-                return this.push(params, data.events);
-            }
+            return this.push(params, data.events);
         } catch (error: any) {
             if (error?.response?.data) {
                 return this.cleanEventsImportResponse(error.response.data);

--- a/src/data/events/EventsD2ApiRepository.ts
+++ b/src/data/events/EventsD2ApiRepository.ts
@@ -10,7 +10,10 @@ import { EventsPackage } from "../../domain/events/entities/EventsPackage";
 import { ProgramEvent } from "../../domain/events/entities/ProgramEvent";
 import { EventsRepository } from "../../domain/events/repositories/EventsRepository";
 import { Instance } from "../../domain/instance/entities/Instance";
-import { SynchronizationResult } from "../../domain/reports/entities/SynchronizationResult";
+import {
+    getSuccessDefaultSyncReportByType,
+    SynchronizationResult,
+} from "../../domain/reports/entities/SynchronizationResult";
 import { cleanObjectDefault, cleanOrgUnitPaths } from "../../domain/synchronization/utils";
 import { D2Api } from "../../types/d2-api";
 import { promiseMap } from "../../utils/common";
@@ -224,19 +227,7 @@ export class EventsD2ApiRepository implements EventsRepository {
     public async save(data: EventsPackage, params: DataImportParams = {}): Promise<SynchronizationResult> {
         try {
             if (data.events.length === 0) {
-                return {
-                    status: "SUCCESS",
-                    stats: {
-                        imported: 0,
-                        updated: 0,
-                        deleted: 0,
-                        ignored: 0,
-                        total: 0,
-                    },
-                    instance: this.instance.toPublicObject(),
-                    date: new Date(),
-                    type: "events",
-                };
+                return getSuccessDefaultSyncReportByType("events", this.instance);
             } else {
                 return this.push(params, data.events);
             }

--- a/src/data/tracked-entity-instances/TEID2ApiRepository.ts
+++ b/src/data/tracked-entity-instances/TEID2ApiRepository.ts
@@ -113,14 +113,7 @@ export class TEID2ApiRepository implements TEIRepository {
 
     async save(data: TEIsPackage, additionalParams: DataImportParams | undefined): Promise<SynchronizationResult> {
         try {
-            const teiPostParams: TrackerPostParams = {
-                idScheme: "UID",
-                dataElementIdScheme: "UID",
-                orgUnitIdScheme: "UID",
-                importMode: "COMMIT",
-                importStrategy: "CREATE_AND_UPDATE",
-                ...additionalParams,
-            };
+            const teiPostParams = this.getTeiPostParams(additionalParams);
 
             const trackerPostRequest: TrackerPostRequest = {
                 trackedEntities: data.trackedEntityInstances.map(tei => this.buildD2TrackerTrackedEntity(tei)),
@@ -140,6 +133,45 @@ export class TEID2ApiRepository implements TEIRepository {
                 date: new Date(),
                 type: "events",
             };
+        }
+    }
+
+    private getTeiPostParams(params: DataImportParams | undefined): TrackerPostParams {
+        const defaultTeiPostParams: TrackerPostParams = {
+            idScheme: "UID",
+            dataElementIdScheme: "UID",
+            orgUnitIdScheme: "UID",
+            importMode: "COMMIT",
+            importStrategy: "CREATE_AND_UPDATE",
+        };
+
+        if (!params) return defaultTeiPostParams;
+
+        const teiPostParams: TrackerPostParams = {
+            idScheme: params?.idScheme ?? defaultTeiPostParams.idScheme,
+            dataElementIdScheme: params?.dataElementIdScheme ?? defaultTeiPostParams.dataElementIdScheme,
+            orgUnitIdScheme: params?.orgUnitIdScheme ?? defaultTeiPostParams.orgUnitIdScheme,
+            importMode: params?.importMode ?? defaultTeiPostParams.importMode,
+            importStrategy: this.convertImportStrategy(params?.strategy) ?? defaultTeiPostParams.importStrategy,
+        };
+
+        return params?.async !== undefined ? { ...teiPostParams, async: params.async } : teiPostParams;
+    }
+
+    private convertImportStrategy(
+        strategy: DataImportParams["strategy"]
+    ): TrackerPostParams["importStrategy"] | undefined {
+        switch (strategy) {
+            case "NEW_AND_UPDATES":
+                return "CREATE_AND_UPDATE";
+            case "NEW":
+                return "CREATE";
+            case "UPDATES":
+                return "UPDATE";
+            case "DELETES":
+                return "DELETE";
+            default:
+                return undefined;
         }
     }
 

--- a/src/domain/events/usecases/EventsSyncUseCase.ts
+++ b/src/domain/events/usecases/EventsSyncUseCase.ts
@@ -118,7 +118,16 @@ export class EventsSyncUseCase extends GenericSyncUseCase {
                 ? getSuccessDefaultSyncReportByType("trackedEntityInstances", instance)
                 : undefined;
 
-        const eventsResponse = await this.postEventsPayload(instance, events, trackedEntityInstances);
+        const wasAnyEventSelectedToSync =
+            !!dataParams.allEvents || (!dataParams.allEvents && dataParams.events && dataParams.events.length > 0);
+
+        const eventsResponse =
+            events?.length > 0 || trackedEntityInstances?.length > 0
+                ? await this.postEventsPayload(instance, events, trackedEntityInstances)
+                : wasAnyEventSelectedToSync
+                ? getSuccessDefaultSyncReportByType("events", instance)
+                : undefined;
+
         const indicatorsResponse = await this.postIndicatorPayload(instance, dataValues);
 
         return _.compact([eventsResponse, indicatorsResponse, teisResponse]);

--- a/src/domain/reports/entities/SynchronizationResult.ts
+++ b/src/domain/reports/entities/SynchronizationResult.ts
@@ -1,4 +1,5 @@
 import { NamedRef } from "../../common/entities/Ref";
+import { Instance } from "../../instance/entities/Instance";
 import { Store } from "../../stores/entities/Store";
 import { SynchronizationPayload } from "../../synchronization/entities/SynchronizationPayload";
 import { SynchronizationResultType } from "../../synchronization/entities/SynchronizationType";
@@ -34,4 +35,23 @@ export interface SynchronizationResult {
     errors?: ErrorMessage[];
     payload?: SynchronizationPayload;
     response?: object;
+}
+
+export function getSuccessDefaultSyncReportByType(
+    type: SynchronizationResultType,
+    instance: Instance
+): SynchronizationResult {
+    return {
+        status: "SUCCESS",
+        stats: {
+            imported: 0,
+            updated: 0,
+            deleted: 0,
+            ignored: 0,
+            total: 0,
+        },
+        instance: instance.toPublicObject(),
+        date: new Date(),
+        type: type,
+    };
 }


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes #8699bn9tq [Metadata Sync - Debug & Resolve Issues for Setup](https://app.clickup.com/t/8699bn9tq)

### :memo: Implementation
- Show also tei sync report if rule has any TEI selected
- Fix error with `orgUnitPath`: Send only allowed params when POST TEIs

### :video_camera: Screenshots/Screen capture

- Show also tei sync report if rule has any TEI selected

BEFORE:
![Screenshot from 2025-06-09 15-38-36](https://github.com/user-attachments/assets/71ab9279-8628-4bd6-af37-63837ae7669f)

AFTER:
![Screenshot from 2025-06-09 15-38-23](https://github.com/user-attachments/assets/54ba82fe-5826-4c6c-91c9-2e585430ac3b)


- Fix error with `orgUnitPath`: Send only allowed params when POST TEIs

BEFORE:
![Screenshot from 2025-06-12 11-52-22](https://github.com/user-attachments/assets/3c226982-bc1b-43be-b763-baffa600b1ea)

AFTER:
![Screenshot from 2025-06-12 11-50-40](https://github.com/user-attachments/assets/c8bedd4e-4adf-4bea-bb9c-ee2c034cd34a)


### :fire: Is there anything the reviewer should know to test it?

### :bookmark_tabs: Others

-   Any change in the [GUI library](https://github.com/EyeSeeTea/d2-ui-components)? If so, what branch/PR?

-   Any change in the [D2 Api](https://github.com/EyeSeeTea/d2-api)? If so, what branch/PR?
