### PR TITLE
[performance]: Reduce duplicate constant API requests on app load

### DIFF
--- a/src/data/common/InmemoryCache.ts
+++ b/src/data/common/InmemoryCache.ts
@@ -11,12 +11,22 @@ export class InmemoryCache {
 
     async getOrPromise<T>(cacheKey: string, promise: () => Promise<T>): Promise<T> {
         if (this.cache.has(cacheKey)) {
-            const data = this.cache.get(cacheKey) as T;
-            return Promise.resolve(data);
+            // Cached entry may be an in-flight promise or a resolved value; awaiting handles both.
+            return (await this.cache.get(cacheKey)) as T;
         } else {
-            const data = await promise();
-            this.cache.set(cacheKey, data);
-            return data;
+            // Cache the in-flight promise so concurrent callers reuse it instead of duplicating the request.
+            const inFlight = promise();
+            this.cache.set(cacheKey, inFlight);
+
+            try {
+                const data = await inFlight;
+                this.cache.set(cacheKey, data);
+                return data;
+            } catch (error) {
+                // Evict on failure so a later call can retry instead of caching the rejection.
+                this.cache.delete(cacheKey);
+                throw error;
+            }
         }
     }
 

--- a/src/data/common/__tests__/InmemoryCache.spec.ts
+++ b/src/data/common/__tests__/InmemoryCache.spec.ts
@@ -36,6 +36,33 @@ describe("Inmemory cache should", () => {
 
         expect(secondResult).toBe(expected);
     });
+    it("dedupe concurrent callers onto a single in-flight request", async () => {
+        const cache = new InmemoryCache();
+        const key = "key";
+        let calls = 0;
+        const promise = () => {
+            calls += 1;
+            return Promise.resolve(calls);
+        };
+
+        const [first, second, third] = await Promise.all([
+            cache.getOrPromise(key, promise),
+            cache.getOrPromise(key, promise),
+            cache.getOrPromise(key, promise),
+        ]);
+
+        expect(calls).toBe(1);
+        expect([first, second, third]).toEqual([1, 1, 1]);
+    });
+    it("evict the key when the promise rejects so a later call can retry", async () => {
+        const cache = new InmemoryCache();
+        const key = "key";
+
+        await expect(cache.getOrPromise(key, () => Promise.reject(new Error("boom")))).rejects.toThrow("boom");
+
+        const retry = await cache.getOrPromise(key, () => Promise.resolve(42));
+        expect(retry).toBe(42);
+    });
 });
 
 export {};

--- a/src/data/config/StorageClientD2Repository.ts
+++ b/src/data/config/StorageClientD2Repository.ts
@@ -32,6 +32,7 @@ export class StorageClientD2Repository implements StorageClientRepository, Stora
         });
     }
 
