### PR TITLE
[fix]: Always build scheduler artifact in `yarn build`

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,10 @@ To build a given front-end:
 $ yarn build [all|core-app|data-metadata-app|module-package-app|modules-list|package-exporter|msf-aggregate-data-app|sp-emergency-responses|wmr]
 ```
 
-To build the scheduler:
+`yarn build` already builds the scheduler and emits the `metadata-synchronization-server.zip` file
+alongside the front-end zips, so it is always included in releases.
+
+To build the scheduler on its own:
 
 ```
 $ yarn build-scheduler

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
         "build:variant": "vite build && cp -r i18n icon.png build",
         "preview": "vite preview",
         "prebuild": "yarn localize && yarn test",
-        "build-scheduler": "ncc build src/scheduler/cli.ts -m -o $npm_package_name-server && zip -r $npm_package_name-server.zip $npm_package_name-server && npx rimraf $npm_package_name-server/",
+        "build-scheduler": "ncc build src/scheduler/cli.ts -m -o ${npm_package_name}-server && zip -r ${npm_package_name}-server.zip ${npm_package_name}-server && npx rimraf ${npm_package_name}-server/",
         "run-ts": "tsx",
         "migrate": "yarn run-ts src/migrations/cli.ts",
         "test": "vitest run",

--- a/scripts/run.ts
+++ b/scripts/run.ts
@@ -113,6 +113,8 @@ function build(args: BuildArgs): void {
             cleanupVariantAssets(variant.name);
         }
     }
+
+    run(`yarn build-scheduler`);
 }
 
 function updateManifestNamespace(manifestPath: string, variantFile: string) {


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/869dqwwjt

### :memo: Implementation

-   Recent releases were missing the scheduler artifact (`metadata-synchronization-server.zip`) because `yarn build` only produced the front-end variant zips and never invoked `yarn build-scheduler`. It had to be generated manually from the release commit.
-   Wire `build-scheduler` into `build()` in `scripts/run.ts`, running it once after the variant loop, so `yarn build` always emits the scheduler artifact and releases include it.
-   Placed the call inside `build()` (rather than appending `&& yarn build-scheduler` to the `build` npm script) so it runs exactly once regardless of the selected variant and doesn't break positional-arg passing.
-   Updated the README to note that `yarn build` now also produces the scheduler zip.



### :fire: Is there anything the reviewer should know to test it?
-   Run `yarn build` (or `yarn build core-app`) and confirm `metadata-synchronization-server.zip` is produced alongside the variant zips.
-   Verify the bundle is present: `unzip -l metadata-synchronization-server.zip | grep index.js`, and that the temp `metadata-synchronization-server/` dir is cleaned up afterwards.
-   Note: under Yarn 4, the existing `build-scheduler` script uses a bare `$npm_package_name`, which Yarn's portable shell mis-parses (`Unbound variable "npm_package_name-server"`). If the build fails on that, the script needs `${npm_package_name}` (braces) instead.

#869dqwwjt