### PR TITLE
feat: add support for skipRuleEngine option for events/TEIs

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2025-10-21T03:21:20.753Z\n"
-"PO-Revision-Date: 2025-10-21T03:21:20.753Z\n"
+"POT-Creation-Date: 2025-11-11T12:44:20.444Z\n"
+"PO-Revision-Date: 2025-11-11T12:44:20.444Z\n"
 
 msgid ""
 "THIS NEW RELEASE INCLUDES SHARING SETTINGS PER INSTANCES. FOR THIS VERSION "
@@ -1081,6 +1081,9 @@ msgid "Ignore data with same value on destination"
 msgstr ""
 
 msgid "Async mode"
+msgstr ""
+
+msgid "Skip Rule Engine on destination"
 msgstr ""
 
 msgid "Sync rule {{idx}}: {{name}} ({{id}})"

--- a/i18n/es.po
+++ b/i18n/es.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: i18next-conv\n"
-"POT-Creation-Date: 2025-10-21T03:21:20.753Z\n"
+"POT-Creation-Date: 2025-11-11T12:44:20.444Z\n"
 "PO-Revision-Date: 2020-07-10T06:53:30.625Z\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1084,6 +1084,9 @@ msgid "Ignore data with same value on destination"
 msgstr ""
 
 msgid "Async mode"
+msgstr ""
+
+msgid "Skip Rule Engine on destination"
 msgstr ""
 
 msgid "Sync rule {{idx}}: {{name}} ({{id}})"

--- a/i18n/fr.po
+++ b/i18n/fr.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: i18next-conv\n"
-"POT-Creation-Date: 2025-10-21T03:21:20.753Z\n"
+"POT-Creation-Date: 2025-11-11T12:44:20.444Z\n"
 "PO-Revision-Date: 2020-07-10T06:53:30.625Z\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1084,6 +1084,9 @@ msgid "Ignore data with same value on destination"
 msgstr ""
 
 msgid "Async mode"
+msgstr ""
+
+msgid "Skip Rule Engine on destination"
 msgstr ""
 
 msgid "Sync rule {{idx}}: {{name}} ({{id}})"

--- a/i18n/pt.po
+++ b/i18n/pt.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: i18next-conv\n"
-"POT-Creation-Date: 2025-10-21T03:21:20.753Z\n"
+"POT-Creation-Date: 2025-11-11T12:44:20.444Z\n"
 "PO-Revision-Date: 2020-07-10T06:53:30.625Z\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1084,6 +1084,9 @@ msgid "Ignore data with same value on destination"
 msgstr ""
 
 msgid "Async mode"
+msgstr ""
+
+msgid "Skip Rule Engine on destination"
 msgstr ""
 
 msgid "Sync rule {{idx}}: {{name}} ({{id}})"

