### PR TITLE
fix: data element category option combos as valid mapping candidates

### DIFF
--- a/src/domain/mapping/usecases/GenericMappingUseCase.ts
+++ b/src/domain/mapping/usecases/GenericMappingUseCase.ts
@@ -369,6 +369,15 @@ export abstract class GenericMappingUseCase {
                     },
                 ];
             }
+            case "dataElements": {
+                return (
+                    object.categoryCombo?.categoryOptionCombos.map(({ id, name }) => ({
+                        id,
+                        name,
+                        model: "categoryOptionCombos",
+                    })) ?? []
+                );
+            }
             default: {
                 return [];
             }

--- a/src/domain/mapping/usecases/GenericMappingUseCase.ts
+++ b/src/domain/mapping/usecases/GenericMappingUseCase.ts
@@ -92,6 +92,10 @@ export abstract class GenericMappingUseCase {
             .metadataRepository(destinationInstance)
             .getDefaultIds("categoryOptionCombos");
 
+        const defaultDestinationCategoryOption = await this.repositoryFactory
+            .metadataRepository(destinationInstance)
+            .getDefaultIds("categoryOptions");
+
         const mappedElement = {
             mappedId: destinationItem.path ?? destinationItem.id,
             mappedName: destinationItem.name,
@@ -102,10 +106,14 @@ export abstract class GenericMappingUseCase {
 
         const categoryCombos = this.autoMapCategoryCombo(originMetadata, destinationItem);
 
+        // A destination with a real category combo (e.g. Gender) doesn't offer "default" as a
+        // candidate, so the origin's default category option never matches. Fall back to the
+        // destination default (not EXCLUDED_KEY) to avoid a false mapping conflict.
         const categoryOptions = await this.autoMapCollection(
             destinationInstance,
             this.getCategoryOptions(originMetadata),
-            this.getCategoryOptions(destinationItem)
+            this.getCategoryOptions(destinationItem),
+            defaultDestinationCategoryOption[0]
         );
 
         // The "default" combo has a different UID per instance, so it never matches by UID/code/name.

--- a/src/domain/mapping/usecases/__tests__/GetValidMappingIdUseCase.spec.ts
+++ b/src/domain/mapping/usecases/__tests__/GetValidMappingIdUseCase.spec.ts
@@ -1,0 +1,57 @@
+import { anything, instance, mock, when } from "ts-mockito";
+import { DynamicRepositoryFactory } from "../../../common/factories/DynamicRepositoryFactory";
+import { Instance } from "../../../instance/entities/Instance";
+import { MetadataPackage } from "../../../metadata/entities/MetadataEntities";
+import { MetadataRepository } from "../../../metadata/repositories/MetadataRepository";
+import { GetValidMappingIdUseCase } from "../GetValidMappingIdUseCase";
+
+describe("GetValidMappingIdUseCase", () => {
+    it("should include the destination data element's own category option combos as valid mapping ids", async () => {
+        const { useCase, destinationInstance } = givenAGetValidMappingIdUseCase();
+
+        const validIds = await useCase.execute(destinationInstance, "dataElementGender");
+
+        expect(validIds).toEqual(expect.arrayContaining(["cocMale", "cocFemale"]));
+    });
+});
+
+function givenAGetValidMappingIdUseCase() {
+    const destinationInstance = Instance.build({
+        type: "local",
+        name: "Destination",
+        url: "http://destination.test",
+    });
+
+    const destinationMetadata: MetadataPackage = {
+        dataElements: [
+            {
+                id: "dataElementGender",
+                name: "Data element with gender",
+                categoryCombo: {
+                    id: "genderCC",
+                    name: "Gender",
+                    categories: [],
+                    categoryOptionCombos: [
+                        { id: "cocMale", name: "Male" },
+                        { id: "cocFemale", name: "Female" },
+                    ],
+                },
+            } as any,
+        ],
+    };
+
+    const mockedMetadataRepository = mock<MetadataRepository>();
+    when(mockedMetadataRepository.getMetadataByIds(anything(), anything(), anything())).thenResolve(
+        destinationMetadata
+    );
+    when(mockedMetadataRepository.getDefaultIds()).thenResolve(["default"]);
+
+    const mockedRepositoryFactory = mock(DynamicRepositoryFactory);
+    when(mockedRepositoryFactory.metadataRepository(anything())).thenReturn(instance(mockedMetadataRepository));
+
+    const useCase = new GetValidMappingIdUseCase(instance(mockedRepositoryFactory), destinationInstance);
+
+    return { useCase, destinationInstance };
+}
+
+export {};


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes #?

### :memo: Implementation

-   Restore the `"dataElements"` case in `GenericMappingUseCase.getCategoryOptionCombos()`, which was removed in #907 (commit a4aebc52). That PR intended to stop generating a spurious inner category-option-combo mapping when a data element is the *origin* of an aggregated mapping (to avoid false conflict warnings on auto-map). As a side effect it also removed the ability to resolve category option combos when a data element is the *destination* of a mapping.
-   This broke mapping a program indicator (or indicator) to a data element that has a real category combination (e.g. Gender: Male/Female): the "Category Option Combos" related-metadata mapping dialog only offered "default" instead of the destination data element's actual category option combos.
-   Added a unit test (`GetValidMappingIdUseCase.spec.ts`) covering that `getValidMappingIds` returns the destination data element's category option combos as valid candidates.
-   Verified manually that the original bug from #907/#1212 ("Auto-map lists warnings even if there're no problem") does not reappear: a later fix (falling back to the destination's real default COC instead of `EXCLUDED_KEY` in `autoMapCollection`) already prevents the false-conflict warning independently of this case.

### :video_camera: Screenshots/Screen capture

### :fire: Is there anything the reviewer should know to test it?

-   Map a program indicator to a data element that has a non-default category combination (e.g. Gender) in the destination instance.
-   Open "Related metadata mapping" > "Category Option Combos" for that row.
-   The picker should now list the destination data element's real category option combos (e.g. Male/Female), not just "default".

### :bookmark_tabs: Others

-   Any change in the [GUI library](https://github.com/EyeSeeTea/d2-ui-components)? If so, what branch/PR? No

-   Any change in the [D2 Api](https://github.com/EyeSeeTea/d2-api)? If so, what branch/PR? No