### PR TITLE
[fix]: Prevent file resource upload on dry run

### DIFF
--- a/src/domain/aggregated/usecases/AggregatedSyncUseCase.ts
+++ b/src/domain/aggregated/usecases/AggregatedSyncUseCase.ts
@@ -39,7 +39,9 @@ export class AggregatedSyncUseCase extends GenericSyncUseCase {
 
         const previousOriginalPayload = await this.buildPayload();
 
-        const originalPayload = await this.manageDataElementWithFileType(previousOriginalPayload, instance);
+        const originalPayload = dataParams.dryRun
+            ? previousOriginalPayload
+            : await this.manageDataElementWithFileType(previousOriginalPayload, instance);
 
         const mappedPayload = await this.mapPayload(instance, originalPayload);
 

--- a/src/domain/entities/wmr/usecases/WmrAggregatedSyncUseCase.ts
+++ b/src/domain/entities/wmr/usecases/WmrAggregatedSyncUseCase.ts
@@ -105,7 +105,9 @@ export class WmrAggregatedSyncUseCase extends GenericSyncUseCase {
 
         const previousOriginalPayload = await this.buildPayload();
 
-        const originalPayload = await this.manageDataElementWithFileType(previousOriginalPayload, instance);
+        const originalPayload = dataParams.dryRun
+            ? previousOriginalPayload
+            : await this.manageDataElementWithFileType(previousOriginalPayload, instance);
 
         const mappedPayload = await this.mapPayload(instance, originalPayload);
 

--- a/src/domain/events/usecases/EventsSyncUseCase.ts
+++ b/src/domain/events/usecases/EventsSyncUseCase.ts
@@ -92,7 +92,8 @@ export class EventsSyncUseCase extends GenericSyncUseCase {
 
         const payloadByTEIs = (await mapper.map({ trackedEntities: teis })) as EventsPackage;
 
-        const finalEvents = await this.manageDataElementWithFileType(events, instance);
+        const finalEvents =
+            dataParams.importMode === "VALIDATE" ? events : await this.manageDataElementWithFileType(events, instance);
 
         const payloadByEvents = (await this.mapPayload(instance, { events: finalEvents })) as EventsPackage;
 

--- a/src/presentation/react/core/components/sync-wizard/common/SummaryStep.tsx
+++ b/src/presentation/react/core/components/sync-wizard/common/SummaryStep.tsx
@@ -523,7 +523,7 @@ export const SummaryStepContent = (props: SummaryStepContentProps) => {
                     <ul>
                         <LiEntry
                             label={i18n.t("Dry run")}
-                            value={syncRule.dataParams.dryRun ? i18n.t("Yes") : i18n.t("No")}
+                            value={isDryRunEnabled(syncRule) ? i18n.t("Yes") : i18n.t("No")}
                         />
                     </ul>
                     <ul>
@@ -589,3 +589,14 @@ export const DataStoreSectionContent = (props: { metadataIds: string[] }) => {
         </>
     );
 };
+
+function isDryRunEnabled(syncRule: SynchronizationRule) {
+    switch (syncRule.type) {
+        case "aggregated":
+            return syncRule.dataParams.dryRun;
+        case "events":
+            return syncRule.dataParams.importMode === "VALIDATE";
+        default:
+            return syncRule.dataParams.dryRun || false;
+    }
+}


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/869c32tua

### :memo: Implementation
This PR updates the sync logic to prevent uploading `FileResource` data elements when a dry run is requested. When 
- `dryRun` is true in `dataParams` for aggregated data synchronization or
- `importMode` is "VALIDATE" for event synchronization
the code now skips the `manageDataElementWithFileType` step that fetches and uploads file resources and uses the original payload directly. 

### :video_camera: Screenshots/Screen capture


### :bookmark_tabs: Others

#869c32tua