### PR TITLE
 Fix 'include objects and references' option in MD sync

### DIFF
--- a/src/domain/common/entities/Ref.ts
+++ b/src/domain/common/entities/Ref.ts
@@ -1,7 +1,9 @@
 import { SharingSetting } from "./SharingSetting";
 
+export type Id = string;
+
 export interface Ref {
-    id: string;
+    id: Id;
 }
 
 export interface NamedRef extends Ref {


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes #8699bv30p [metadata-synchronization: Fix 'include objects and references' option](https://app.clickup.com/t/8699bv30p)

- related to: https://github.com/EyeSeeTea/metadata-synchronization/pull/999

### :memo: Implementation
- Save ids already requested to not request them again in next iterations

### :video_camera: Screenshots/Screen capture

BEFORE:

[before.webm](https://github.com/user-attachments/assets/16ccbb73-56b9-413a-a415-217b902411a0)

AFTER:

[after.webm](https://github.com/user-attachments/assets/4e2943dd-9c49-44b2-9067-56f6176b0c42)


### :fire: Is there anything the reviewer should know to test it?

### :bookmark_tabs: Others

-   Any change in the [GUI library](https://github.com/EyeSeeTea/d2-ui-components)? If so, what branch/PR?

-   Any change in the [D2 Api](https://github.com/EyeSeeTea/d2-api)? If so, what branch/PR?
