### PR TITLE
[fix]: Scheduler failing on DHIS2 2.43 (userCredentials removed from /me)

### DIFF
--- a/src/data/storage/StorageDataStoreClient.ts
+++ b/src/data/storage/StorageDataStoreClient.ts
@@ -8,6 +8,7 @@ import { getD2APiFromInstance } from "../../utils/d2-utils";
 import { DataStorageType } from "../../domain/storage-client-config/entities/StorageConfig";
 import { Future, FutureData } from "../../domain/common/entities/Future";
 import { apiToFuture } from "../common/utils/api-futures";
+import { getErrorMessage } from "../../utils/error";
 
 export const dataStoreNamespace = "metadata-synchronization";
 
@@ -41,7 +42,7 @@ export class StorageDataStoreClient extends StorageClient {
             const value = await this.dataStore.get<T>(key).getData();
             return value;
         } catch (error: any) {
-            console.error(error);
+            console.error(`Error reading dataStore key "${key}": ${getErrorMessage(error)}`);
             return undefined;
         }
     }
@@ -50,7 +51,7 @@ export class StorageDataStoreClient extends StorageClient {
         return Future.fromPromise(this.dataStore.get<T>(key).getData())
             .map(value => value)
             .mapError(error => {
-                console.error(error);
+                console.error(`Error reading dataStore key "${key}": ${getErrorMessage(error)}`);
                 return error;
             });
     }

--- a/src/data/user/UserD2ApiRepository.ts
+++ b/src/data/user/UserD2ApiRepository.ts
@@ -2,8 +2,23 @@ import { Instance } from "../../domain/instance/entities/Instance";
 import { AppRoles } from "../../domain/role/AppRoles";
 import { User } from "../../domain/user/entities/User";
 import { UserRepository } from "../../domain/user/repositories/UserRepository";
-import { D2Api } from "../../types/d2-api";
+import { D2Api, Id } from "../../types/d2-api";
 import { getD2APiFromInstance } from "../../utils/d2-utils";
