### PR TITLE
fix: events sync error due to spaces in fields filters

### DIFF
--- a/src/domain/events/mapper/EventsPayloadMapperFactory.ts
+++ b/src/domain/events/mapper/EventsPayloadMapperFactory.ts
@@ -42,7 +42,7 @@ async function getMappedTrackedProgramStages(
     if (destinationProgramStages && destinationProgramStages?.length > 0) {
         const result = await remoteMetadataRepository.getMetadataByIds<ProgramStageRef>(
             destinationProgramStages,
-            "id, program"
+            "id,program"
         );
 
         return result.programStages ?? [];

--- a/src/domain/tracked-entity-instances/mapper/TEIsPayloadMapperFactory.ts
+++ b/src/domain/tracked-entity-instances/mapper/TEIsPayloadMapperFactory.ts
@@ -51,7 +51,7 @@ async function getAllPossibleDestinationPrograms(
         const programs = (
             await metadataRepository.getMetadataByIds<ProgramRef>(
                 allPossibleDestinationProgramIds,
-                "id,programType, programTrackedEntityAttributes[trackedEntityAttribute],programStages[id,programStageDataElements[dataElement]]"
+                "id,programType,programTrackedEntityAttributes[trackedEntityAttribute],programStages[id,programStageDataElements[dataElement]]"
             )
         ).programs;
 


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Discovered as part of https://app.clickup.com/t/869d78d3e

### :memo: Implementation

- Tested in v42 only, but I assume it can be reproducible in all versions
- The problem is that if any Route url contains unencoded spaces it will fail with a 400 error.

Example: 

GET `http://localhost:8081/dhis2/api/routes/HC1CpN3KuQy/run/api/metadata?fields=id,programType, programTrackedEntityAttributes[trackedEntityAttribute],programStages[id,programStageDataElements[dataElement]]&filter=id:in:[cn4tDPLFfOT]&defaults=EXCLUDE` :

```
{
    "httpStatus": "Bad Request",
    "httpStatusCode": 400,
    "status": "ERROR",
    "message": "Illegal character in query at index 60: http://{ip:port-redacted}/api/metadata?fields=id,programType, programTrackedEntityAttributes[trackedEntityAttribute],programStages[id,programStageDataElements[dataElement]]&filter=id:in:[cn4tDPLFfOT]&defaults=EXCLUDE"
}
```

- After removing the space, it works fine. This was happening in `TEIsPayloadMapperFactory` but looked for other instances of spaces in filters and found only `EventsPayloadMapperFactory`

### :video_camera: Screenshots/Screen capture

### :fire: Is there anything the reviewer should know to test it?

- Run any events sync

### :bookmark_tabs: Others

-   Any change in the [GUI library](https://github.com/EyeSeeTea/d2-ui-components)? If so, what branch/PR?
No

-   Any change in the [D2 Api](https://github.com/EyeSeeTea/d2-api)? If so, what branch/PR?
No