--- a/src/data/events/EventsD2ApiRepository.ts
+++ b/src/data/events/EventsD2ApiRepository.ts
@@ -302,6 +302,7 @@ export class EventsD2ApiRepository implements EventsRepository {
             dataElementIdScheme: params.dataElementIdScheme ?? "UID",
             orgUnitIdScheme: params.orgUnitIdScheme ?? "UID",
             importMode: params.importMode ?? "COMMIT",
+            skipRuleEngine: params.skipRuleEngine,
         };
 
         const trackerPostRequest: TrackerPostRequest = {

--- a/src/data/tracked-entity-instances/TEID2ApiRepository.ts
+++ b/src/data/tracked-entity-instances/TEID2ApiRepository.ts
@@ -174,6 +174,7 @@ export class TEID2ApiRepository implements TEIRepository {
             orgUnitIdScheme: params?.orgUnitIdScheme ?? defaultTeiPostParams.orgUnitIdScheme,
             importMode: params?.importMode ?? defaultTeiPostParams.importMode,
             importStrategy: this.convertImportStrategy(params?.strategy) ?? defaultTeiPostParams.importStrategy,
+            skipRuleEngine: params?.skipRuleEngine,
         };
 
         return params?.async !== undefined ? { ...teiPostParams, async: params.async } : teiPostParams;

--- a/src/domain/aggregated/entities/DataSynchronizationParams.ts
+++ b/src/domain/aggregated/entities/DataSynchronizationParams.ts
@@ -17,6 +17,7 @@ export interface DataImportParams {
     skipAudit?: boolean;
     strategy?: "NEW_AND_UPDATES" | "NEW" | "UPDATES" | "DELETES";
     async?: boolean;
+    skipRuleEngine?: boolean;
 }
 
 export interface DataSynchronizationParams extends DataImportParams {

--- a/src/presentation/react/core/components/sync-params-selector/SyncParamsSelector.tsx
+++ b/src/presentation/react/core/components/sync-params-selector/SyncParamsSelector.tsx
@@ -112,6 +112,15 @@ const SyncParamsSelector: React.FC<SyncParamsSelectorProps> = ({ syncRule, onCha
         );
     };
 
+    const changeSkipRuleEngine = (skipRuleEngine: boolean) => {
+        onChange(
+            syncRule.updateDataParams({
+                ...dataParams,
+                skipRuleEngine,
+            })
+        );
+    };
+
     return (
         <React.Fragment>
             <Typography className={classes.advancedOptionsTitle} variant={"subtitle1"} gutterBottom>
@@ -201,6 +210,16 @@ const SyncParamsSelector: React.FC<SyncParamsSelectorProps> = ({ syncRule, onCha
                         label={i18n.t("Async mode")}
                         onValueChange={changeAsyncMode}
                         value={dataParams.async ?? true}
+                    />
+                </div>
+            )}
+
+            {syncRule.type === "events" && (
+                <div>
+                    <Toggle
+                        label={i18n.t("Skip Rule Engine on destination")}
+                        onValueChange={changeSkipRuleEngine}
+                        value={dataParams.skipRuleEngine ?? false}
                     />
                 </div>
             )}

--- a/src/presentation/react/core/components/sync-wizard/common/SummaryStep.tsx
+++ b/src/presentation/react/core/components/sync-wizard/common/SummaryStep.tsx
@@ -546,6 +546,14 @@ export const SummaryStepContent = (props: SummaryStepContentProps) => {
                             })}
                         />
                     </ul>
+                    {syncRule.type === "events" && (
+                        <ul>
+                            <LiEntry
+                                label={i18n.t("Skip Rule Engine on destination")}
+                                value={syncRule.dataParams.skipRuleEngine ? i18n.t("Yes") : i18n.t("No")}
+                            />
+                        </ul>
+                    )}
                 </LiEntry>
             )}
 


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/869b4jwb9 #869b4jwb9

### :memo: Implementation

- Add a `skipRuleEngine` flag to `DataSynchronizationParams`
- When posting tracker events and TEIs, it adds the `skipRuleEngine` parameter if set in the DataImportParams
- Add the "Skip Rule Engine on destination" toggle in `SyncParamsSelector` (only for events) 
- Add the value to the `SummaryStep` (only for events)

### :video_camera: Screenshots/Screen capture

Instance selection / Advanced options (step 8)
<img width="1512" height="480" alt="imagen" src="https://github.com/user-attachments/assets/8637a4ca-f417-4744-a2a1-5cd281115f31" />

Summary (step 10)
<img width="483" height="294" alt="imagen" src="https://github.com/user-attachments/assets/fd910d08-c1f3-4c8c-80e9-c40b21f5ec11" />

### :fire: Is there anything the reviewer should know to test it?

### :bookmark_tabs: Others

-   Any change in the [GUI library](https://github.com/EyeSeeTea/d2-ui-components)? If so, what branch/PR?

-   Any change in the [D2 Api](https://github.com/EyeSeeTea/d2-api)? If so, what branch/PR?
