### PR TITLE
Incomplete cron expresion validation in scheduler

### DIFF
--- a/src/utils/validCronExpression.js
+++ b/src/utils/validCronExpression.js
@@ -2,22 +2,40 @@ const WEEKDAYS = ["MON", "TUE", "WED", "THU", "FRI", "SAT", "SUN"];
 const MONTHS = ["JAN", "FEB", "MAR", "APR", "MAY", "JUN", "JUL", "AUG", "SEP", "OCT", "NOV", "DEC"];
 
 const isValidFields = fields => fields && fields.length === 6;
-const isValidNumber = (number, x, y) => number >= x && number <= y;
+const isInteger = value => typeof value === "string" && /^\d+$/.test(value);
+const isValidNumber = (value, min, max) => {
+    if (!isInteger(value)) return false;
+    const number = Number(value);
+    return number >= min && number <= max;
+};
 const isWildcard = field => field === "*";
 const isUndefined = field => field === "?";
+const hasExactSingleSpaces = exp => /^[^\s]+( [^\s]+){5}$/.test(exp);
 
-const isValidNumberRange = (range, x, y) => {
+const isValidNumberRange = (range, min, max) => {
     const boundaries = range.split("-");
-    if (!boundaries || boundaries.length !== 2) return false;
+    if (boundaries.length !== 2) return false;
 
-    return isValidNumber(boundaries[0], x, y) && isValidNumber(boundaries[1], x, y) && boundaries[0] <= boundaries[1];
+    const [start, end] = boundaries;
+
+    if (!isValidNumber(start, min, max) || !isValidNumber(end, min, max)) return false;
+
+    return Number(start) <= Number(end);
 };
 
-const isValidFraction = (fraction, x, y) => {
+const isValidFraction = (fraction, min, max) => {
     const components = fraction.split("/");
-    if (!components || components.length !== 2) return false;
+    if (components.length !== 2) return false;
 
-    return (isWildcard(components[0]) || isValidNumber(components[0], x, y)) && isValidNumber(components[1], x, y);
+    const [base, step] = components;
+
+    const baseOk = isWildcard(base) || isValidNumber(base, min, max) || isValidNumberRange(base, min, max);
+
+    if (!baseOk) return false;
+
+    if (!isInteger(step)) return false;
+    const stepNum = Number(step);
+    return stepNum >= 1 && stepNum <= max;
 };
 
 const isAlphabeticWeekday = field => {
@@ -37,16 +55,19 @@ const isAlphabeticMonth = field => {
     );
 };
 
-const isValidWithinRange = (field, x, y) =>
-    isWildcard(field) || isValidNumber(field, x, y) || isValidNumberRange(field, x, y) || isValidFraction(field, x, y);
+const isValidWithinRange = (field, min, max) =>
+    isWildcard(field) ||
+    isValidNumber(field, min, max) ||
+    isValidNumberRange(field, min, max) ||
+    isValidFraction(field, min, max);
 
 const isValidSecondField = field => isValidWithinRange(field, 0, 59);
 const isValidMinuteField = field => isValidWithinRange(field, 0, 59);
 const isValidHourField = field => isValidWithinRange(field, 0, 23);
-const isValidDayField = field => isValidWithinRange(field, 0, 31) || isUndefined(field);
+const isValidDayField = field => isUndefined(field) || isValidWithinRange(field, 1, 31);
 const isValidMonthField = field => isValidWithinRange(field, 1, 12) || isAlphabeticMonth(field);
 const isValidWeekdayField = field =>
-    isValidWithinRange(field, 1, 7) || isAlphabeticWeekday(field) || isUndefined(field);
+    isUndefined(field) || isValidWithinRange(field, 1, 7) || isAlphabeticWeekday(field);
 
 // isValidation of CronExpression, following the Spring Scheduling pattern:
 // - Documentation: https://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/scheduling/support/CronSequenceGenerator.html
@@ -56,7 +77,9 @@ const isValidCronExpression = exp => {
         return false;
     }
 
-    const fields = exp.trim().split(" ");
+    if (!hasExactSingleSpaces(exp)) return false;
+
+    const fields = exp.split(" ");
     if (!isValidFields(fields)) {
         return false;
     }


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes #869bvjk4e [Incomplete cron expresion validation in scheduler](https://app.clickup.com/t/869bvjk4e)

### :memo: Implementation

- Fix validation for cron expression in scheduler

### :video_camera: Screenshots/Screen capture

### :fire: Is there anything the reviewer should know to test it?
Test different invalid cron expressions:
- 0 0 /2 * * *
-                       0 0 */2 * * *
-       0 0 1/2 * * *          

### :bookmark_tabs: Others

-   Any change in the [GUI library](https://github.com/EyeSeeTea/d2-ui-components)? If so, what branch/PR?

-   Any change in the [D2 Api](https://github.com/EyeSeeTea/d2-api)? If so, what branch/PR?
