### PR TITLE
Fix typo in analytics completion message

### DIFF
--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -27,7 +27,7 @@ export async function* executeAnalytics(instance: Instance, options?: AnalyticsO
         await timeout(1500);
     }
 
-    return i18n.t("Updating analytics done`for instance {{name}}", instance);
+    return i18n.t("Updating analytics done for instance {{name}}", instance);
 }
 
 type AnalyticsMessage = { message: string; completed: boolean };


### PR DESCRIPTION
## Summary
- fix stray backtick typo in analytics completion message

## Testing
- `yarn test --runInBand`

------
https://chatgpt.com/codex/tasks/task_b_685a9885c024832ebfa7f43044022e3a