### PR TITLE
Fix time-sensitive test

### DIFF
--- a/src/scheduler/SchedulerCLI/__tests__/SchedulerCLI.spec.ts
+++ b/src/scheduler/SchedulerCLI/__tests__/SchedulerCLI.spec.ts
@@ -23,7 +23,7 @@ describe("SchedulerCLI", () => {
     let mockLogger: Logger;
 
     beforeEach(() => {
-        jest.useFakeTimers();
+        jest.useFakeTimers("modern");
         jest.setSystemTime(new Date("2025-06-12T08:12:50.777Z"));
 
         jest.clearAllMocks();


### PR DESCRIPTION
## Summary
- stabilize SchedulerCLI test by enabling modern timers

## Testing
- `yarn test src/scheduler/SchedulerCLI/__tests__/SchedulerCLI.spec.ts --runInBand`
- `yarn test` *(fails: This package doesn't seem to be present in your lockfile)*

------
https://chatgpt.com/codex/tasks/task_b_685ec3517be88329846ec4bd4e79629c