### PR TITLE
[fix]: Avoid false category option combo conflict when mapping indicators

### DIFF
--- a/src/domain/mapping/usecases/GenericMappingUseCase.ts
+++ b/src/domain/mapping/usecases/GenericMappingUseCase.ts
@@ -108,16 +108,20 @@ export abstract class GenericMappingUseCase {
             this.getCategoryOptions(destinationItem)
         );
 
+        // The "default" combo has a different UID per instance, so it never matches by UID/code/name.
+        // Fall back to the destination default (not EXCLUDED_KEY) to avoid a false mapping conflict.
         const categoryOptionCombos = await this.autoMapCollection(
             destinationInstance,
             this.getCategoryOptionCombos(originMetadata, defaultOriginCategoryOptionCombo[0]),
-            this.getCategoryOptionCombos(destinationItem, defaultDestinationCategoryOptionCombo[0])
+            this.getCategoryOptionCombos(destinationItem, defaultDestinationCategoryOptionCombo[0]),
+            defaultDestinationCategoryOptionCombo[0]
         );
 
         const attributeOptionCombos = await this.autoMapCollection(
             destinationInstance,
             this.getAttributeOptionCombos(originMetadata, defaultOriginCategoryOptionCombo[0]),
-            this.getAttributeOptionCombos(destinationItem, defaultDestinationCategoryOptionCombo[0])
+            this.getAttributeOptionCombos(destinationItem, defaultDestinationCategoryOptionCombo[0]),
+            defaultDestinationCategoryOptionCombo[0]
         );
 
         const options =
@@ -253,7 +257,8 @@ export abstract class GenericMappingUseCase {
     protected async autoMapCollection(
         destinationInstance: DataSource,
         originMetadata: CombinedMetadata[],
-        destinationMetadata: CombinedMetadata[]
+        destinationMetadata: CombinedMetadata[],
+        defaultValue: string = EXCLUDED_KEY
     ) {
         if (originMetadata.length === 0) return {};
         const filter = _.compact(destinationMetadata.map(({ id }) => cleanNestedMappedId(id)));
@@ -266,7 +271,7 @@ export abstract class GenericMappingUseCase {
             const [candidate] = await this.autoMap({
                 destinationInstance,
                 selectedItem: { ...item, id: cleanNestedMappedId(item.id) },
-                defaultValue: EXCLUDED_KEY,
+                defaultValue,
                 filter,
             });
             if (item.id && candidate) {


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes [869cdhrcw](https://app.clickup.com/t/4528615/869cdhrcw)

### :memo: Implementation
-   Mapping an indicator to a destination data element (Aggregated mapping → Indicator) showed a phantom Category Option Combo error, even though both instances only have the single `default` COC.
-   Root cause: `GenericMappingUseCase.buildMapping` auto-maps the indicator's synthetic default COC/AOC by UID. The `default` COC is generated with a **different UID on each DHIS2 instance**, so no match was found and it fell back to `EXCLUDED_KEY`, setting `conflicts: true` (the red "Mapping has errors" warning). It only reproduces when the two instances have different default COC UIDs (fresh instances, not clones of the same seed DB).
-   Fix: `autoMapCollection` now accepts an optional `defaultValue` (defaults to `EXCLUDED_KEY`, so category options / options / program stages are unchanged). `buildMapping` passes the destination default COC/AOC UID for the category- and attribute-option-combo collections, so origin-default maps directly to destination-default with no conflict.

### :video_camera: Screenshots/Screen capture
Before:
https://github.com/user-attachments/assets/9e366202-07e6-48ba-9740-d3ca6b398346

After:
https://github.com/user-attachments/assets/889941ba-d28f-442d-b8c6-a12e55861270


### :fire: Is there anything the reviewer should know to test it?
-   Use **two instances whose default categoryOptionCombo UIDs differ**. This is required to trigger the bug (identical default UIDs, e.g. clones of the same demo DB, hide it).
-   Steps: create an indicator in the origin and a matching aggregate data element (default category combo) in the destination → Aggregated mapping → Indicator → map the indicator to the data element → open the Category Option Combos related mapping. Before this change the `default` COC is flagged Excluded/⚠; after, it maps default → default cleanly.

### :bookmark_tabs: Others

#869cdhrcw