+    @cache()
     public getStorageClient(): FutureData<StorageClient> {
         return this.constantClient.getObjectFuture(Namespace.CONFIG).map(constantConfig => {
             return constantConfig ? this.constantClient : this.dataStoreClient;
@@ -42,6 +43,7 @@ export class StorageClientD2Repository implements StorageClientRepository, Stora
     @deprecated - We are moving from Promises to Futures, this method will be removed in future refactors.
     use getStorageClient instead
     */
+    @cache()
     public async getStorageClientPromise(): Promise<StorageClient> {
         const constantConfig = await this.constantClient.getObject(Namespace.CONFIG);
         return constantConfig ? this.constantClient : this.dataStoreClient;
@@ -82,6 +84,8 @@ export class StorageClientD2Repository implements StorageClientRepository, Stora
         // Reset memoize
         clear(this.detectStorageClients, this);
         clear(this.getUserStorageClient, this);
+        clear(this.getStorageClient, this);
+        clear(this.getStorageClientPromise, this);
     }
 
     public changeStorageClient(client: AppStorageType): FutureData<void> {

--- a/src/data/transformations/__tests__/integration/teiTransformations-api.spec.ts
+++ b/src/data/transformations/__tests__/integration/teiTransformations-api.spec.ts
@@ -18,8 +18,6 @@ const localInstance = Instance.build({
     type: "local",
 });
 
-const repositoryFactory = buildRepositoryFactory(localInstance);
-
 const mockAttributes = [
     {
         attribute: "attribute1",
@@ -415,6 +413,7 @@ async function runSyncEventsTest({ from, to }: { from: string; to: string }) {
 
     setupMockEndpoints(local, to);
     setupTrackerEndpoints(local);
+    const repositoryFactory = buildRepositoryFactory(localInstance);
 
     const builder: SynchronizationBuilder = {
         originInstance: "LOCAL",

--- a/src/domain/common/factories/DynamicRepositoryFactory.ts
+++ b/src/domain/common/factories/DynamicRepositoryFactory.ts
@@ -137,9 +137,11 @@ export class DynamicRepositoryFactory {
             throw new Error(`Dependency ${key} is not registered`);
         }
 
-        const createdRepository = this.createdReposities.get(`${key}-${tag}`) || creator(instance);
+        // Cache per instance so repeated lookups reuse the same repository instead of recreating it.
+        const cacheKey = `${key}-${tag}-${instance.id}`;
+        const createdRepository = this.createdReposities.get(cacheKey) || creator(instance);
 
-        this.createdReposities.set(key, createdRepository);
+        this.createdReposities.set(cacheKey, createdRepository);
 
         return createdRepository as T;
     }
@@ -151,9 +153,10 @@ export class DynamicRepositoryFactory {
             throw new Error(`Dependency ${key} is not registered`);
         }
 
-        const createdRepository = this.createdReposities.get(`${key}-${tag}`) || creator(instance);
+        const cacheKey = `${key}-${tag}`;
+        const createdRepository = this.createdReposities.get(cacheKey) || creator(instance);
 
-        this.createdReposities.set(key, createdRepository);
+        this.createdReposities.set(cacheKey, createdRepository);
 
         return createdRepository as T;
     }

--- a/src/presentation/NewCompositionRoot.ts
+++ b/src/presentation/NewCompositionRoot.ts
@@ -46,7 +46,7 @@ function getCompositionRoot(repositories: Repositories) {
 export function getWebappCompositionRoot(instance: Instance) {
     const storageClientRepository = new StorageClientD2Repository(instance);
     const repositories: Repositories = {
-        storageClientRepository: new StorageClientD2Repository(instance),
+        storageClientRepository: storageClientRepository,
         settingsRepository: new SettingsD2ApiRepository(storageClientRepository),
         userSettingsRepository: new UserSettingsD2ApiRepository(instance),
     };

--- a/src/presentation/react/core/components/sync-wizard/common/InstanceSelectionStep.tsx
+++ b/src/presentation/react/core/components/sync-wizard/common/InstanceSelectionStep.tsx
@@ -1,7 +1,6 @@
 import { MultiSelector, useSnackbar } from "@eyeseetea/d2-ui-components";
 import { Button, makeStyles, Typography } from "@material-ui/core";
 import React, { useCallback, useEffect, useState } from "react";
-import { a } from "vitest/dist/chunks/suite.d.FvehnV49";
 import { Instance } from "../../../../../../domain/instance/entities/Instance";
 import { User } from "../../../../../../domain/user/entities/User";
 import i18n from "../../../../../../utils/i18n";


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/869d11cuy

### :memo: Implementation

-    On app load the same `GET /api/constants?...filter=code:eq:MDSYNC_config` request fired multiple times (each returning the same, often empty, result).
-   Root cause: `DynamicRepositoryFactory.getbyInstance` read its created-repository cache with `` `${key}-${tag}` `` but wrote it with `key`, so the cache never hit and `configRepository(instance)` rebuilt a fresh `StorageClientD2Repository` (and `StorageConstantClient`) on every call. The existing per-instance `@cache()` therefore couldn't dedupe across consumers (migrations, settings, store, instance, …).
-   Fixed the factory to read/write the cache with the same key, keyed by `instance.id` — dedupes lookups for the same instance while keeping different target instances isolated (cross-instance sync stays correct).

### :video_camera: Screenshots/Screen capture

### :fire: Is there anything the reviewer should know to test it?

### :bookmark_tabs: Others


#869d11cuy