### PR TITLE
fix: replicate rule inclusions

### DIFF
--- a/src/presentation/webapp/core/pages/sync-rules-creation/SyncRulesCreationPage.tsx
+++ b/src/presentation/webapp/core/pages/sync-rules-creation/SyncRulesCreationPage.tsx
@@ -8,12 +8,17 @@ import PageHeader from "../../../../react/core/components/page-header/PageHeader
 import SyncWizard from "../../../../react/core/components/sync-wizard/SyncWizard";
 import { TestWrapper } from "../../../../react/core/components/test-wrapper/TestWrapper";
 import { useAppContext } from "../../../../react/core/contexts/AppContext";
+import { UserSettingsInclusionsConfig } from "../../../../../domain/user-settings/UserSettings";
 import { useUserSettings } from "../settings/useUserSettings";
 
 export interface SyncRulesCreationParams {
     id: string;
     action: "edit" | "new";
     type: SynchronizationType;
+}
+
+function createNewSyncRule(type: SynchronizationType, defaultInclusions: UserSettingsInclusionsConfig) {
+    return SynchronizationRule.create(type).setDefaultInclusions(defaultInclusions);
 }
 
 const SyncRulesCreation: React.FC = () => {
@@ -23,9 +28,12 @@ const SyncRulesCreation: React.FC = () => {
     const { id, action, type } = useParams() as SyncRulesCreationParams;
     const { compositionRoot } = useAppContext();
     const { userSettings } = useUserSettings();
+    const replicatedSyncRule = location.state?.syncRule;
 
     const [dialogOpen, updateDialogOpen] = useState(false);
-    const [syncRule, updateSyncRule] = useState(location.state?.syncRule ?? SynchronizationRule.create(type));
+    const [syncRule, updateSyncRule] = useState(
+        replicatedSyncRule ?? createNewSyncRule(type, userSettings.inclusionConfig)
+    );
     const [originalSyncRule, setOriginalSyncRule] = useState<SynchronizationRule | undefined>(undefined);
 
     const isEdit = action === "edit" && !!id;
@@ -54,11 +62,15 @@ const SyncRulesCreation: React.FC = () => {
                 setOriginalSyncRule(syncRule ?? SynchronizationRule.create(type));
                 loading.reset();
             });
+        } else if (replicatedSyncRule) {
+            updateSyncRule(replicatedSyncRule);
+            setOriginalSyncRule(replicatedSyncRule);
         } else {
-            updateSyncRule(syncRule => syncRule?.setDefaultInclusions(userSettings.inclusionConfig));
-            setOriginalSyncRule(syncRule => syncRule?.setDefaultInclusions(userSettings.inclusionConfig));
+            const initialSyncRule = createNewSyncRule(type, userSettings.inclusionConfig);
+            updateSyncRule(initialSyncRule);
+            setOriginalSyncRule(initialSyncRule);
         }
-    }, [compositionRoot, loading, isEdit, id, type, userSettings.inclusionConfig]);
+    }, [compositionRoot, loading, isEdit, id, type, userSettings.inclusionConfig, replicatedSyncRule]);
 
     return (
         <TestWrapper>

--- a/src/presentation/webapp/core/pages/sync-rules-creation/SyncRulesCreationPage.tsx
+++ b/src/presentation/webapp/core/pages/sync-rules-creation/SyncRulesCreationPage.tsx
@@ -17,7 +17,7 @@ export interface SyncRulesCreationParams {
     type: SynchronizationType;
 }
 
-function createNewSyncRule(type: SynchronizationType, defaultInclusions: UserSettingsInclusionsConfig) {
+function createSyncRuleWithInclusions(type: SynchronizationType, defaultInclusions: UserSettingsInclusionsConfig) {
     return SynchronizationRule.create(type).setDefaultInclusions(defaultInclusions);
 }
 
@@ -32,7 +32,7 @@ const SyncRulesCreation: React.FC = () => {
 
     const [dialogOpen, updateDialogOpen] = useState(false);
     const [syncRule, updateSyncRule] = useState(
-        replicatedSyncRule ?? createNewSyncRule(type, userSettings.inclusionConfig)
+        replicatedSyncRule ?? createSyncRuleWithInclusions(type, userSettings.inclusionConfig)
     );
     const [originalSyncRule, setOriginalSyncRule] = useState<SynchronizationRule | undefined>(undefined);
 
@@ -62,11 +62,9 @@ const SyncRulesCreation: React.FC = () => {
                 setOriginalSyncRule(syncRule ?? SynchronizationRule.create(type));
                 loading.reset();
             });
-        } else if (replicatedSyncRule) {
-            updateSyncRule(replicatedSyncRule);
-            setOriginalSyncRule(replicatedSyncRule);
         } else {
-            const initialSyncRule = createNewSyncRule(type, userSettings.inclusionConfig);
+            const initialSyncRule =
+                replicatedSyncRule ?? createSyncRuleWithInclusions(type, userSettings.inclusionConfig);
             updateSyncRule(initialSyncRule);
             setOriginalSyncRule(initialSyncRule);
         }


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/869d1ndau #869d1ndau

### :memo: Implementation

When replicating a rule, the wizard's initialization effect was calling `setDefaultInclusions` on the cloned rule, overwriting the source's sharing/users/orgUnits include-objects-and-references flags with the user's default inclusion config.

### :video_camera: Screenshots/Screen capture

### :fire: Is there anything the reviewer should know to test it?

- Create any rule with the three inclusion options at `Only references` (sharing, users, organization units)
- Replicate the rule
- Before the fix: inclusion options were not correctly replicated (they were overwritten with defaults)
- After the fix: inclsion options match the source rule