### PR TITLE
Release/v2.24.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "metadata-synchronization",
     "description": "Advanced metadata & data synchronization utility",
-    "version": "2.24.1",
+    "version": "2.24.2",
     "license": "GPL-3.0",
     "author": "EyeSeeTea team",
     "homepage": ".",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "metadata-synchronization",
     "description": "Advanced metadata & data synchronization utility",
-    "version": "2.24.0",
+    "version": "2.24.1",
     "license": "GPL-3.0",
     "author": "EyeSeeTea team",
     "homepage": ".",

--- a/src/presentation/react/core/components/metadata-table/MetadataTable.tsx
+++ b/src/presentation/react/core/components/metadata-table/MetadataTable.tsx
@@ -618,14 +618,9 @@ const MetadataTable: React.FC<MetadataTableProps> = ({
         const { sorting, pagination, selection } = tableState;
 
         const included = _.reject(selection, { indeterminate: true }).map(({ id }) => id);
-        const currentMetadataTypeIds = rows
-            .filter(row => row.model.getMetadataType() === model.getMetadataType())
-            .map(row => row.id);
-        const prevMetadataTypeIds = selectedIds.filter(id => currentMetadataTypeIds.includes(id));
-        const mergedSelection = _.uniq([
-            ...selectedIds.filter(id => !currentMetadataTypeIds.includes(id)),
-            ...included,
-        ]);
+
+        const [prevMetadataTypeIds, otherMetadataTypeIds] = _.partition(selectedIds, id => ids.includes(id));
+        const mergedSelection = _.uniq([...otherMetadataTypeIds, ...included]);
 
         const newlySelectedIds = _.difference(included, prevMetadataTypeIds);
         const newlyUnselectedIds = _.difference(prevMetadataTypeIds, included);

--- a/src/presentation/react/core/components/metadata-table/MetadataTable.tsx
+++ b/src/presentation/react/core/components/metadata-table/MetadataTable.tsx
@@ -618,8 +618,17 @@ const MetadataTable: React.FC<MetadataTableProps> = ({
         const { sorting, pagination, selection } = tableState;
 
         const included = _.reject(selection, { indeterminate: true }).map(({ id }) => id);
-        const newlySelectedIds = _.difference(included, selectedIds);
-        const newlyUnselectedIds = _.difference(selectedIds, included);
+        const currentMetadataTypeIds = rows
+            .filter(row => row.model.getMetadataType() === model.getMetadataType())
+            .map(row => row.id);
+        const prevMetadataTypeIds = selectedIds.filter(id => currentMetadataTypeIds.includes(id));
+        const mergedSelection = _.uniq([
+            ...selectedIds.filter(id => !currentMetadataTypeIds.includes(id)),
+            ...included,
+        ]);
+
+        const newlySelectedIds = _.difference(included, prevMetadataTypeIds);
+        const newlyUnselectedIds = _.difference(prevMetadataTypeIds, included);
 
         const parseChildren = (ids: string[]) =>
             _(rows)
@@ -637,11 +646,11 @@ const MetadataTable: React.FC<MetadataTableProps> = ({
             .filter(id => !_.find(rows, { id }))
             .value();
 
-        if (!_.isEqual(stateSelection, included)) {
-            notifyNewSelection(included, excluded);
+        if (!_.isEqual(stateSelection, mergedSelection)) {
+            notifyNewSelection(mergedSelection, excluded);
         }
 
-        setStateSelection(included);
+        setStateSelection(mergedSelection);
         updateFilters({
             order: sorting,
             page: pagination.page,

--- a/src/presentation/webapp/core/pages/sync-rules-creation/SyncRulesCreationPage.tsx
+++ b/src/presentation/webapp/core/pages/sync-rules-creation/SyncRulesCreationPage.tsx
@@ -8,12 +8,17 @@ import PageHeader from "../../../../react/core/components/page-header/PageHeader
 import SyncWizard from "../../../../react/core/components/sync-wizard/SyncWizard";
 import { TestWrapper } from "../../../../react/core/components/test-wrapper/TestWrapper";
 import { useAppContext } from "../../../../react/core/contexts/AppContext";
+import { UserSettingsInclusionsConfig } from "../../../../../domain/user-settings/UserSettings";
 import { useUserSettings } from "../settings/useUserSettings";
 
 export interface SyncRulesCreationParams {
     id: string;
     action: "edit" | "new";
     type: SynchronizationType;
+}
+
+function createNewSyncRule(type: SynchronizationType, defaultInclusions: UserSettingsInclusionsConfig) {
+    return SynchronizationRule.create(type).setDefaultInclusions(defaultInclusions);
 }
 
 const SyncRulesCreation: React.FC = () => {
@@ -23,9 +28,12 @@ const SyncRulesCreation: React.FC = () => {
     const { id, action, type } = useParams() as SyncRulesCreationParams;
     const { compositionRoot } = useAppContext();
     const { userSettings } = useUserSettings();
+    const replicatedSyncRule = location.state?.syncRule;
 
     const [dialogOpen, updateDialogOpen] = useState(false);
-    const [syncRule, updateSyncRule] = useState(location.state?.syncRule ?? SynchronizationRule.create(type));
+    const [syncRule, updateSyncRule] = useState(
+        replicatedSyncRule ?? createNewSyncRule(type, userSettings.inclusionConfig)
+    );
     const [originalSyncRule, setOriginalSyncRule] = useState<SynchronizationRule | undefined>(undefined);
 
     const isEdit = action === "edit" && !!id;
@@ -54,11 +62,15 @@ const SyncRulesCreation: React.FC = () => {
                 setOriginalSyncRule(syncRule ?? SynchronizationRule.create(type));
                 loading.reset();
             });
+        } else if (replicatedSyncRule) {
+            updateSyncRule(replicatedSyncRule);
+            setOriginalSyncRule(replicatedSyncRule);
         } else {
-            updateSyncRule(syncRule => syncRule?.setDefaultInclusions(userSettings.inclusionConfig));
-            setOriginalSyncRule(syncRule => syncRule?.setDefaultInclusions(userSettings.inclusionConfig));
+            const initialSyncRule = createNewSyncRule(type, userSettings.inclusionConfig);
+            updateSyncRule(initialSyncRule);
+            setOriginalSyncRule(initialSyncRule);
         }
-    }, [compositionRoot, loading, isEdit, id, type, userSettings.inclusionConfig]);
+    }, [compositionRoot, loading, isEdit, id, type, userSettings.inclusionConfig, replicatedSyncRule]);
 
     return (
         <TestWrapper>

--- a/src/presentation/webapp/core/pages/sync-rules-creation/SyncRulesCreationPage.tsx
+++ b/src/presentation/webapp/core/pages/sync-rules-creation/SyncRulesCreationPage.tsx
@@ -17,7 +17,7 @@ export interface SyncRulesCreationParams {
     type: SynchronizationType;
 }
 
-function createNewSyncRule(type: SynchronizationType, defaultInclusions: UserSettingsInclusionsConfig) {
+function createSyncRuleWithInclusions(type: SynchronizationType, defaultInclusions: UserSettingsInclusionsConfig) {
     return SynchronizationRule.create(type).setDefaultInclusions(defaultInclusions);
 }
 
@@ -32,7 +32,7 @@ const SyncRulesCreation: React.FC = () => {
 
     const [dialogOpen, updateDialogOpen] = useState(false);
     const [syncRule, updateSyncRule] = useState(
-        replicatedSyncRule ?? createNewSyncRule(type, userSettings.inclusionConfig)
+        replicatedSyncRule ?? createSyncRuleWithInclusions(type, userSettings.inclusionConfig)
     );
     const [originalSyncRule, setOriginalSyncRule] = useState<SynchronizationRule | undefined>(undefined);
 
@@ -62,11 +62,9 @@ const SyncRulesCreation: React.FC = () => {
                 setOriginalSyncRule(syncRule ?? SynchronizationRule.create(type));
                 loading.reset();
             });
-        } else if (replicatedSyncRule) {
-            updateSyncRule(replicatedSyncRule);
-            setOriginalSyncRule(replicatedSyncRule);
         } else {
-            const initialSyncRule = createNewSyncRule(type, userSettings.inclusionConfig);
+            const initialSyncRule =
+                replicatedSyncRule ?? createSyncRuleWithInclusions(type, userSettings.inclusionConfig);
             updateSyncRule(initialSyncRule);
             setOriginalSyncRule(initialSyncRule);
         }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -59,6 +59,7 @@ export default defineConfig(({ mode }) => {
         envPrefix: "VITE_",
         resolve: {
             alias: [{ find: "@peculiar/webcrypto", replacement: "/src/utils/shims/webcrypto-browser.js" }],
+            dedupe: ["@dhis2/prop-types"],
         },
     };
 });


### PR DESCRIPTION
## Summary

Brings the v2.24.2 release to `master`. This PR contains exactly the commits that are in the [v2.24.2 release](https://github.com/EyeSeeTea/metadata-synchronization/releases/tag/v2.24.2) — nothing else from `development`.

## What's included

Cherry-picked on top of `v2.24.0` (the previous `master` tip):

- **fix: preserve sync params when cloning a sync rule** (#1059)
- **refactor: simplify sync rule initialization and rename createSyncRuleWithInclusions** (#1059)
- **build: dedupe @dhis2/prop-types to fix production build** — required to make the production build pass on a fresh install; the nested `@dhis2/prop-types` copies don't expose a default export and tripped Rollup
- **fix: select all action in metadata table** (#1048)
- **fix: optimize selection logic in MetadataTable component** (#1048)

## Release notes
**v2.24.1** — Fix sync rule replication overwriting inclusion options (sharing, users, organisation units) with defaults (#1059)
**v2.24.2** — Fix "Select All" in metadata table unselecting selections from other metadata types (#1048)
