### PR TITLE
[feature]: Show tracked entity/event period filters for all period configurations

### DIFF
--- a/src/presentation/react/core/components/sync-wizard/data/PeriodSelectionStep.tsx
+++ b/src/presentation/react/core/components/sync-wizard/data/PeriodSelectionStep.tsx
@@ -101,7 +101,7 @@ const PeriodSelectionStep: React.FC<SyncWizardStepProps> = ({ syncRule, onChange
                 onFieldChange={onFieldChange}
                 skipPeriods={skipPeriods}
             />
-            {objectWithPeriod.period === "SINCE_LAST_SUCCESSFUL_SYNC" && syncRule.metadataTypes.includes("programs") ? (
+            {syncRule.metadataTypes.includes("programs") ? (
                 <>
                     <Dropdown
                         label={i18n.t("Tracked entities sync period field")}


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes [869b9ugya](https://app.clickup.com/t/4528615/869b9ugya)

### :memo: Implementation
- [x] -   Removed the `SINCE_LAST_SUCCESSFUL_SYNC` guard on the "Tracked entities sync period field" and "Events sync period field" dropdowns in `PeriodSelectionStep`. These filters are now visible for **all** period configurations (Fixed, Relative, Since last successful sync, etc.), allowing users to always choose which date field (e.g. enrollment date, occurred date, last updated) is used for filtering.

### :video_camera: Screenshots/Screen capture

https://github.com/user-attachments/assets/5e80ae12-8425-4faf-a521-3c0131a95085


### :fire: Is there anything the reviewer should know to test it?
-   Create or edit an event sync rule that includes programs, go to the Period step, and select any period type other than "Since last successful sync" — the tracked entity and event period field dropdowns should now appear.

### :bookmark_tabs: Others

#869b9ugya