### PR TITLE
Include TEIs referenced by events when using allTEIs option

### DIFF
--- a/src/domain/events/builders/EventsPayloadBuilder.ts
+++ b/src/domain/events/builders/EventsPayloadBuilder.ts
@@ -55,12 +55,12 @@ export class EventsPayloadBuilder {
             .filter(({ programType }) => programType === "WITH_REGISTRATION")
             .map(({ id }) => id);
 
-        const trackedEntityInstances =
-            dataParams.allTEIs && trackerProgramIds.length > 0
-                ? await teisRepository.getAllTEIs(dataParams, trackerProgramIds)
-                : dataParams.teis
-                ? await teisRepository.getTEIsById(dataParams, dataParams.teis)
-                : [];
+        const trackedEntityInstances = await this.buildTrackedEntityInstances(
+            teisRepository,
+            dataParams,
+            trackerProgramIds,
+            events
+        );
 
         const directIndicators = programIndicators.map(({ id }) => id);
         const indicatorsByProgram = _.flatten(
@@ -94,6 +94,39 @@ export class EventsPayloadBuilder {
         const dataValues = _.reject(candidateDataValues, ({ dataElement }) => excludedIds.includes(dataElement));
 
         return { events, dataValues, trackedEntityInstances };
+    }
+
+    private async buildTrackedEntityInstances(
+        teisRepository: Awaited<ReturnType<typeof this.getTeisRepository>>,
+        dataParams: SynchronizationBuilder["dataParams"],
+        trackerProgramIds: string[],
+        events: ProgramEvent[]
+    ): Promise<TrackedEntityInstance[]> {
+        const trackedEntityInstances =
+            dataParams?.allTEIs && trackerProgramIds.length > 0
+                ? await teisRepository.getAllTEIs(dataParams, trackerProgramIds)
+                : dataParams?.teis
+                ? await teisRepository.getTEIsById(dataParams, dataParams.teis)
+                : [];
+
+        if (!dataParams?.allTEIs) {
+            return trackedEntityInstances;
+        }
+        // if allTEIs is true, get TEIs referenced by events but not included because of filters
+        // i.e. TEIs not included in the filtered period, but referenced by events from that period
+        const trackedEntityInstancesMissingIds = _(events)
+            .flatMap(event => event.trackedEntity)
+            .filter(teiId => Boolean(teiId) && !trackedEntityInstances.some(tei => tei.trackedEntity === teiId))
+            .uniq()
+            .value() as string[];
+        if (trackedEntityInstancesMissingIds.length === 0) {
+            return trackedEntityInstances;
+        }
+        const trackedEntityInstancesMissing = await teisRepository.getTEIsById(
+            dataParams,
+            trackedEntityInstancesMissingIds
+        );
+        return [...trackedEntityInstances, ...trackedEntityInstancesMissing];
     }
 
     @cache()

--- a/src/domain/events/builders/EventsPayloadBuilder.ts
+++ b/src/domain/events/builders/EventsPayloadBuilder.ts
@@ -12,6 +12,7 @@ import { DataValue } from "../../aggregated/entities/DataValue";
 import { TrackedEntityInstance } from "../../tracked-entity-instances/entities/TrackedEntityInstance";
 import { eventsFields } from "../usecases/EventsSyncUseCase";
 import { Ref } from "../../common/entities/Ref";
+import { TEIRepository } from "../../tracked-entity-instances/repositories/TEIRepository";
 
 export type EventsPayload = {
     events: ProgramEvent[];
@@ -97,7 +98,7 @@ export class EventsPayloadBuilder {
     }
 
     private async buildTrackedEntityInstances(
-        teisRepository: Awaited<ReturnType<typeof this.getTeisRepository>>,
+        teisRepository: TEIRepository,
         dataParams: SynchronizationBuilder["dataParams"],
         trackerProgramIds: string[],
         events: ProgramEvent[]

--- a/src/domain/events/entities/ProgramEvent.ts
+++ b/src/domain/events/entities/ProgramEvent.ts
@@ -16,6 +16,7 @@ export interface ProgramEvent {
     attributeOptionCombo?: string;
     dataValues: ProgramEventDataValue[];
     event?: string;
+    trackedEntity?: string;
 }
 
 export type EventStatus = "ACTIVE" | "COMPLETED" | "VISITED" | "SCHEDULE" | "OVERDUE" | "SKIPPED";


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/869b5ggyy #869b5ggyy

### :memo: Implementation

In Sync Event rules, when `allTEIs` is selected, but the period filter leaves out some TEI referenced by any event from that period, the sync was failing because of the missing TEI dependency.

- Added optional attr `trackedEntity` to the `ProgramEvent` type (it was already being mapped)
- Include in the Events Sync Payload all the TEIs referenced by the events if the "Sync all TEIs" option is used 