+import { NamedRef } from "../../domain/common/entities/Ref";
+
+// DHIS2 2.43 moved `username`/`userRoles` out of the (now removed) `userCredentials` wrapper.
+export type CurrentUserRole = NamedRef & { authorities: string[] };
+export type CurrentUserResponse = {
+    id: Id;
+    name: string;
+    email: string;
+    username: string;
+    userRoles?: CurrentUserRole[];
+    userGroups: NamedRef[];
+    organisationUnits: NamedRef[];
+    dataViewOrganisationUnits: NamedRef[];
+    userCredentials?: { username?: string; userRoles?: CurrentUserRole[] };
+};
 
 export class UserD2ApiRepository implements UserRepository {
     private api: D2Api;
@@ -13,48 +28,36 @@ export class UserD2ApiRepository implements UserRepository {
     }
 
     async getCurrent(): Promise<User> {
-        const currentUser = await this.api.currentUser
-            .get({
-                fields: {
-                    id: true,
-                    name: true,
-                    email: true,
-                    userCredentials: {
-                        username: true,
-                        userRoles: {
-                            $all: true,
-                        },
-                    },
-                    userGroups: { id: true, name: true },
-                    organisationUnits: { id: true, name: true },
-                    dataViewOrganisationUnits: { id: true, name: true },
-                },
+        const currentUser = await this.api
+            .get<CurrentUserResponse>("/me", {
+                fields: [
+                    "id,name,email",
+                    "username,userRoles[:all]",
+                    "userCredentials[username,userRoles[:all]]",
+                    "userGroups[id,name]",
+                    "organisationUnits[id,name]",
+                    "dataViewOrganisationUnits[id,name]",
+                ].join(","),
             })
             .getData();
 
-        const isGlobalAdmin = !!currentUser.userCredentials.userRoles.find((role: any) =>
-            role.authorities.find((authority: string) => authority === "ALL")
-        );
+        const username = currentUser.userCredentials?.username ?? currentUser.username;
+        const userRoles: CurrentUserRole[] = currentUser.userCredentials?.userRoles ?? currentUser.userRoles ?? [];
+        const isGlobalAdmin = !!userRoles.find(role => role.authorities.find(authority => authority === "ALL"));
 
         return {
             id: currentUser.id,
             name: currentUser.name,
             email: currentUser.email,
-            username: currentUser.userCredentials.username,
+            username: username,
             userGroups: currentUser.userGroups,
             organisationUnits: currentUser.organisationUnits,
             dataViewOrganisationUnits: currentUser.dataViewOrganisationUnits,
             isGlobalAdmin,
             isAppConfigurator:
-                isGlobalAdmin ||
-                !!currentUser.userCredentials.userRoles.find(
-                    (role: any) => role.name === AppRoles.CONFIGURATION_ACCESS.name
-                ),
+                isGlobalAdmin || !!userRoles.find(role => role.name === AppRoles.CONFIGURATION_ACCESS.name),
             isAppExecutor:
-                isGlobalAdmin ||
-                !!currentUser.userCredentials.userRoles.find(
-                    (role: any) => role.name === AppRoles.SYNC_RULE_EXECUTION_ACCESS.name
-                ),
+                isGlobalAdmin || !!userRoles.find(role => role.name === AppRoles.SYNC_RULE_EXECUTION_ACCESS.name),
         };
     }
 }

--- a/src/domain/synchronization/usecases/GenericSyncUseCase.ts
+++ b/src/domain/synchronization/usecases/GenericSyncUseCase.ts
@@ -148,12 +148,15 @@ export abstract class GenericSyncUseCase {
         const { syncRule } = this.builder;
         const metadataPackage = await this.extractMetadata();
         const dataStats = useAggregatedDataExchange ? undefined : await this.buildDataStats();
-        const currentUser = await this.api.currentUser
-            .get({ fields: { userCredentials: { username: true } } })
+        // DHIS2 2.43 removed the `userCredentials` wrapper; `username` is now top-level.
+        const currentUser = await this.api
+            .get<{ username?: string; userCredentials?: { username?: string } }>("/me", {
+                fields: "username,userCredentials[username]",
+            })
             .getData();
 
         return SynchronizationReport.build({
-            user: currentUser.userCredentials.username ?? "Unknown",
+            user: currentUser.userCredentials?.username ?? currentUser.username ?? "Unknown",
             types: _.keys(metadataPackage),
             status: "RUNNING" as SynchronizationReportStatus,
             syncRule,
@@ -252,13 +255,13 @@ export abstract class GenericSyncUseCase {
             const oldRule = await this.repositoryFactory.rulesRepository(this.localInstance).getById(syncRule);
 
             if (oldRule) {
-                const currentUser = await this.api.currentUser
-                    .get({ fields: { userCredentials: { name: true }, id: true } })
+                const currentUser = await this.api
+                    .get<{ id: string; name: string }>("/me", { fields: "id,name" })
                     .getData();
 
                 const updatedRule = oldRule.updateLastExecuted(executionDate, {
                     id: currentUser.id,
-                    name: currentUser.userCredentials.name,
+                    name: currentUser.name,
                 });
                 await this.repositoryFactory.rulesRepository(this.localInstance).save([updatedRule]);
             }

--- a/src/presentation/react/core/components/package-import-dialog/PackageImportDialog.tsx
+++ b/src/presentation/react/core/components/package-import-dialog/PackageImportDialog.tsx
@@ -34,7 +34,7 @@ const PackageImportDialog: React.FC<PackageImportDialogProps> = ({
     const [enableImport, setEnableImport] = useState(false);
     const snackbar = useSnackbar();
     const loading = useLoading();
-    const { compositionRoot, api } = useAppContext();
+    const { compositionRoot } = useAppContext();
 
     const [packageImportRule, setPackageImportRule] = useState<PackageImportRule>(
         PackageImportRule.create(instance, selectedPackagesId)
@@ -92,20 +92,14 @@ const PackageImportDialog: React.FC<PackageImportDialogProps> = ({
         //    4 - Save ImportedPackage (using ImportedPackageRepository)
         const importedPackages: Package[] = [];
 
-        const currentUser = await api.currentUser
-            .get({ fields: { id: true, userCredentials: { username: true } } })
-            .getData();
+        const currentUser = await compositionRoot.user.current();
 
-        const report = SynchronizationReport.create(
-            "metadata",
-            currentUser.userCredentials.username ?? "Unknown",
-            true
-        );
+        const report = SynchronizationReport.create("metadata", currentUser.username ?? "Unknown", true);
 
         const storePackageUrls: Record<string, string> = {};
 
         try {
-            const author = { id: currentUser.id, name: currentUser.userCredentials.username };
+            const author = { id: currentUser.id, name: currentUser.username };
 
             const executePackageImport = async (packageId: string) => {
                 const getPackageResult = await getPackage(packageId);

--- a/src/presentation/react/core/components/package-list-table/PackageListTable.tsx
+++ b/src/presentation/react/core/components/package-list-table/PackageListTable.tsx
@@ -385,9 +385,7 @@ export const PackagesListTable: React.FC<PackagesListTableProps> = ({
             result.match({
                 success: async originPackage => {
                     try {
-                        const currentUser = await api.currentUser
-                            .get({ fields: { id: true, userCredentials: { username: true } } })
-                            .getData();
+                        const currentUser = await compositionRoot.user.current();
 
                         loading.show(true, i18n.t("Importing package {{name}}", { name: originPackage.name }));
 
@@ -410,7 +408,7 @@ export const PackagesListTable: React.FC<PackagesListTableProps> = ({
 
                         const report = SynchronizationReport.create(
                             "metadata",
-                            currentUser.userCredentials.username ?? "Unknown",
+                            currentUser.username ?? "Unknown",
                             true
                         );
 
@@ -431,7 +429,7 @@ export const PackagesListTable: React.FC<PackagesListTableProps> = ({
                         if (result.status === "SUCCESS") {
                             const author = {
                                 id: currentUser.id,
-                                name: currentUser.userCredentials.username,
+                                name: currentUser.username,
                             };
 
                             await saveImportedPackage(
@@ -456,7 +454,6 @@ export const PackagesListTable: React.FC<PackagesListTableProps> = ({
         },
         [
             compositionRoot,
-            api,
             loading,
             remoteInstance,
             snackbar,

--- a/src/scheduler/SchedulerCLI/SchedulerCLI.ts
+++ b/src/scheduler/SchedulerCLI/SchedulerCLI.ts
@@ -6,6 +6,7 @@ import { DEFAULT_SCHEDULED_JOB_ID, ScheduledJob } from "../../domain/scheduler/e
 import { SchedulerExecutionInfo } from "../../domain/scheduler/entities/SchedulerExecutionInfo";
 import { Logger } from "./Logger";
 import { SynchronizationRule } from "../../domain/rules/entities/SynchronizationRule";
+import { getErrorMessage } from "../../utils/error";
 
 // NOTICE: This is refactored
 
@@ -86,8 +87,7 @@ export class SchedulerCLI {
 
             this.updateNextExecutionOfScheduler(scheduledJobs);
         } catch (error) {
-            const errorMessage = typeof error === "string" ? error : JSON.stringify(error, null, 2);
-            logger.error("scheduler", `${errorMessage}`);
+            logger.error("scheduler", getErrorMessage(error));
         }
     }
 
@@ -139,8 +139,7 @@ export class SchedulerCLI {
                 },
             });
         } catch (error) {
-            const errorMessage = typeof error === "string" ? error : JSON.stringify(error, null, 2);
-            logger.error(name, `Failed executing rule: ${errorMessage}`);
+            logger.error(name, `Failed executing rule: ${getErrorMessage(error)}`);
         }
     }
 

--- a/src/scheduler/cli.ts
+++ b/src/scheduler/cli.ts
@@ -10,6 +10,7 @@ import Scheduler from "./Scheduler";
 import LoggerLog4js from "./LoggerLog4js";
 import { SchedulerCLI } from "./SchedulerCLI/SchedulerCLI";
 import { Future, FutureData } from "../domain/common/entities/Future";
+import { getErrorMessage } from "../utils/error";
 
 // NOTICE: This file is refactored
 
@@ -53,8 +54,7 @@ async function main() {
 
                 await start(config, logger);
             } catch (error) {
-                const errorMessage = typeof error === "string" ? error : JSON.stringify(error, null, 2);
-                logger.fatal("main", `${errorMessage}`);
+                logger.fatal("main", getErrorMessage(error));
                 process.exit(1);
             }
         },

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -1,0 +1,34 @@
+/**
+ * Converts an unknown thrown value into a readable, log-friendly string,
+ * avoiding the "{}" that `JSON.stringify` produces for Error/axios objects.
+ */
+export function getErrorMessage(error: unknown): string {
+    if (typeof error === "string") return error;
+
+    if (error && typeof error === "object") {
+        // Axios / D2Api error: the DHIS2 payload carries the real message and conflicts.
+        const response = (error as { response?: { status?: number; data?: unknown } }).response;
+        if (response) {
+            const status = response.status !== undefined ? `HTTP ${response.status}` : "HTTP error";
+            const data = safeStringify(response.data);
+            return data ? `${status}: ${data}` : status;
+        }
+
+        if (error instanceof Error) {
+            return error.stack ? `${error.message}\n${error.stack}` : error.message;
+        }
+    }
+
+    return safeStringify(error) ?? String(error);
+}
+
+function safeStringify(value: unknown): string | undefined {
+    if (value === undefined || value === null) return undefined;
+    if (typeof value === "string") return value;
+
+    try {
+        return JSON.stringify(value);
+    } catch {
+        return undefined;
+    }
+}

--- a/src/utils/permissions.ts
+++ b/src/utils/permissions.ts
@@ -2,6 +2,7 @@ import memoize from "nano-memoize";
 import { AppRoles } from "../domain/role/AppRoles";
 import { SynchronizationRule } from "../domain/rules/entities/SynchronizationRule";
 import { D2Api } from "../types/d2-api";
+import { CurrentUserResponse } from "../data/user/UserD2ApiRepository";
 
 // Applying parallel change
 // Exists a GetCurrentUseCase that we should use for the new code
@@ -24,22 +25,15 @@ export interface UserInfo {
  */
 export const getUserInfo = memoize(
     async (api: D2Api): Promise<UserInfo> => {
-        const currentUser = await api.currentUser
-            .get({
-                fields: {
-                    id: true,
-                    name: true,
-                    userCredentials: { username: true },
-                    userGroups: true,
-                },
-            })
+        const currentUser = await api
+            .get<CurrentUserResponse>("/me", { fields: "id,name,userGroups,username,userCredentials[username]" })
             .getData();
 
         return {
             userGroups: currentUser.userGroups,
             id: currentUser.id,
             name: currentUser.name,
-            username: currentUser.userCredentials.username,
+            username: currentUser.userCredentials?.username ?? currentUser.username,
         };
     },
     { serializer: (api: D2Api) => api.baseUrl }
@@ -50,19 +44,11 @@ export const getUserInfo = memoize(
  */
 const getUserRoles = memoize(
     async (api: D2Api) => {
-        const currentUser = await api.currentUser
-            .get({
-                fields: {
-                    userCredentials: {
-                        userRoles: {
-                            $all: true,
-                        },
-                    },
-                },
-            })
+        const currentUser = await api
+            .get<CurrentUserResponse>("/me", { fields: "userRoles[:all],userCredentials[userRoles[:all]]" })
             .getData();
 
-        return currentUser.userCredentials.userRoles;
+        return currentUser.userCredentials?.userRoles ?? currentUser.userRoles ?? [];
     },
     { serializer: (api: D2Api) => api.baseUrl }
 );


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/4528615/869dqwtvv

### :memo: Implementation
**Root cause:** DHIS2 version 2.43 removed the `userCredentials` wrapper from `/api/me`; `username`/`userRoles` are now top-level. Code reading `currentUser.userCredentials.userRoles`/`.username` threw `Cannot read properties of undefined (reading 'userRoles')`. In the scheduler this surfaced only as `[ERROR] scheduler - {}` because the catch blocks serialized the error with `JSON.stringify(error)`, which returns `{}` for `Error` objects.

- [x] Added a `getErrorMessage` helper (`src/utils/error.ts`) and used it in the scheduler catch blocks (`cli.ts`, `SchedulerCLI.ts`) so errors log with their real message/stack instead of `{}`. Also applied it to previously swallowed dataStore read errors (`StorageDataStoreClient`).
- [x] Updated all current-user (`/me`) reads to support both pre-2.43 and 2.43+ shapes via a fallback (`userCredentials?.x ?? x`): `permissions.ts` (`getUserInfo`, `getUserRoles`), `UserD2ApiRepository.getCurrent`, `GenericSyncUseCase`, and the package list/import components (routed through the user use case).

### :video_camera: Screenshots/Screen capture

### :fire: Is there anything the reviewer should know to test it?
-   Run the scheduler against a DHIS2 2.43 instance that has a scheduler-enabled sync rule. Before this change it fails right after "Loading synchronization rules from remote server"; after, rules load and schedule normally.


#869dqwtvv
