### PR TITLE
Fix E7613: Category option combo not found for program indicators with aggregateExportCategoryOptionCombo

### DIFF
--- a/src/domain/aggregated/mapper/AggregatedPayloadMapper.ts
+++ b/src/domain/aggregated/mapper/AggregatedPayloadMapper.ts
@@ -53,20 +53,26 @@ export class AggregatedPayloadMapper implements PayloadMapper {
 
         const dataElementId = dataElement.replace(".", "-");
 
+        // Special scenario: program indicators can return categoryOptionCombo/attributeOptionCombo
+        // in the compound format {dataElement}.{categoryOptionCombo} (from aggregateExportCategoryOptionCombo
+        // / aggregateExportAttributeOptionCombo). The mapping dictionary is keyed by the unpacked id.
+        const realCategoryOptionCombo = _.last(categoryOptionCombo?.split(".")) ?? categoryOptionCombo;
+        const realAttributeOptionCombo = _.last(attributeOptionCombo?.split(".")) ?? attributeOptionCombo;
+
         const mappedOrgUnit = organisationUnits[orgUnit]?.mappedId ?? orgUnit;
         const mappedDataElement = aggregatedDataElements[dataElementId]?.mappedId ?? dataElement;
         const mappedValue = mapOptionValue(value, [innerMapping, globalMapping]);
         const mappedComment = mapOptionValue(comment, [innerMapping, globalMapping]);
         const mappedCategory =
             mapCategoryOptionCombo(
-                categoryOptionCombo,
+                realCategoryOptionCombo,
                 [innerMapping, globalMapping],
                 originCategoryOptionCombos,
                 destinationCategoryOptionCombos,
                 false
-            ) ?? categoryOptionCombo;
+            ) ?? realCategoryOptionCombo;
         const mappedAttribute = mapCategoryOptionCombo(
-            attributeOptionCombo,
+            realAttributeOptionCombo,
             [innerMapping, globalMapping],
             originCategoryOptionCombos,
             destinationCategoryOptionCombos,

--- a/src/domain/aggregated/mapper/__tests__/AggregatedPayloadMapper.spec.ts
+++ b/src/domain/aggregated/mapper/__tests__/AggregatedPayloadMapper.spec.ts
@@ -9,6 +9,8 @@ import dataValuesIndicator from "./data/data-values/dataValues_indicator.json";
 import dataValuesCommentOption from "./data/data-values/dataValues_comment_option.json";
 import dataValuesProgramIndicator from "./data/data-values/dataValues_program_indicator.json";
 import dataValuesProgramIndicatorWithOptionCombos from "./data/data-values/dataValues_program_indicator_with_option_combos.json";
+import dataValuesProgramIndicatorCompoundOptionCombo from "./data/data-values/dataValues_program_indicator_compound_option_combo.json";
+import dataValuesProgramIndicatorCompoundOptionComboNoMapping from "./data/data-values/dataValues_program_indicator_compound_option_combo_no_mapping.json";
 import dataValuesProgramdataElement from "./data/data-values/dataValues_program_data_element.json";
 
 import orgUnitsMapping from "./data/mapping/mapping_orgUnits.json";
@@ -45,6 +47,8 @@ import dataValuesIndicatorDataElementMapping from "./data/expected/dataValues_in
 import dataValuesCommentMapping from "./data/expected/dataValues_comment_option_mapping.json";
 import dataValuesProgramIndicatorDataElementMapping from "./data/expected/dataValues_program_indicator_de_mapping.json";
 import dataValuesProgramIndicatorWithAttributeOptionCombosMapping from "./data/expected/dataValues_program_indicator_with_attribute_option_combos_mapping.json";
+import dataValuesProgramIndicatorCompoundOptionComboMapping from "./data/expected/dataValues_program_indicator_compound_option_combo_mapping.json";
+import dataValuesProgramIndicatorCompoundOptionComboNoMappingExpected from "./data/expected/dataValues_program_indicator_compound_option_combo_no_mapping.json";
 import dataValuesProgramDataElementToAggregatedMapping from "./data/expected/dataValues_program_DE_Aggregated_mapping.json";
 
 describe("AggreggatedPayloadMapper", () => {
@@ -180,6 +184,20 @@ describe("AggreggatedPayloadMapper", () => {
         const mappedPayload = await aggregatedMapper.map(dataValuesProgramdataElement);
 
         expect(mappedPayload).toEqual(dataValuesProgramDataElementToAggregatedMapping);
+    });
+    it("should return the payload with unpacked and mapped category option combo and attribute option combo if they are received in the compound {dataElement}.{optionCombo} format", async () => {
+        const aggregatedMapper = createAggregatedPayloadMapper(programIndicatorWithAttributeOptionCombosMapping);
+
+        const mappedPayload = await aggregatedMapper.map(dataValuesProgramIndicatorCompoundOptionCombo);
+
+        expect(mappedPayload).toEqual(dataValuesProgramIndicatorCompoundOptionComboMapping);
+    });
+    it("should return the payload with the unpacked category option combo if it is received in the compound {dataElement}.{optionCombo} format and there is no mapping for it", async () => {
+        const aggregatedMapper = createAggregatedPayloadMapper(programIndicatorDataElementMapping);
+
+        const mappedPayload = await aggregatedMapper.map(dataValuesProgramIndicatorCompoundOptionComboNoMapping);
+
+        expect(mappedPayload).toEqual(dataValuesProgramIndicatorCompoundOptionComboNoMappingExpected);
     });
 });
 

--- a/src/domain/aggregated/mapper/__tests__/data/data-values/dataValues_program_indicator_compound_option_combo.json
+++ b/src/domain/aggregated/mapper/__tests__/data/data-values/dataValues_program_indicator_compound_option_combo.json
@@ -1,0 +1,12 @@
+{
+    "dataValues": [
+        {
+            "dataElement": "xQWBiTAywVq",
+            "period": "2021",
+            "orgUnit": "BWW8zaLISW4",
+            "categoryOptionCombo": "zLHm0ciINoI.HllvX50cXC0",
+            "attributeOptionCombo": "zLHm0ciINoI.xYerKDKCefk",
+            "value": "12.0"
+        }
+    ]
+}

--- a/src/domain/aggregated/mapper/__tests__/data/data-values/dataValues_program_indicator_compound_option_combo_no_mapping.json
+++ b/src/domain/aggregated/mapper/__tests__/data/data-values/dataValues_program_indicator_compound_option_combo_no_mapping.json
@@ -1,0 +1,11 @@
+{
+    "dataValues": [
+        {
+            "dataElement": "ysN9dTOAwXf",
+            "period": "2021",
+            "orgUnit": "BWW8zaLISW4",
+            "categoryOptionCombo": "zLHm0ciINoI.CatOptCom01",
+            "value": "12.0"
+        }
+    ]
+}

--- a/src/domain/aggregated/mapper/__tests__/data/expected/dataValues_program_indicator_compound_option_combo_mapping.json
+++ b/src/domain/aggregated/mapper/__tests__/data/expected/dataValues_program_indicator_compound_option_combo_mapping.json
@@ -1,0 +1,12 @@
+{
+    "dataValues": [
+        {
+            "dataElement": "F6yeCU8jIbq",
+            "period": "2021",
+            "orgUnit": "BWW8zaLISW4",
+            "categoryOptionCombo": "Xr12mI7VPn3",
+            "attributeOptionCombo": "Yr13mI7VPn4",
+            "value": "12.0"
+        }
+    ]
+}

--- a/src/domain/aggregated/mapper/__tests__/data/expected/dataValues_program_indicator_compound_option_combo_no_mapping.json
+++ b/src/domain/aggregated/mapper/__tests__/data/expected/dataValues_program_indicator_compound_option_combo_no_mapping.json
@@ -1,0 +1,11 @@
+{
+    "dataValues": [
+        {
+            "dataElement": "ysN9dTOAwXf",
+            "period": "2021",
+            "orgUnit": "BWW8zaLISW4",
+            "categoryOptionCombo": "CatOptCom01",
+            "value": "12.0"
+        }
+    ]
+}


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/869dhyaaq  #869dhyaaq
-   Regression introduced in #1033

### :memo: Implementation

In MSF, the program indicator `eYthSmwTJTi` ("[DD]-Tracker-IPD-Nutrition-ITFC Patients-ITFC: Patients at beginning of week(default)") has the DHIS2 metadata field `aggregateExportCategoryOptionCombo` set to `"zLHm0ciINoI.AOPzxwWACxk"` (`{dataElement}.{categoryOptionCombo}`, where `zLHm0ciINoI` is the data element "ITFC: Patients at beginning of week" / NUT1, and `AOPzxwWACxk` is the instance's global default category option combo):

```json
GET /api/identifiableObjects/eYthSmwTJTi
{
  "id": "eYthSmwTJTi",
  "dimensionItemType": "PROGRAM_INDICATOR",
  "aggregateExportCategoryOptionCombo": "zLHm0ciINoI.AOPzxwWACxk",
  ...
}
```

This field tells DHIS2 analytics how to export the program indicator's aggregated value, and DHIS2 already uses it for **mapping/auto-map** in this app: `GenericMappingUseCase.getCategoryOptionCombos`/`getAttributeOptionCombos` unpack it with `_.last(aggregateExportCategoryOptionCombo.split("."))` to build the mapping dictionary entry, keyed by the unpacked category option combo id (e.g. `mapping.categoryOptionCombos["AOPzxwWACxk"]`), and `AutoMapUseCase`/`GenericMappingUseCase.autoMap` use the dataElement part (`_.first(split("."))`) to prioritize the matching destination data element when auto-mapping the program indicator.

#### The regression

Before #1033, program indicators were always synced with `includeCategories: false` in `AggregatedD2ApiRepository.getAnalytics`, which forces `categoryOptionCombo`/`attributeOptionCombo` to `defaultCategoryOptionCombo`/`undefined`, discarding whatever DHIS2 analytics returned for these fields.

#1033 changed `EventsPayloadBuilder` to call `getAnalytics` with `includeCategories: true` for program indicators, in order to support program indicators **with real disaggregation** (real category option combos must now pass through). As a side effect, for program indicators that have `aggregateExportCategoryOptionCombo` configured (like `eYthSmwTJTi`), DHIS2 analytics returns the **compound, unpacked** value directly in the data value:

```json
{
  "dataElement": "eYthSmwTJTi",
  "categoryOptionCombo": "zLHm0ciINoI.AOPzxwWACxk",
  "value": "29"
}
```

`AggregatedPayloadMapper.buildMappedDataValue()` passed this compound `categoryOptionCombo` value unchanged into `mapCategoryOptionCombo()`. The mapping dictionary entry built by `GenericMappingUseCase` is keyed by the **unpacked** id (`"AOPzxwWACxk"`), so the lookup `categoryOptionCombos["zLHm0ciINoI.AOPzxwWACxk"]` never matched. With no match, `mapCategoryOptionCombo()` returned the value unchanged, and the invalid compound string `"zLHm0ciINoI.AOPzxwWACxk"` was sent to the destination instance as `categoryOptionCombo`, which DHIS2 rejects:

```
Category option combo not found or not accessible for writing data: zLHm0ciINoI.AOPzxwWACxk (E7613)
```

The `dataElement` field happened to be mapped correctly anyway (`eYthSmwTJTi` -> `zLHm0ciINoI`), but only because the mapping dictionary's `aggregatedDataElements["eYthSmwTJTi"].mappedId` already resolves it independently — this masked the `categoryOptionCombo` mismatch.

#### The fix

In `AggregatedPayloadMapper.buildMappedDataValue()`, unpack `categoryOptionCombo`/`attributeOptionCombo` with `_.last(value.split("."))` **before** calling `mapCategoryOptionCombo()`, and use that unpacked value as the fallback when no mapping entry is found. This mirrors the exact same unpacking pattern already used by `GenericMappingUseCase.getCategoryOptionCombos`/`getAttributeOptionCombos` to build the mapping dictionary keys, so the lookup now matches.

This is a minimal, symmetric fix:
- Preserves `includeCategories: true` for program indicators, so program indicators **with real disaggregation** (the feature added in #1033) keep working.
- Does not touch `dataElement` resolution (already correct via the mapping dictionary).
- Values that are already plain (non-compound) ids are unaffected (`_.last(split("."))` on a string without `.` returns the string itself).

#### Tests added

Two new cases in `AggregatedPayloadMapper.spec.ts` reproduce the bug scenario directly and act as regression guards / documentation:

1. `dataValues_program_indicator_compound_option_combo.json` + `..._mapping.json` — compound `categoryOptionCombo`/`attributeOptionCombo` (`"{dataElement}.{optionCombo}"`) with an existing mapping entry keyed by the unpacked id: verifies both get unpacked and correctly mapped (this is the exact "Nutrition ITFC - PI" scenario).
2. `dataValues_program_indicator_compound_option_combo_no_mapping.json` + `..._no_mapping.json` — compound `categoryOptionCombo` with no mapping entry: verifies the fallback returns the unpacked real category option combo id, not the invalid compound string.

### :video_camera: Screenshots/Screen capture

N/A

### :fire: Is there anything the reviewer should know to test it?

Reproduced manually against a DHIS2 2.42 instance running the "Nutrition ITFC - PI" sync rule (program indicator `eYthSmwTJTi`), which previously finished with:

```
Type: Program Indicators
Status: Warning - Import process completed successfully
Error found: Category option combo not found or not accessible for writing data: zLHm0ciINoI.AOPzxwWACxk
```

After the fix, the sync rule completes without warnings, and the posted `categoryOptionCombo` is correctly resolved/mapped instead of the invalid compound string.

### :bookmark_tabs: Others

-   Any change in the [GUI library](https://github.com/EyeSeeTea/d2-ui-components)? No
-   Any change in the [D2 Api](https://github.com/EyeSeeTea/d2-api)? No