### PR TITLE
Support internal (same-instance) Aggregate Data Exchange

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2026-06-16T15:11:31.847Z\n"
-"PO-Revision-Date: 2026-06-16T15:11:31.854Z\n"
+"POT-Creation-Date: 2026-07-07T09:14:53.473Z\n"
+"PO-Revision-Date: 2026-07-07T09:14:53.473Z\n"
 
 msgid ""
 "THIS NEW RELEASE INCLUDES SHARING SETTINGS PER INSTANCES. FOR THIS VERSION "
@@ -37,6 +37,19 @@ msgstr "Program not found"
 
 msgid "An instance with this name already exists"
 msgstr "An instance with this name already exists"
+
+msgid "The instance type cannot be changed after the instance is created"
+msgstr "The instance type cannot be changed after the instance is created"
+
+msgid "The exchange target type cannot be changed after the instance is created"
+msgstr "The exchange target type cannot be changed after the instance is created"
+
+msgid ""
+"An internal Aggregated Data Exchange instance already exists: "
+"{{instanceName}}"
+msgstr ""
+"An internal Aggregated Data Exchange instance already exists: "
+"{{instanceName}}"
 
 msgid ""
 "An Aggregated Data Exchange instance with this URL already exists: "
@@ -182,6 +195,12 @@ msgstr "Ok"
 
 msgid "Cancel"
 msgstr "Cancel"
+
+msgid "Instance: {{name}}"
+msgstr "Instance: {{name}}"
+
+msgid "Internal exchange — no credentials required."
+msgstr "Internal exchange — no credentials required."
 
 msgid "Authentication Scheme (*)"
 msgstr "Authentication Scheme (*)"
@@ -1958,6 +1977,12 @@ msgstr "API Token"
 msgid "Aggregated Data Exchange"
 msgstr "Aggregated Data Exchange"
 
+msgid "External"
+msgstr "External"
+
+msgid "Internal"
+msgstr "Internal"
+
 msgid "Please fix the issues before testing the connection"
 msgstr "Please fix the issues before testing the connection"
 
@@ -1966,6 +1991,9 @@ msgstr "Connected successfully to instance"
 
 msgid "Server name (*)"
 msgstr "Server name (*)"
+
+msgid "Exchange target type (*)"
+msgstr "Exchange target type (*)"
 
 msgid "URL endpoint (*)"
 msgstr "URL endpoint (*)"

--- a/i18n/es.po
+++ b/i18n/es.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: i18next-conv\n"
-"POT-Creation-Date: 2026-06-16T15:11:31.847Z\n"
+"POT-Creation-Date: 2026-07-06T15:09:17.686Z\n"
 "PO-Revision-Date: 2020-07-10T06:53:30.625Z\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -34,6 +34,22 @@ msgstr ""
 
 msgid "An instance with this name already exists"
 msgstr ""
+
+msgid "The instance type cannot be changed after the instance is created"
+msgstr "The instance type cannot be changed after the instance is created"
+
+msgid ""
+"The exchange target type cannot be changed after the instance is created"
+msgstr ""
+"The exchange target type cannot be changed after the instance is created"
+
+#, fuzzy
+msgid ""
+"An internal Aggregated Data Exchange instance already exists: "
+"{{instanceName}}"
+msgstr ""
+"An Aggregated Data Exchange instance with this URL already exists: "
+"{{instanceName}}"
 
 msgid ""
 "An Aggregated Data Exchange instance with this URL already exists: "
@@ -175,6 +191,12 @@ msgstr ""
 
 msgid "Cancel"
 msgstr ""
+
+msgid "Instance: {{name}}"
+msgstr "Instance: {{name}}"
+
+msgid "Internal exchange — no credentials required."
+msgstr "Internal exchange — no credentials required."
 
 msgid "Authentication Scheme (*)"
 msgstr ""
@@ -1858,6 +1880,12 @@ msgstr ""
 msgid "Aggregated Data Exchange"
 msgstr ""
 
+msgid "External"
+msgstr "External"
+
+msgid "Internal"
+msgstr "Internal"
+
 msgid "Please fix the issues before testing the connection"
 msgstr ""
 
@@ -1866,6 +1894,9 @@ msgstr ""
 
 msgid "Server name (*)"
 msgstr ""
+
+msgid "Exchange target type (*)"
+msgstr "Exchange target type (*)"
 
 msgid "URL endpoint (*)"
 msgstr ""

--- a/i18n/fr.po
+++ b/i18n/fr.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: i18next-conv\n"
-"POT-Creation-Date: 2026-06-16T15:11:31.847Z\n"
+"POT-Creation-Date: 2026-07-06T15:09:17.686Z\n"
 "PO-Revision-Date: 2020-07-10T06:53:30.625Z\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -34,6 +34,22 @@ msgstr ""
 
 msgid "An instance with this name already exists"
 msgstr ""
+
+msgid "The instance type cannot be changed after the instance is created"
+msgstr "The instance type cannot be changed after the instance is created"
+
+msgid ""
+"The exchange target type cannot be changed after the instance is created"
+msgstr ""
+"The exchange target type cannot be changed after the instance is created"
+
+#, fuzzy
+msgid ""
+"An internal Aggregated Data Exchange instance already exists: "
+"{{instanceName}}"
+msgstr ""
+"An Aggregated Data Exchange instance with this URL already exists: "
+"{{instanceName}}"
 
 msgid ""
 "An Aggregated Data Exchange instance with this URL already exists: "
@@ -175,6 +191,12 @@ msgstr ""
 
 msgid "Cancel"
 msgstr ""
+
+msgid "Instance: {{name}}"
+msgstr "Instance: {{name}}"
+
+msgid "Internal exchange — no credentials required."
+msgstr "Internal exchange — no credentials required."
 
 msgid "Authentication Scheme (*)"
 msgstr ""
@@ -1858,6 +1880,12 @@ msgstr ""
 msgid "Aggregated Data Exchange"
 msgstr ""
 
+msgid "External"
+msgstr "External"
+
+msgid "Internal"
+msgstr "Internal"
+
 msgid "Please fix the issues before testing the connection"
 msgstr ""
 
@@ -1866,6 +1894,9 @@ msgstr ""
 
 msgid "Server name (*)"
 msgstr ""
+
+msgid "Exchange target type (*)"
+msgstr "Exchange target type (*)"
 
 msgid "URL endpoint (*)"
 msgstr ""

--- a/i18n/pt.po
+++ b/i18n/pt.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: i18next-conv\n"
-"POT-Creation-Date: 2026-06-16T15:11:31.847Z\n"
+"POT-Creation-Date: 2026-07-06T15:09:17.686Z\n"
 "PO-Revision-Date: 2020-07-10T06:53:30.625Z\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -34,6 +34,22 @@ msgstr ""
 
 msgid "An instance with this name already exists"
 msgstr ""
+
+msgid "The instance type cannot be changed after the instance is created"
+msgstr "The instance type cannot be changed after the instance is created"
+
+msgid ""
+"The exchange target type cannot be changed after the instance is created"
+msgstr ""
+"The exchange target type cannot be changed after the instance is created"
+
+#, fuzzy
+msgid ""
+"An internal Aggregated Data Exchange instance already exists: "
+"{{instanceName}}"
+msgstr ""
+"An Aggregated Data Exchange instance with this URL already exists: "
+"{{instanceName}}"
 
 msgid ""
 "An Aggregated Data Exchange instance with this URL already exists: "
@@ -175,6 +191,12 @@ msgstr ""
 
 msgid "Cancel"
 msgstr ""
+
+msgid "Instance: {{name}}"
+msgstr "Instance: {{name}}"
+
+msgid "Internal exchange — no credentials required."
+msgstr "Internal exchange — no credentials required."
 
 msgid "Authentication Scheme (*)"
 msgstr ""
@@ -1858,6 +1880,12 @@ msgstr ""
 msgid "Aggregated Data Exchange"
 msgstr ""
 
+msgid "External"
+msgstr "External"
+
+msgid "Internal"
+msgstr "Internal"
+
 msgid "Please fix the issues before testing the connection"
 msgstr ""
 
@@ -1866,6 +1894,9 @@ msgstr ""
 
 msgid "Server name (*)"
 msgstr ""
+
+msgid "Exchange target type (*)"
+msgstr "Exchange target type (*)"
 
 msgid "URL endpoint (*)"
 msgstr ""

--- a/src/data/aggregated/AggregatedDataExchangeApiExecutor.ts
+++ b/src/data/aggregated/AggregatedDataExchangeApiExecutor.ts
@@ -1,49 +1,14 @@
-import { AggregatedPackage } from "../../domain/aggregated/entities/AggregatedPackage";
 import { AggregatedDataExchangeExecutor } from "../../domain/aggregated/repositories/AggregatedDataExchangeExecutor";
 import { Instance } from "../../domain/instance/entities/Instance";
 import { SynchronizationResult } from "../../domain/reports/entities/SynchronizationResult";
 import { D2Api } from "../../types/d2-api";
-import { promiseMap } from "../../utils/common";
 import { getD2APiFromInstance } from "../../utils/d2-utils";
-import { getAggregatedDataExchanges } from "./getAggregateDataExchange";
 
 export class AggregatedDataExchangeApiExecutor implements AggregatedDataExchangeExecutor {
     private api: D2Api;
 
     constructor(localInstance: Instance) {
         this.api = getD2APiFromInstance(localInstance);
-    }
-
-    async getSourceData(aggregatedDataExchangeId: string[]): Promise<AggregatedPackage> {
-        const responses = await promiseMap(aggregatedDataExchangeId, async adexId => {
-            return this.getByAdexId(adexId);
-        });
-
-        return {
-            dataValues: responses.flatMap(res => res.dataValues),
-        };
-    }
-
-    private async getByAdexId(aggregatedDataExchangeId: string) {
-        const aggregatedDataExchanges = await getAggregatedDataExchanges(this.api, [aggregatedDataExchangeId]);
-
-        const aggregatedDataExchange = aggregatedDataExchanges[0];
-
-        if (!aggregatedDataExchange) {
-            throw new Error(`AggregatedDataExchange with id ${aggregatedDataExchangeId} not found`);
-        }
-
-        const request = aggregatedDataExchange.source.requests[0];
-
-        const analyticsResponse = await this.api
-            .get<AggregatedPackage>("/analytics/dataValueSet.json", {
-                dimension: [`dx:${request.dx.join(";")}`, `pe:${request.pe.join(";")}`, `ou:${request.ou.join(";")}`],
-                inputIdScheme: "CODE",
-                outputIdScheme: "CODE",
-            })
-            .getData();
-
-        return analyticsResponse;
     }
 
     async execute(aggregatedDataExchangeId: string, targetInstance: Instance): Promise<SynchronizationResult> {

--- a/src/data/aggregated/models/AggregatedDataExchange.ts
+++ b/src/data/aggregated/models/AggregatedDataExchange.ts
@@ -1,3 +1,6 @@
+// DHIS2 caps the aggregate data exchange source request name at 50 characters (error E4001).
+export const MAX_ADEX_SOURCE_REQUEST_NAME_LENGTH = 50;
+
 type AggregatedDataExchangeRequest = {
     name: string;
     dx: string[];
@@ -26,7 +29,7 @@ type AggregatedDataExchangeApiConfig = {
 
 type AggregatedDataExchangeTarget = {
     type: "EXTERNAL" | "INTERNAL";
-    api: AggregatedDataExchangeApiConfig;
+    api?: AggregatedDataExchangeApiConfig;
     request: {
         idScheme: Scheme;
         dataElementIdScheme: Scheme;

--- a/src/data/instance/InstanceD2ApiRepository.ts
+++ b/src/data/instance/InstanceD2ApiRepository.ts
@@ -1,6 +1,6 @@
 //import Cryptr from "cryptr";
 import _ from "lodash";
-import { Instance, InstanceType } from "../../domain/instance/entities/Instance";
+import { ExchangeTargetType, Instance, InstanceType } from "../../domain/instance/entities/Instance";
 import { InstanceMessage } from "../../domain/instance/entities/Message";
 import { InstanceRepository, InstancesFilter } from "../../domain/instance/repositories/InstanceRepository";
 import { D2Api, D2User } from "../../types/d2-api";
@@ -78,7 +78,7 @@ export class InstanceD2ApiRepository implements InstanceRepository {
                       ..._.pick(instance.toObject(), "id"),
                   }
                 : {
-                      ..._.pick(instance.toObject(), "id", "name", "type", "url", "description"),
+                      ..._.pick(instance.toObject(), "id", "name", "type", "url", "description", "exchangeTargetType"),
                   };
 
         await storageClient.saveObjectInCollection(Namespace.INSTANCES, instanceData);
@@ -190,6 +190,7 @@ export class InstanceD2ApiRepository implements InstanceRepository {
                             type: dataStoreInstance.type,
                             url: dataStoreInstance.url || "",
                             description: dataStoreInstance.description || "",
+                            exchangeTargetType: dataStoreInstance.exchangeTargetType ?? "external",
                         });
                     } else {
                         const instance = routeInstancesWithVersion.find(
@@ -280,4 +281,5 @@ export interface InstanceDataStoreData {
     name?: string;
     url?: string;
     description?: string;
+    exchangeTargetType?: ExchangeTargetType;
 }

--- a/src/data/rules/RulesD2ApiRepository.ts
+++ b/src/data/rules/RulesD2ApiRepository.ts
@@ -20,6 +20,7 @@ import { getAggregatedDataExchanges } from "../aggregated/getAggregateDataExchan
 import { getAggregatedDataExchangeJobConfigurations } from "../aggregated/getAggregatedDataExchangeJobConfigurations";
 import { toSynchronizationRulePersistedSnapshot } from "../../domain/rules/PersistedSnapshot";
 import { getRuleAggregatedDataExchanges } from "./utils/getRuleAggregatedDataExchanges";
+import { buildAggregatedDataExchangePayload } from "./utils/buildAggregatedDataExchangePayload";
 
 export class RulesD2ApiRepository implements RulesRepository {
     private api: D2Api;
@@ -208,42 +209,13 @@ export class RulesD2ApiRepository implements RulesRepository {
                     inst => inst.id === ade.target.instanceId && inst.type === "aggregated-data-exchange"
                 );
 
-                const name = `${ruleData.name} target: ${instance?.name || ""}`;
-
-                return {
-                    id: ade.id,
-                    name,
-                    source: {
-                        requests: [
-                            {
-                                name,
-                                dx: metadataCodes,
-                                pe: periods,
-                                ou: orgUnitCodes,
-                                filters: [],
-                                inputIdScheme: "CODE" as const,
-                                outputIdScheme: "CODE" as const,
-                                outputDataElementIdScheme: "CODE" as const,
-                                outputOrgUnitIdScheme: "CODE" as const,
-                            },
-                        ],
-                    },
-                    target: {
-                        type: "EXTERNAL" as const,
-                        api: {
-                            url: instance?.url || "",
-                            username: ade.target.username,
-                            password: ade.target.password,
-                            token: ade.target.token,
-                        },
-                        request: {
-                            idScheme: "CODE" as const,
-                            dataElementIdScheme: "CODE" as const,
-                            orgUnitIdScheme: "CODE" as const,
-                            categoryOptionComboIdScheme: "CODE" as const,
-                        },
-                    },
-                };
+                return buildAggregatedDataExchangePayload(ade, ruleData.name, instance, {
+                    periods,
+                    orgUnits,
+                    orgUnitCodes,
+                    metadataIds,
+                    metadataCodes,
+                });
             });
         });
 
@@ -282,7 +254,7 @@ export class RulesD2ApiRepository implements RulesRepository {
 
             if (hasChanged) {
                 if (
-                    aggregateDataExchange.target.api.url &&
+                    aggregateDataExchange.target.api?.url &&
                     !aggregateDataExchange.target.api.password &&
                     !aggregateDataExchange.target.api.token
                 ) {

--- a/src/data/rules/utils/__tests__/buildAggregatedDataExchangePayload.spec.ts
+++ b/src/data/rules/utils/__tests__/buildAggregatedDataExchangePayload.spec.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect } from "vitest";
+import { RuleAggregatedDataExchange } from "../../../../domain/rules/value-object/RuleAggregatedDataExchange";
+import { InstanceDataStoreData } from "../../../instance/InstanceD2ApiRepository";
+import { buildAggregatedDataExchangePayload } from "../buildAggregatedDataExchangePayload";
+
+const RULE_NAME = "My rule";
+
+const dimensions = {
+    periods: ["202401"],
+    orgUnits: ["ou-uid-1"],
+    orgUnitCodes: ["OU_CODE_1"],
+    metadataIds: ["de-uid-1"],
+    metadataCodes: ["DE_CODE_1"],
+};
+
+const internalInstance: InstanceDataStoreData = {
+    id: "instInternal",
+    name: "Internal ADEX",
+    type: "aggregated-data-exchange",
+    url: "http://origin.test",
+    exchangeTargetType: "internal",
+};
+
+const externalInstance: InstanceDataStoreData = {
+    id: "instExternal",
+    name: "External ADEX",
+    type: "aggregated-data-exchange",
+    url: "https://remote.test",
+    exchangeTargetType: "external",
+};
+
+const buildRuleAdex = (
+    instanceId: string,
+    type: "internal" | "external",
+    credentials?: { username: string; password: string }
+) =>
+    RuleAggregatedDataExchange.create({
+        id: "adex-id-1",
+        target: {
+            instanceId,
+            type,
+            authType: "http-basic",
+            username: credentials?.username,
+            password: credentials?.password,
+        },
+    }).getOrThrow();
+
+describe("buildAggregatedDataExchangePayload", () => {
+    describe("internal target", () => {
+        const ade = buildRuleAdex(internalInstance.id, "internal");
+        const payload = buildAggregatedDataExchangePayload(ade, RULE_NAME, internalInstance, dimensions);
+
+        it("uses INTERNAL target with no api block", () => {
+            expect(payload.target).toEqual({
+                type: "INTERNAL",
+                request: {
+                    idScheme: "UID",
+                    dataElementIdScheme: "UID",
+                    orgUnitIdScheme: "UID",
+                    categoryOptionComboIdScheme: "UID",
+                },
+            });
+        });
+
+        it("uses UID schemes and UID identifiers in the source request", () => {
+            expect(payload.source.requests[0]).toEqual({
+                name: "My rule target: Internal ADEX",
+                dx: ["de-uid-1"],
+                pe: ["202401"],
+                ou: ["ou-uid-1"],
+                filters: [],
+                inputIdScheme: "UID",
+                outputIdScheme: "UID",
+                outputDataElementIdScheme: "UID",
+                outputOrgUnitIdScheme: "UID",
+            });
+        });
+    });
+
+    describe("external target", () => {
+        const ade = buildRuleAdex(externalInstance.id, "external", { username: "admin", password: "district" });
+        const payload = buildAggregatedDataExchangePayload(ade, RULE_NAME, externalInstance, dimensions);
+
+        it("uses EXTERNAL target with api url and credentials", () => {
+            expect(payload.target).toEqual({
+                type: "EXTERNAL",
+                api: { url: "https://remote.test", username: "admin", password: "district", token: undefined },
+                request: {
+                    idScheme: "CODE",
+                    dataElementIdScheme: "CODE",
+                    orgUnitIdScheme: "CODE",
+                    categoryOptionComboIdScheme: "CODE",
+                },
+            });
+        });
+
+        it("uses CODE schemes and code identifiers in the source request", () => {
+            expect(payload.source.requests[0]).toEqual({
+                name: "My rule target: External ADEX",
+                dx: ["DE_CODE_1"],
+                pe: ["202401"],
+                ou: ["OU_CODE_1"],
+                filters: [],
+                inputIdScheme: "CODE",
+                outputIdScheme: "CODE",
+                outputDataElementIdScheme: "CODE",
+                outputOrgUnitIdScheme: "CODE",
+            });
+        });
+    });
+
+    it("keeps the top-level exchange id and name", () => {
+        const ade = buildRuleAdex(internalInstance.id, "internal");
+        const payload = buildAggregatedDataExchangePayload(ade, RULE_NAME, internalInstance, dimensions);
+
+        expect(payload.id).toBe("adex-id-1");
+        expect(payload.name).toBe("My rule target: Internal ADEX");
+    });
+
+    it("truncates the source request name to 50 characters (E4001)", () => {
+        const longRuleName = "x".repeat(60);
+        const ade = buildRuleAdex(internalInstance.id, "internal");
+
+        const payload = buildAggregatedDataExchangePayload(ade, longRuleName, internalInstance, dimensions);
+
+        const fullName = `${longRuleName} target: ${internalInstance.name}`;
+        expect(payload.name).toBe(fullName); // top-level name is not truncated
+        expect(payload.source.requests[0].name).toBe(fullName.slice(0, 50));
+        expect(payload.source.requests[0].name).toHaveLength(50);
+    });
+});

--- a/src/data/rules/utils/__tests__/buildAggregatedDataExchangePayload.spec.ts
+++ b/src/data/rules/utils/__tests__/buildAggregatedDataExchangePayload.spec.ts
@@ -117,6 +117,14 @@ describe("buildAggregatedDataExchangePayload", () => {
         expect(payload.name).toBe("My rule target: Internal ADEX");
     });
 
+    it("throws when the target instance is undefined (deleted after the rule was created)", () => {
+        const ade = buildRuleAdex(externalInstance.id, "external", { username: "admin", password: "district" });
+
+        expect(() => buildAggregatedDataExchangePayload(ade, RULE_NAME, undefined, dimensions)).toThrow(
+            `Cannot build aggregated data exchange payload for rule "${RULE_NAME}": target instance "${externalInstance.id}" was not found (it may have been deleted).`
+        );
+    });
+
     it("truncates the source request name to 50 characters (E4001)", () => {
         const longRuleName = "x".repeat(60);
         const ade = buildRuleAdex(internalInstance.id, "internal");

--- a/src/data/rules/utils/__tests__/getRuleAggregatedDataExchanges.spec.ts
+++ b/src/data/rules/utils/__tests__/getRuleAggregatedDataExchanges.spec.ts
@@ -1,0 +1,84 @@
+import { Server } from "miragejs";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { Instance } from "../../../../domain/instance/entities/Instance";
+import { startDhis } from "../../../../utils/dhisServer";
+import { getD2APiFromInstance } from "../../../../utils/d2-utils";
+import { InstanceDataStoreData } from "../../../instance/InstanceD2ApiRepository";
+import { getRuleAggregatedDataExchanges } from "../getRuleAggregatedDataExchanges";
+
+const LOCAL_URL = "http://origin.test";
+const REMOTE_URL = "https://remote.test";
+
+const localInstance = Instance.build({ url: LOCAL_URL, name: "Testing", version: "2.40", type: "local" });
+
+const request = {
+    dataElementIdScheme: "UID",
+    orgUnitIdScheme: "UID",
+    categoryOptionComboIdScheme: "UID",
+    idScheme: "UID",
+};
+
+const internalExchange = {
+    id: "adexInternal1",
+    name: "Internal exchange",
+    source: { requests: [] },
+    target: { type: "INTERNAL", request },
+};
+
+const externalExchange = {
+    id: "adexExternal1",
+    name: "External exchange",
+    source: { requests: [] },
+    target: {
+        type: "EXTERNAL",
+        api: { url: REMOTE_URL, username: "admin", password: "district" },
+        request,
+    },
+};
+
+const instances: InstanceDataStoreData[] = [
+    { id: "instInternal", type: "aggregated-data-exchange", url: LOCAL_URL, exchangeTargetType: "internal" },
+    { id: "instExternal", type: "aggregated-data-exchange", url: REMOTE_URL, exchangeTargetType: "external" },
+];
+
+describe("getRuleAggregatedDataExchanges", () => {
+    let local: Server;
+
+    beforeEach(() => {
+        local = startDhis({ urlPrefix: LOCAL_URL });
+        local.get("/aggregateDataExchanges", async () => ({
+            aggregateDataExchanges: [internalExchange, externalExchange],
+        }));
+    });
+
+    afterEach(() => {
+        local.shutdown();
+    });
+
+    it("maps internal exchanges without credentials and external exchanges with credentials matched by URL", async () => {
+        const api = getD2APiFromInstance(localInstance);
+
+        const result = await getRuleAggregatedDataExchanges(
+            api,
+            [{ id: "adexInternal1" }, { id: "adexExternal1" }],
+            instances
+        );
+
+        expect(result.map(rule => rule.toProps())).toEqual([
+            {
+                id: "adexInternal1",
+                target: { instanceId: "instInternal", type: "internal", authType: "http-basic" },
+            },
+            {
+                id: "adexExternal1",
+                target: {
+                    instanceId: "instExternal",
+                    type: "external",
+                    authType: "http-basic",
+                    username: "admin",
+                    password: "district",
+                },
+            },
+        ]);
+    });
+});

--- a/src/data/rules/utils/buildAggregatedDataExchangePayload.ts
+++ b/src/data/rules/utils/buildAggregatedDataExchangePayload.ts
@@ -1,0 +1,71 @@
+import { RuleAggregatedDataExchange } from "../../../domain/rules/value-object/RuleAggregatedDataExchange";
+import {
+    AggregatedDataExchange,
+    MAX_ADEX_SOURCE_REQUEST_NAME_LENGTH,
+} from "../../aggregated/models/AggregatedDataExchange";
+import { InstanceDataStoreData } from "../../instance/InstanceD2ApiRepository";
+
+export type AdexRequestDimensions = {
+    periods: string[];
+    orgUnits: string[];
+    orgUnitCodes: string[];
+    metadataIds: string[];
+    metadataCodes: string[];
+};
+
+export function buildAggregatedDataExchangePayload(
+    ade: RuleAggregatedDataExchange,
+    ruleName: string,
+    instance: InstanceDataStoreData | undefined,
+    dimensions: AdexRequestDimensions
+): AggregatedDataExchange {
+    const name = `${ruleName} target: ${instance?.name || ""}`;
+    const requestName = name.slice(0, MAX_ADEX_SOURCE_REQUEST_NAME_LENGTH);
+
+    const isInternal = instance?.exchangeTargetType === "internal";
+
+    const scheme: "UID" | "CODE" = isInternal ? "UID" : "CODE";
+    const dx = isInternal ? dimensions.metadataIds : dimensions.metadataCodes;
+    const ou = isInternal ? dimensions.orgUnits : dimensions.orgUnitCodes;
+
+    const request = {
+        idScheme: scheme,
+        dataElementIdScheme: scheme,
+        orgUnitIdScheme: scheme,
+        categoryOptionComboIdScheme: scheme,
+    };
+
+    const target = isInternal
+        ? { type: "INTERNAL" as const, request }
+        : {
+              type: "EXTERNAL" as const,
+              api: {
+                  url: instance?.url || "",
+                  username: ade.target.username,
+                  password: ade.target.password,
+                  token: ade.target.token,
+              },
+              request,
+          };
+
+    return {
+        id: ade.id,
+        name,
+        source: {
+            requests: [
+                {
+                    name: requestName,
+                    dx,
+                    pe: dimensions.periods,
+                    ou,
+                    filters: [],
+                    inputIdScheme: scheme,
+                    outputIdScheme: scheme,
+                    outputDataElementIdScheme: scheme,
+                    outputOrgUnitIdScheme: scheme,
+                },
+            ],
+        },
+        target,
+    };
+}

--- a/src/data/rules/utils/buildAggregatedDataExchangePayload.ts
+++ b/src/data/rules/utils/buildAggregatedDataExchangePayload.ts
@@ -19,10 +19,16 @@ export function buildAggregatedDataExchangePayload(
     instance: InstanceDataStoreData | undefined,
     dimensions: AdexRequestDimensions
 ): AggregatedDataExchange {
-    const name = `${ruleName} target: ${instance?.name || ""}`;
+    if (!instance) {
+        throw new Error(
+            `Cannot build aggregated data exchange payload for rule "${ruleName}": target instance "${ade.target.instanceId}" was not found (it may have been deleted).`
+        );
+    }
+
+    const name = `${ruleName} target: ${instance.name || ""}`;
     const requestName = name.slice(0, MAX_ADEX_SOURCE_REQUEST_NAME_LENGTH);
 
-    const isInternal = instance?.exchangeTargetType === "internal";
+    const isInternal = instance.exchangeTargetType === "internal";
 
     const scheme: "UID" | "CODE" = isInternal ? "UID" : "CODE";
     const dx = isInternal ? dimensions.metadataIds : dimensions.metadataCodes;
@@ -40,7 +46,7 @@ export function buildAggregatedDataExchangePayload(
         : {
               type: "EXTERNAL" as const,
               api: {
-                  url: instance?.url || "",
+                  url: instance.url || "",
                   username: ade.target.username,
                   password: ade.target.password,
                   token: ade.target.token,

--- a/src/data/rules/utils/getRuleAggregatedDataExchanges.ts
+++ b/src/data/rules/utils/getRuleAggregatedDataExchanges.ts
@@ -20,13 +20,34 @@ export async function getRuleAggregatedDataExchanges(
     }
 
     return adexItems.map(adex => {
+        if (adex.target.type === "INTERNAL") {
+            const instance = instances.find(
+                inst => inst.type === "aggregated-data-exchange" && inst.exchangeTargetType === "internal"
+            );
+
+            if (!instance) {
+                throw new Error(
+                    `Internal Aggregated Data Exchange instance not found for Aggregated Data Exchange ${adex.id}`
+                );
+            }
+
+            return RuleAggregatedDataExchange.createExisted({
+                id: adex.id,
+                target: {
+                    instanceId: instance.id,
+                    type: "internal",
+                    authType: "http-basic",
+                },
+            }).getOrThrow();
+        }
+
         const instance = instances.find(
-            inst => inst.url === adex.target.api.url && inst.type === "aggregated-data-exchange"
+            inst => inst.url === adex.target.api?.url && inst.type === "aggregated-data-exchange"
         );
 
         if (!instance) {
             throw new Error(
-                `Instance with url ${adex.target.api.url} not found for Aggregated Data Exchange ${adex.id}`
+                `Instance with url ${adex.target.api?.url} not found for Aggregated Data Exchange ${adex.id}`
             );
         }
 
@@ -34,10 +55,11 @@ export async function getRuleAggregatedDataExchanges(
             id: adex.id,
             target: {
                 instanceId: instance.id,
-                authType: adex.target.api.username ? "http-basic" : "api-token",
-                username: adex.target.api.username,
-                password: adex.target.api.password,
-                token: adex.target.api.token,
+                type: "external",
+                authType: adex.target.api?.username ? "http-basic" : "api-token",
+                username: adex.target.api?.username,
+                password: adex.target.api?.password,
+                token: adex.target.api?.token,
             },
         }).getOrThrow();
     });

--- a/src/domain/aggregated/repositories/AggregatedDataExchangeExecutor.ts
+++ b/src/domain/aggregated/repositories/AggregatedDataExchangeExecutor.ts
@@ -1,8 +1,6 @@
 import { Instance } from "../../instance/entities/Instance";
 import { SynchronizationResult } from "../../reports/entities/SynchronizationResult";
-import { AggregatedPackage } from "../entities/AggregatedPackage";
 
 export interface AggregatedDataExchangeExecutor {
     execute(aggregatedDataExchangeId: string, targetInstance: Instance): Promise<SynchronizationResult>;
-    getSourceData(aggregatedDataExchangeId: string[]): Promise<AggregatedPackage>;
 }

--- a/src/domain/instance/entities/Instance.ts
+++ b/src/domain/instance/entities/Instance.ts
@@ -10,6 +10,9 @@ import { ModelValidation, validateModel, ValidationError } from "../../common/en
 export type PublicInstance = Omit<InstanceData, "password">;
 export type InstanceType = "local" | "dhis" | "aggregated-data-exchange";
 
+export const exchangeTargetTypes = ["external", "internal"] as const;
+export type ExchangeTargetType = typeof exchangeTargetTypes[number];
+
 type AuthType = "api-token" | "http-basic";
 export interface InstanceData extends SharedRef {
     type: InstanceType;
@@ -22,6 +25,7 @@ export interface InstanceData extends SharedRef {
     token?: string;
     description?: string;
     version?: string;
+    exchangeTargetType?: ExchangeTargetType;
 }
 
 export class Instance extends ShareableEntity<InstanceData> {
@@ -71,6 +75,14 @@ export class Instance extends ShareableEntity<InstanceData> {
 
     public get version(): string | undefined {
         return this.data.version;
+    }
+
+    public get exchangeTargetType(): ExchangeTargetType {
+        return this.data.exchangeTargetType ?? "external";
+    }
+
+    public get isInternalDataExchange(): boolean {
+        return this.type === "aggregated-data-exchange" && this.exchangeTargetType === "internal";
     }
 
     public get versionSmall(): string {
@@ -176,14 +188,23 @@ export class Instance extends ShareableEntity<InstanceData> {
             userGroupAccesses: [],
             authType: "http-basic",
             ...data,
+            ...(type === "aggregated-data-exchange"
+                ? { exchangeTargetType: data.exchangeTargetType ?? "external" }
+                : {}),
         });
     }
 
     private moduleValidations = (): ModelValidation[] => {
+        const urlValidations: ModelValidation[] = this.isInternalDataExchange
+            ? []
+            : [
+                  { property: "url", validation: "isUrl" },
+                  { property: "url", validation: "hasText" },
+              ];
+
         const baseValidations: ModelValidation[] = [
             { property: "name", validation: "hasText" },
-            { property: "url", validation: "isUrl" },
-            { property: "url", validation: "hasText" },
+            ...urlValidations,
         ].filter((v): v is ModelValidation => v !== undefined);
 
         const authValidationsByType = {

--- a/src/domain/instance/usecases/SaveInstanceUseCase.ts
+++ b/src/domain/instance/usecases/SaveInstanceUseCase.ts
@@ -21,21 +21,70 @@ export class SaveInstanceUseCase implements UseCase {
             ];
         }
 
-        const exitedAdexInstanceByUrl =
-            instance.type === "aggregated-data-exchange"
+        const existedInstance = instances?.find(existed => existed.id === instance.id);
+
+        if (existedInstance && existedInstance.type !== instance.type) {
+            return [
+                {
+                    property: "type",
+                    error: "type_immutable",
+                    description: i18n.t("The instance type cannot be changed after the instance is created"),
+                },
+            ];
+        }
+
+        if (
+            existedInstance &&
+            instance.type === "aggregated-data-exchange" &&
+            existedInstance.type === "aggregated-data-exchange" &&
+            existedInstance.exchangeTargetType !== instance.exchangeTargetType
+        ) {
+            return [
+                {
+                    property: "exchangeTargetType",
+                    error: "exchange_target_type_immutable",
+                    description: i18n.t("The exchange target type cannot be changed after the instance is created"),
+                },
+            ];
+        }
+
+        if (instance.isInternalDataExchange) {
+            const existedInternalAdexInstance = instances?.find(
+                existed => existed.isInternalDataExchange && existed.id !== instance.id
+            );
+
+            if (existedInternalAdexInstance) {
+                return [
+                    {
+                        property: "exchangeTargetType",
+                        error: "internal_exists",
+                        description: i18n.t(
+                            "An internal Aggregated Data Exchange instance already exists: {{instanceName}}",
+                            { instanceName: existedInternalAdexInstance.name, nsSeparator: false }
+                        ),
+                    },
+                ];
+            }
+        }
+
+        const existedAdexInstanceByUrl =
+            instance.type === "aggregated-data-exchange" && !instance.isInternalDataExchange
                 ? instances?.find(
-                      existed => existed.type === "aggregated-data-exchange" && existed.url === instance.url
+                      existed =>
+                          existed.type === "aggregated-data-exchange" &&
+                          !existed.isInternalDataExchange &&
+                          existed.url === instance.url
                   )
                 : undefined;
 
-        if (exitedAdexInstanceByUrl && exitedAdexInstanceByUrl.id !== instance.id) {
+        if (existedAdexInstanceByUrl && existedAdexInstanceByUrl.id !== instance.id) {
             return [
                 {
                     property: "url",
                     error: "url_exists",
                     description: i18n.t(
                         "An Aggregated Data Exchange instance with this URL already exists: {{instanceName}}",
-                        { instanceName: exitedAdexInstanceByUrl.name, nsSeparator: false }
+                        { instanceName: existedAdexInstanceByUrl.name, nsSeparator: false }
                     ),
                 },
             ];

--- a/src/domain/instance/usecases/__tests__/SaveInstanceUseCase.spec.ts
+++ b/src/domain/instance/usecases/__tests__/SaveInstanceUseCase.spec.ts
@@ -1,0 +1,199 @@
+import { describe, it, expect } from "vitest";
+import { mock, when, anything, instance as resolveMock, verify } from "ts-mockito";
+import { SaveInstanceUseCase } from "../SaveInstanceUseCase";
+import { InstanceRepository } from "../../repositories/InstanceRepository";
+import { ExchangeTargetType, Instance } from "../../entities/Instance";
+
+const LOCAL_URL = "http://localhost:8080";
+
+describe("SaveInstanceUseCase", () => {
+    const localInstance = Instance.build({ id: "LOCAL", type: "local", name: "Local Instance", url: LOCAL_URL });
+
+    function buildAdexInstance(params: {
+        id: string;
+        name: string;
+        exchangeTargetType: ExchangeTargetType;
+        url: string;
+    }): Instance {
+        return Instance.build({
+            id: params.id,
+            name: params.name,
+            type: "aggregated-data-exchange",
+            url: params.url,
+            exchangeTargetType: params.exchangeTargetType,
+        });
+    }
+
+    function createUseCase(existingInstances: Instance[]) {
+        const repository = mock<InstanceRepository>();
+        when(repository.getAll(anything())).thenResolve([localInstance, ...existingInstances]);
+        when(repository.save(anything())).thenResolve();
+
+        return { useCase: new SaveInstanceUseCase(resolveMock(repository)), repository };
+    }
+
+    it("rejects a second internal Aggregated Data Exchange instance", async () => {
+        const existingInternal = buildAdexInstance({
+            id: "internal1",
+            name: "Internal 1",
+            exchangeTargetType: "internal",
+            url: LOCAL_URL,
+        });
+        const { useCase, repository } = createUseCase([existingInternal]);
+
+        const newInternal = buildAdexInstance({
+            id: "internal2",
+            name: "Internal 2",
+            exchangeTargetType: "internal",
+            url: LOCAL_URL,
+        });
+
+        const errors = await useCase.execute(newInternal);
+
+        expect(errors).toHaveLength(1);
+        expect(errors[0].property).toBe("exchangeTargetType");
+        expect(errors[0].error).toBe("internal_exists");
+        verify(repository.save(anything())).never();
+    });
+
+    it("allows updating the existing internal instance", async () => {
+        const existingInternal = buildAdexInstance({
+            id: "internal1",
+            name: "Internal 1",
+            exchangeTargetType: "internal",
+            url: LOCAL_URL,
+        });
+        const { useCase, repository } = createUseCase([existingInternal]);
+
+        const updatedInternal = buildAdexInstance({
+            id: "internal1",
+            name: "Internal 1 renamed",
+            exchangeTargetType: "internal",
+            url: LOCAL_URL,
+        });
+
+        const errors = await useCase.execute(updatedInternal);
+
+        expect(errors).toEqual([]);
+        verify(repository.save(anything())).once();
+    });
+
+    it("allows creating an internal instance when only external ones exist", async () => {
+        const existingExternal = buildAdexInstance({
+            id: "external1",
+            name: "External 1",
+            exchangeTargetType: "external",
+            url: "https://play.dhis2.org/remote",
+        });
+        const { useCase, repository } = createUseCase([existingExternal]);
+
+        const newInternal = buildAdexInstance({
+            id: "internal1",
+            name: "Internal 1",
+            exchangeTargetType: "internal",
+            url: LOCAL_URL,
+        });
+
+        const errors = await useCase.execute(newInternal);
+
+        expect(errors).toEqual([]);
+        verify(repository.save(anything())).once();
+    });
+
+    it("still rejects two external instances sharing the same URL", async () => {
+        const sharedUrl = "https://play.dhis2.org/remote";
+        const existingExternal = buildAdexInstance({
+            id: "external1",
+            name: "External 1",
+            exchangeTargetType: "external",
+            url: sharedUrl,
+        });
+        const { useCase, repository } = createUseCase([existingExternal]);
+
+        const newExternal = buildAdexInstance({
+            id: "external2",
+            name: "External 2",
+            exchangeTargetType: "external",
+            url: sharedUrl,
+        });
+
+        const errors = await useCase.execute(newExternal);
+
+        expect(errors).toHaveLength(1);
+        expect(errors[0].property).toBe("url");
+        expect(errors[0].error).toBe("url_exists");
+        verify(repository.save(anything())).never();
+    });
+
+    it("rejects changing the exchange target type of an existing instance", async () => {
+        const existingExternal = buildAdexInstance({
+            id: "adex1",
+            name: "ADEX 1",
+            exchangeTargetType: "external",
+            url: "https://play.dhis2.org/remote",
+        });
+        const { useCase, repository } = createUseCase([existingExternal]);
+
+        const switchedToInternal = buildAdexInstance({
+            id: "adex1",
+            name: "ADEX 1",
+            exchangeTargetType: "internal",
+            url: LOCAL_URL,
+        });
+
+        const errors = await useCase.execute(switchedToInternal);
+
+        expect(errors).toHaveLength(1);
+        expect(errors[0].property).toBe("exchangeTargetType");
+        expect(errors[0].error).toBe("exchange_target_type_immutable");
+        verify(repository.save(anything())).never();
+    });
+
+    it("rejects changing the type of an existing instance", async () => {
+        const existingExternal = buildAdexInstance({
+            id: "adex1",
+            name: "ADEX 1",
+            exchangeTargetType: "external",
+            url: "https://play.dhis2.org/remote",
+        });
+        const { useCase, repository } = createUseCase([existingExternal]);
+
+        const switchedToDhis = Instance.build({
+            id: "adex1",
+            name: "ADEX 1",
+            type: "dhis",
+            url: "https://play.dhis2.org/remote",
+            username: "admin",
+            password: "district",
+        });
+
+        const errors = await useCase.execute(switchedToDhis);
+
+        expect(errors).toHaveLength(1);
+        expect(errors[0].property).toBe("type");
+        expect(errors[0].error).toBe("type_immutable");
+        verify(repository.save(anything())).never();
+    });
+
+    it("allows saving an existing instance keeping the same exchange target type", async () => {
+        const existingExternal = buildAdexInstance({
+            id: "adex1",
+            name: "ADEX 1",
+            exchangeTargetType: "external",
+            url: "https://play.dhis2.org/remote",
+        });
+        const { useCase, repository } = createUseCase([existingExternal]);
+
+        const renamed = buildAdexInstance({
+            id: "adex1",
+            name: "ADEX 1 renamed",
+            exchangeTargetType: "external",
+            url: "https://play.dhis2.org/remote",
+        });
+
+        const errors = await useCase.execute(renamed);
+
+        expect(errors).toEqual([]);
+        verify(repository.save(anything())).once();
+    });
+});

--- a/src/domain/rules/entities/SynchronizationRule.ts
+++ b/src/domain/rules/entities/SynchronizationRule.ts
@@ -955,7 +955,7 @@ export class SynchronizationRule {
             aggregatedDataExchanges: _.compact([
                 this.useAggregatedDataExchange &&
                 (isEmpty(this.aggregatedDataExchanges) ||
-                    this.aggregatedDataExchanges?.some(adex => !adex.target.password))
+                    this.aggregatedDataExchanges?.some(adex => adex.isMissingCredentials))
                     ? {
                           key: "cannot_be_empty",
                           namespace: { element: "aggregatedDataExchanges" },

--- a/src/domain/rules/value-object/RuleAggregatedDataExchange.spec.ts
+++ b/src/domain/rules/value-object/RuleAggregatedDataExchange.spec.ts
@@ -115,11 +115,11 @@ describe("RuleAggregatedDataExchange", () => {
                 id: "F12345678901",
                 target: {
                     instanceId: "G12345678901",
-                    type: "external",
-                    authType: "http-basic",
+                    type: "external" as const,
+                    authType: "http-basic" as const,
                     // username missing
                     // password missing
-                } as any,
+                },
             });
 
             res.match({
@@ -131,15 +131,37 @@ describe("RuleAggregatedDataExchange", () => {
             });
         });
 
+        it("Should return error when http-basic with a password but no username", () => {
+            const res = RuleAggregatedDataExchange.create({
+                ...validprops,
+                id: "F12345678902",
+                target: {
+                    instanceId: "G12345678902",
+                    type: "external" as const,
+                    authType: "http-basic" as const,
+                    password: "pass",
+                    // username missing
+                },
+            });
+
+            res.match({
+                success: _ => fail("expected error for missing username"),
+                error: errors => {
+                    expect(errors.some(e => e.property === "username")).toBe(true);
+                    expect(errors.some(e => e.property === "password")).toBe(false);
+                },
+            });
+        });
+
         it("Should return error when api-token without token", () => {
             const res = RuleAggregatedDataExchange.create({
                 ...validprops,
                 id: "H12345678901",
                 target: {
                     instanceId: "I12345678901",
-                    type: "external",
-                    authType: "api-token",
-                } as any,
+                    type: "external" as const,
+                    authType: "api-token" as const,
+                },
             });
 
             res.match({
@@ -198,10 +220,10 @@ describe("RuleAggregatedDataExchange", () => {
                 id: "L12345678901",
                 target: {
                     instanceId: "M12345678901",
-                    type: "external",
-                    authType: "http-basic",
+                    type: "external" as const,
+                    authType: "http-basic" as const,
                     // username missing
-                } as any,
+                },
             });
 
             res.match({

--- a/src/domain/rules/value-object/RuleAggregatedDataExchange.spec.ts
+++ b/src/domain/rules/value-object/RuleAggregatedDataExchange.spec.ts
@@ -6,6 +6,7 @@ const validprops = {
     id: "A12345678901",
     target: {
         instanceId: "B12345678901",
+        type: "external" as const,
         authType: "http-basic" as const,
         username: "user",
         password: "pass",
@@ -13,171 +14,266 @@ const validprops = {
 };
 
 describe("RuleAggregatedDataExchange", () => {
-    it("Should return success with valid props", () => {
-        const res = RuleAggregatedDataExchange.create(validprops);
+    describe("create", () => {
+        it("Should return success with valid props", () => {
+            const res = RuleAggregatedDataExchange.create(validprops);
 
-        res.match({
-            success: value => {
-                expect(value.toProps()).toEqual(validprops);
-            },
-            error: errors => {
-                fail(errors);
-            },
+            res.match({
+                success: value => {
+                    expect(value.toProps()).toEqual(validprops);
+                },
+                error: errors => {
+                    fail(errors);
+                },
+            });
+        });
+
+        it("Should generate a valid id if empty string provided", () => {
+            const res = RuleAggregatedDataExchange.create({
+                ...validprops,
+                id: "",
+            });
+
+            res.match({
+                success: value => {
+                    expect(isValidUid(value.id)).toBe(true);
+                },
+                error: errors => {
+                    fail(errors);
+                },
+            });
+        });
+
+        it("Should return success with api-token target", () => {
+            const props = {
+                ...validprops,
+                id: "C12345678901",
+                target: {
+                    instanceId: "D12345678901",
+                    type: "external" as const,
+                    authType: "api-token" as const,
+                    token: "secret-token",
+                },
+            };
+            const res = RuleAggregatedDataExchange.create(props);
+
+            res.match({
+                success: value => {
+                    expect(value.toProps()).toEqual(props);
+                },
+                error: errors => {
+                    fail(errors);
+                },
+            });
+        });
+
+        it("Should return success with internal target and no credentials", () => {
+            const props = {
+                id: "O12345678901",
+                target: {
+                    instanceId: "P12345678901",
+                    type: "internal" as const,
+                    authType: "http-basic" as const,
+                },
+            };
+            const res = RuleAggregatedDataExchange.create(props);
+
+            res.match({
+                success: value => {
+                    expect(value.toProps()).toEqual(props);
+                },
+                error: errors => {
+                    fail(errors);
+                },
+            });
+        });
+
+        it("Should return error when missing instanceId", () => {
+            const res = RuleAggregatedDataExchange.create({
+                ...validprops,
+                id: "E12345678901",
+                target: {
+                    // @ts-expect-error testing validation when instanceId is missing
+                    instanceId: undefined,
+                    type: "external",
+                    authType: "api-token",
+                    token: "t",
+                },
+            });
+
+            res.match({
+                success: _ => fail("expected error for missing instanceId"),
+                error: errors => {
+                    expect(errors.some(e => e.property === "instanceId")).toBe(true);
+                },
+            });
+        });
+
+        it("Should return error when http-basic without username or password", () => {
+            const res = RuleAggregatedDataExchange.create({
+                ...validprops,
+                id: "F12345678901",
+                target: {
+                    instanceId: "G12345678901",
+                    type: "external",
+                    authType: "http-basic",
+                    // username missing
+                    // password missing
+                } as any,
+            });
+
+            res.match({
+                success: _ => fail("expected error for missing username/password"),
+                error: errors => {
+                    expect(errors.some(e => e.property === "username")).toBe(true);
+                    expect(errors.some(e => e.property === "password")).toBe(true);
+                },
+            });
+        });
+
+        it("Should return error when api-token without token", () => {
+            const res = RuleAggregatedDataExchange.create({
+                ...validprops,
+                id: "H12345678901",
+                target: {
+                    instanceId: "I12345678901",
+                    type: "external",
+                    authType: "api-token",
+                } as any,
+            });
+
+            res.match({
+                success: _ => fail("expected error for missing token"),
+                error: errors => {
+                    expect(errors.some(e => e.property === "token")).toBe(true);
+                },
+            });
         });
     });
 
-    it("Should generate a valid id if empty string provided", () => {
-        const res = RuleAggregatedDataExchange.create({
-            ...validprops,
-            id: "",
+    describe("createExisted", () => {
+        it("Should return success with http-basic and username only", () => {
+            const props = {
+                id: "J12345678901",
+                target: {
+                    instanceId: "K12345678901",
+                    type: "external" as const,
+                    authType: "http-basic" as const,
+                    username: "user",
+                    // password optional in createExisted
+                },
+            };
+            const res = RuleAggregatedDataExchange.createExisted(props);
+
+            res.match({
+                success: value => {
+                    expect(value.toProps()).toEqual(props);
+                },
+                error: errors => fail(errors),
+            });
         });
 
-        res.match({
-            success: value => {
-                expect(isValidUid(value.id)).toBe(true);
-            },
-            error: errors => {
-                fail(errors);
-            },
-        });
-    });
+        it("Should return success with internal target and no credentials", () => {
+            const props = {
+                id: "Q12345678901",
+                target: {
+                    instanceId: "R12345678901",
+                    type: "internal" as const,
+                    authType: "http-basic" as const,
+                },
+            };
+            const res = RuleAggregatedDataExchange.createExisted(props);
 
-    it("Should return success with api-token target", () => {
-        const props = {
-            ...validprops,
-            id: "C12345678901",
-            target: {
-                instanceId: "D12345678901",
-                authType: "api-token" as const,
-                token: "secret-token",
-            },
-        };
-        const res = RuleAggregatedDataExchange.create(props);
-
-        res.match({
-            success: value => {
-                expect(value.toProps()).toEqual(props);
-            },
-            error: errors => {
-                fail(errors);
-            },
-        });
-    });
-
-    it("Should return error when missing instanceId", () => {
-        const res = RuleAggregatedDataExchange.create({
-            ...validprops,
-            id: "E12345678901",
-            target: {
-                // @ts-expect-error testing validation when instanceId is missing
-                instanceId: undefined,
-                authType: "api-token",
-                token: "t",
-            },
+            res.match({
+                success: value => {
+                    expect(value.toProps()).toEqual(props);
+                },
+                error: errors => fail(errors),
+            });
         });
 
-        res.match({
-            success: _ => fail("expected error for missing instanceId"),
-            error: errors => {
-                expect(errors.some(e => e.property === "instanceId")).toBe(true);
-            },
-        });
-    });
+        it("Should return error when http-basic username is missing", () => {
+            const res = RuleAggregatedDataExchange.createExisted({
+                ...validprops,
+                id: "L12345678901",
+                target: {
+                    instanceId: "M12345678901",
+                    type: "external",
+                    authType: "http-basic",
+                    // username missing
+                } as any,
+            });
 
-    it("Should return error when http-basic without username or password", () => {
-        const res = RuleAggregatedDataExchange.create({
-            ...validprops,
-            id: "F12345678901",
-            target: {
-                instanceId: "G12345678901",
-                authType: "http-basic",
-                // username missing
-                // password missing
-            } as any,
-        });
-
-        res.match({
-            success: _ => fail("expected error for missing username/password"),
-            error: errors => {
-                expect(errors.some(e => e.property === "username")).toBe(true);
-                expect(errors.some(e => e.property === "password")).toBe(true);
-            },
-        });
-    });
-
-    it("Should return error when api-token without token", () => {
-        const res = RuleAggregatedDataExchange.create({
-            ...validprops,
-            id: "H12345678901",
-            target: {
-                instanceId: "I12345678901",
-                authType: "api-token",
-            } as any,
+            res.match({
+                success: _ => fail("expected error for missing username in createExisted"),
+                error: errors => {
+                    expect(errors.some(e => e.property === "username")).toBe(true);
+                },
+            });
         });
 
-        res.match({
-            success: _ => fail("expected error for missing token"),
-            error: errors => {
-                expect(errors.some(e => e.property === "token")).toBe(true);
-            },
+        it("Should return error when id is empty (no autogeneration)", () => {
+            const res = RuleAggregatedDataExchange.createExisted({
+                ...validprops,
+                id: "",
+                target: {
+                    instanceId: "N12345678901",
+                    type: "external",
+                    authType: "api-token",
+                    token: "t",
+                },
+            });
+
+            res.match({
+                success: _ => fail("expected error because id is required in createExisted"),
+                error: errors => {
+                    expect(errors.some(e => e.property === "id")).toBe(true);
+                },
+            });
         });
     });
 
-    it("Should return success in createExisted with http-basic and username only", () => {
-        const res = RuleAggregatedDataExchange.createExisted({
-            ...validprops,
-            id: "J12345678901",
-            target: {
-                instanceId: "K12345678901",
-                authType: "http-basic",
-                username: "user",
-                // password optional in createExisted
-            },
+    describe("isMissingCredentials", () => {
+        it("is false for internal targets", () => {
+            const adex = RuleAggregatedDataExchange.create({
+                id: "S12345678901",
+                target: { instanceId: "T12345678901", type: "internal", authType: "http-basic" },
+            }).getOrThrow();
+
+            expect(adex.isMissingCredentials).toBe(false);
         });
 
-        res.match({
-            success: _ => {
-                expect(true).toBe(true);
-            },
-            error: errors => fail(errors),
-        });
-    });
+        it("is false for external http-basic with a password", () => {
+            const adex = RuleAggregatedDataExchange.create(validprops).getOrThrow();
 
-    it("Should return error in createExisted when http-basic username is missing", () => {
-        const res = RuleAggregatedDataExchange.createExisted({
-            ...validprops,
-            id: "L12345678901",
-            target: {
-                instanceId: "M12345678901",
-                authType: "http-basic",
-                // username missing
-            } as any,
+            expect(adex.isMissingCredentials).toBe(false);
         });
 
-        res.match({
-            success: _ => fail("expected error for missing username in createExisted"),
-            error: errors => {
-                expect(errors.some(e => e.property === "username")).toBe(true);
-            },
-        });
-    });
+        it("is true for external http-basic without a password", () => {
+            const adex = RuleAggregatedDataExchange.createExisted({
+                id: "U12345678901",
+                target: { instanceId: "V12345678901", type: "external", authType: "http-basic", username: "user" },
+            }).getOrThrow();
 
-    it("Should return error in createExisted when id is empty (no autogeneration)", () => {
-        const res = RuleAggregatedDataExchange.createExisted({
-            ...validprops,
-            id: "",
-            target: {
-                instanceId: "N12345678901",
-                authType: "api-token",
-                token: "t",
-            },
+            expect(adex.isMissingCredentials).toBe(true);
         });
 
-        res.match({
-            success: _ => fail("expected error because id is required in createExisted"),
-            error: errors => {
-                expect(errors.some(e => e.property === "id")).toBe(true);
-            },
+        it("is false for external api-token with a token", () => {
+            const adex = RuleAggregatedDataExchange.create({
+                id: "W12345678901",
+                target: { instanceId: "X12345678901", type: "external", authType: "api-token", token: "secret" },
+            }).getOrThrow();
+
+            expect(adex.isMissingCredentials).toBe(false);
+        });
+
+        it("is true for external api-token without a token", () => {
+            const adex = RuleAggregatedDataExchange.createExisted({
+                id: "Y12345678901",
+                target: { instanceId: "Z12345678901", type: "external", authType: "api-token" },
+            }).getOrThrow();
+
+            expect(adex.isMissingCredentials).toBe(true);
         });
     });
 });

--- a/src/domain/rules/value-object/RuleAggregatedDataExchange.ts
+++ b/src/domain/rules/value-object/RuleAggregatedDataExchange.ts
@@ -10,6 +10,7 @@ export type RuleAggregatedDataExchangeProps = {
 
 type RuleAggregatedDataExchangeTarget = {
     instanceId: string;
+    type: "external" | "internal";
     authType: "http-basic" | "api-token";
     username?: string;
     password?: string;
@@ -31,11 +32,19 @@ export class RuleAggregatedDataExchange extends ValueObject<RuleAggregatedDataEx
         return new RuleAggregatedDataExchange({ ...this.props, id: generateUid() });
     }
 
+    public get isMissingCredentials(): boolean {
+        if (this.target.type === "internal") return false;
+
+        return this.target.authType === "http-basic" ? !this.target.password : !this.target.token;
+    }
+
     public static create(
         props: RuleAggregatedDataExchangeProps
     ): Either<ValidationError[], RuleAggregatedDataExchange> {
         const authTargetValidations: ModelValidation[] =
-            props.target.authType === "http-basic"
+            props.target.type === "internal"
+                ? []
+                : props.target.authType === "http-basic"
                 ? [
                       {
                           property: "username",
@@ -66,7 +75,7 @@ export class RuleAggregatedDataExchange extends ValueObject<RuleAggregatedDataEx
         props: RuleAggregatedDataExchangeProps
     ): Either<ValidationError[], RuleAggregatedDataExchange> {
         const authTargetValidations: ModelValidation[] =
-            props.target.authType === "http-basic"
+            props.target.type !== "internal" && props.target.authType === "http-basic"
                 ? [
                       {
                           property: "username",

--- a/src/domain/rules/value-object/RuleAggregatedDataExchange.ts
+++ b/src/domain/rules/value-object/RuleAggregatedDataExchange.ts
@@ -35,7 +35,9 @@ export class RuleAggregatedDataExchange extends ValueObject<RuleAggregatedDataEx
     public get isMissingCredentials(): boolean {
         if (this.target.type === "internal") return false;
 
-        return this.target.authType === "http-basic" ? !this.target.password : !this.target.token;
+        return this.target.authType === "http-basic"
+            ? !this.target.username || !this.target.password
+            : !this.target.token;
     }
 
     public static create(

--- a/src/domain/synchronization/usecases/DownloadPayloadFromSyncRuleUseCase.ts
+++ b/src/domain/synchronization/usecases/DownloadPayloadFromSyncRuleUseCase.ts
@@ -59,12 +59,6 @@ export class DownloadPayloadFromSyncRuleUseCase implements UseCase {
 
         const sync: GenericSyncUseCase = this.compositionRoot.sync[rule.type](rule.toBuilder());
 
-        const aggregateDataExchanges = rule.aggregatedDataExchanges?.map(ade => ade.id) || [];
-
-        const payload: SynchronizationPayload = rule.useAggregatedDataExchange
-            ? await this.aggregatedDataExchangeExecutor.getSourceData(aggregateDataExchanges)
-            : await this.buildPayload(rule.type, rule);
-
         const date = moment().format("YYYYMMDDHHmm");
 
         const mappedData =

--- a/src/presentation/react/core/components/adex-instances-credentials-dialog/AdexInstanceCredentialsDialog.tsx
+++ b/src/presentation/react/core/components/adex-instances-credentials-dialog/AdexInstanceCredentialsDialog.tsx
@@ -38,9 +38,24 @@ const AdexInstanceCredentialsDialog: React.FC<AdexInstanceCredentialsDialogProps
             {adexInstanceCandidates.map((adexProps, index) => {
                 const instance = instances.find((instance: Instance) => instance.id === adexProps.target.instanceId);
 
+                const instanceTitle = i18n.t("Instance: {{name}}", {
+                    name: instance?.name ?? "",
+                    nsSeparator: false,
+                });
+
+                if (adexProps.target.type === "internal") {
+                    return (
+                        <div key={index}>
+                            <h4>{instanceTitle}</h4>
+                            <p>{i18n.t("Internal exchange — no credentials required.")}</p>
+                            <Divider style={{ marginTop: 20, marginBottom: 20 }} />
+                        </div>
+                    );
+                }
+
                 return (
                     <div key={index}>
-                        <h4>Instance: {instance?.name}</h4>
+                        <h4>{instanceTitle}</h4>
 
                         <DropdownContainer>
                             <Dropdown

--- a/src/presentation/react/core/components/adex-instances-credentials-dialog/useAdexInstanceCredentials.ts
+++ b/src/presentation/react/core/components/adex-instances-credentials-dialog/useAdexInstanceCredentials.ts
@@ -29,9 +29,11 @@ export function useAdexInstanceCredentials(
                 if (existingAdex) {
                     return existingAdex.toProps();
                 } else {
+                    const instance = fetchedInstances.find(instance => instance.id === instanceId);
+                    const type = instance?.isInternalDataExchange ? "internal" : "external";
                     return {
                         id: "",
-                        target: { instanceId, authType: "http-basic", username: "", password: "" },
+                        target: { instanceId, type, authType: "http-basic", username: "", password: "" },
                     };
                 }
             });

--- a/src/presentation/react/core/components/create-package-from-file-dialog/CreatePackageFromFileDialog.tsx
+++ b/src/presentation/react/core/components/create-package-from-file-dialog/CreatePackageFromFileDialog.tsx
@@ -18,6 +18,7 @@ import { NamedRef } from "../../../../../domain/common/entities/Ref";
 import Dropdown from "../dropdown/Dropdown";
 import { Module } from "../../../../../domain/modules/entities/Module";
 import { useGetSupportedVersions } from "../../hooks/useGetSupportedVersions";
+import { useLocalInstance } from "../../hooks/useLocalInstance";
 
 interface CreatePackageFromFileDialogProps {
     onClose: () => void;
@@ -50,18 +51,15 @@ export const CreatePackageFromFileDialog: React.FC<CreatePackageFromFileDialogPr
     const { supportedVersions } = useGetSupportedVersions();
     const [errors, setErrors] = useState<Dictionary<ValidationError>>({});
 
+    const { localInstance, error } = useLocalInstance();
+
     useEffect(() => {
-        compositionRoot.instances.getById("LOCAL").then(instanceResponse => {
-            instanceResponse.match({
-                success: instance => {
-                    if (versions.length === 0 && instance.version) updateVersions([instance.versionSmall]);
-                },
-                error: () => {
-                    snackbar.error(i18n.t("Error fetching instance version"));
-                },
-            });
-        });
-    }, [compositionRoot, versions, updateVersions, snackbar]);
+        if (versions.length === 0 && localInstance?.version) updateVersions([localInstance.versionSmall]);
+    }, [localInstance, versions, updateVersions]);
+
+    useEffect(() => {
+        if (error) snackbar.error(i18n.t("Error fetching instance version"));
+    }, [error, snackbar]);
 
     useEffect(() => {
         compositionRoot.user.current().then(({ userGroups }) => setUserGroups(userGroups));

--- a/src/presentation/react/core/components/module-list-table/NewPackageDialog.tsx
+++ b/src/presentation/react/core/components/module-list-table/NewPackageDialog.tsx
@@ -9,10 +9,9 @@ import { Module } from "../../../../../domain/modules/entities/Module";
 import { Package } from "../../../../../domain/packages/entities/Package";
 import i18n from "../../../../../utils/i18n";
 import { Dictionary } from "../../../../../types/utils";
-import { useAppContext } from "../../contexts/AppContext";
+import { useLocalInstance } from "../../hooks/useLocalInstance";
 
 export const NewPackageDialog: React.FC<NewPackageDialogProps> = ({ module, save, close }) => {
-    const { compositionRoot } = useAppContext();
     const classes = useStyles();
     const snackbar = useSnackbar();
 
@@ -75,18 +74,15 @@ export const NewPackageDialog: React.FC<NewPackageDialogProps> = ({ module, save
         else setErrors(messages);
     }, [item, save, module, versions]);
 
+    const { localInstance, error } = useLocalInstance();
+
     useEffect(() => {
-        compositionRoot.instances.getById("LOCAL").then(instanceResponse => {
-            instanceResponse.match({
-                success: instance => {
-                    if (versions.length === 0 && instance.version) updateVersions([instance.versionSmall]);
-                },
-                error: () => {
-                    snackbar.error(i18n.t("Error fetching instance version"));
-                },
-            });
-        });
-    }, [compositionRoot, versions, updateVersions, snackbar]);
+        if (versions.length === 0 && localInstance?.version) updateVersions([localInstance.versionSmall]);
+    }, [localInstance, versions, updateVersions]);
+
+    useEffect(() => {
+        if (error) snackbar.error(i18n.t("Error fetching instance version"));
+    }, [error, snackbar]);
 
     return (
         <ConfirmationDialog

--- a/src/presentation/react/core/components/sync-wizard/Steps.ts
+++ b/src/presentation/react/core/components/sync-wizard/Steps.ts
@@ -60,7 +60,7 @@ const commonSteps: {
                 syncRule.targetInstances.some(instanceId => !aggregatedDataExchangeInstanceIds.includes(instanceId));
 
             const hasInstancesWithoutCredentials =
-                syncRule.aggregatedDataExchanges?.some(adex => !adex.target.password) || false;
+                syncRule.aggregatedDataExchanges?.some(adex => adex.isMissingCredentials) || false;
 
             return {
                 showDialog: hasInstancesNotInAggregatedDataExchanges || hasInstancesWithoutCredentials,

--- a/src/presentation/react/core/components/sync-wizard/common/InstanceSelectionStep.tsx
+++ b/src/presentation/react/core/components/sync-wizard/common/InstanceSelectionStep.tsx
@@ -6,6 +6,7 @@ import { RuleAggregatedDataExchange } from "../../../../../../domain/rules/value
 import { User } from "../../../../../../domain/user/entities/User";
 import i18n from "../../../../../../utils/i18n";
 import { useAppContext } from "../../../contexts/AppContext";
+import { useLocalInstance } from "../../../hooks/useLocalInstance";
 import AdexInstanceCredentialsDialog from "../../adex-instances-credentials-dialog/AdexInstanceCredentialsDialog";
 import SyncParamsSelector from "../../sync-params-selector/SyncParamsSelector";
 import { SyncWizardStepProps } from "../Steps";
@@ -56,22 +57,14 @@ const InstanceSelectionStep: React.FC<SyncWizardStepProps> = ({ syncRule, onChan
     const [selectedOptions, setSelectedOptions] = useState<string[]>(syncRule.targetInstances);
     const [targetInstances, setTargetInstances] = useState<Instance[]>([]);
     const [instanceOptions, setInstanceOptions] = useState<{ value: string; text: string }[]>([]);
-    const [localInstance, setLocalInstance] = useState<Instance | null>(null);
     const [showDialog, setShowDialog] = useState(false);
     const snackbar = useSnackbar();
 
+    const { localInstance, error } = useLocalInstance();
+
     useEffect(() => {
-        compositionRoot.instances.getById("LOCAL").then(instanceResponse => {
-            instanceResponse.match({
-                success: instance => {
-                    setLocalInstance(instance);
-                },
-                error: () => {
-                    snackbar.error(i18n.t("Error fetching local instance"));
-                },
-            });
-        });
-    }, [compositionRoot, snackbar]);
+        if (error) snackbar.error(i18n.t("Error fetching local instance"));
+    }, [error, snackbar]);
 
     const includeCurrentUrlAndTypeIsEvents = (selectedinstanceIds: string[]) => {
         return (

--- a/src/presentation/react/core/components/sync-wizard/common/InstanceSelectionStep.tsx
+++ b/src/presentation/react/core/components/sync-wizard/common/InstanceSelectionStep.tsx
@@ -2,6 +2,7 @@ import { MultiSelector, useSnackbar } from "@eyeseetea/d2-ui-components";
 import { Button, makeStyles, Typography } from "@material-ui/core";
 import React, { useCallback, useEffect, useState } from "react";
 import { Instance } from "../../../../../../domain/instance/entities/Instance";
+import { RuleAggregatedDataExchange } from "../../../../../../domain/rules/value-object/RuleAggregatedDataExchange";
 import { User } from "../../../../../../domain/user/entities/User";
 import i18n from "../../../../../../utils/i18n";
 import { useAppContext } from "../../../contexts/AppContext";
@@ -22,6 +23,29 @@ export const buildInstanceOptions = (instances: Instance[], currentUser: User) =
         };
 
         return { value: instance.id, text: `${instance.name} (${instance.url}) ` + buildName() };
+    });
+};
+
+export const buildAdexTargetInstances = (
+    selectedInstanceIds: string[],
+    existingAdexes: RuleAggregatedDataExchange[],
+    availableInstances: Instance[]
+): RuleAggregatedDataExchange[] => {
+    return selectedInstanceIds.flatMap(instanceId => {
+        const existingAdex = existingAdexes.find(adex => adex.target.instanceId === instanceId);
+        if (existingAdex) return [existingAdex];
+
+        const instance = availableInstances.find(target => target.id === instanceId);
+        if (instance?.isInternalDataExchange) {
+            return [
+                RuleAggregatedDataExchange.create({
+                    id: "",
+                    target: { instanceId, type: "internal", authType: "http-basic" },
+                }).getOrThrow(),
+            ];
+        }
+
+        return [];
     });
 };
 
@@ -52,6 +76,7 @@ const InstanceSelectionStep: React.FC<SyncWizardStepProps> = ({ syncRule, onChan
     const includeCurrentUrlAndTypeIsEvents = (selectedinstanceIds: string[]) => {
         return (
             syncRule.type === "events" &&
+            !syncRule.useAggregatedDataExchange &&
             selectedinstanceIds
                 .map(id => targetInstances.find(instance => instance.id === id)?.url)
                 .includes(localInstance?.url)
@@ -69,19 +94,7 @@ const InstanceSelectionStep: React.FC<SyncWizardStepProps> = ({ syncRule, onChan
                 })
             );
         } else {
-            if (
-                syncRule.useAggregatedDataExchange &&
-                syncRule.aggregatedDataExchanges &&
-                syncRule.aggregatedDataExchanges.length > 0
-            ) {
-                const adexTargetInstances = syncRule.aggregatedDataExchanges.filter(adex => {
-                    return instances.includes(adex.target.instanceId);
-                });
-
-                onChange(syncRule.updateTargetInstances(instances).updateAggregatedDataExchanges(adexTargetInstances));
-            } else {
-                onChange(syncRule.updateTargetInstances(instances));
-            }
+            onChange(syncRule.updateTargetInstances(instances));
         }
     };
 
@@ -94,9 +107,26 @@ const InstanceSelectionStep: React.FC<SyncWizardStepProps> = ({ syncRule, onChan
             });
     }, [compositionRoot, syncRule.useAggregatedDataExchange]);
 
+    useEffect(() => {
+        if (!syncRule.useAggregatedDataExchange || targetInstances.length === 0) return;
+
+        const existingAdexes = syncRule.aggregatedDataExchanges ?? [];
+        const reconciledAdexes = buildAdexTargetInstances(syncRule.targetInstances, existingAdexes, targetInstances);
+
+        const existingIds = existingAdexes.map(adex => adex.target.instanceId).sort();
+        const reconciledIds = reconciledAdexes.map(adex => adex.target.instanceId).sort();
+
+        if (existingIds.join() !== reconciledIds.join()) {
+            onChange(syncRule.updateAggregatedDataExchanges(reconciledAdexes));
+        }
+    }, [syncRule, targetInstances, onChange]);
+
     const onSetAdexCredentials = useCallback(() => {
         setShowDialog(true);
     }, []);
+
+    const selectedTargetInstances = targetInstances.filter(instance => syncRule.targetInstances.includes(instance.id));
+    const hasExternalTargetSelected = selectedTargetInstances.some(instance => !instance.isInternalDataExchange);
 
     return (
         <React.Fragment>
@@ -121,7 +151,7 @@ const InstanceSelectionStep: React.FC<SyncWizardStepProps> = ({ syncRule, onChan
                     generateNewUidDisabled={includeCurrentUrlAndTypeIsEvents(selectedOptions)}
                 />
             )}
-            {syncRule.useAggregatedDataExchange && syncRule.targetInstances.length > 0 && (
+            {syncRule.useAggregatedDataExchange && syncRule.targetInstances.length > 0 && hasExternalTargetSelected && (
                 <Button variant="contained" onClick={onSetAdexCredentials} style={{ marginTop: 16 }}>
                     {i18n.t("Set Credentials")}
                 </Button>

--- a/src/presentation/react/core/components/sync-wizard/common/__tests__/buildAdexTargetInstances.spec.ts
+++ b/src/presentation/react/core/components/sync-wizard/common/__tests__/buildAdexTargetInstances.spec.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from "vitest";
+import { Instance } from "../../../../../../../domain/instance/entities/Instance";
+import { RuleAggregatedDataExchange } from "../../../../../../../domain/rules/value-object/RuleAggregatedDataExchange";
+import { buildAdexTargetInstances } from "../InstanceSelectionStep";
+
+const INTERNAL_ID = "internal01";
+const EXTERNAL_ID = "external01";
+
+const buildAdexInstance = (id: string, exchangeTargetType: "external" | "internal"): Instance =>
+    Instance.build({ id, name: id, type: "aggregated-data-exchange", url: "http://test", exchangeTargetType });
+
+const availableInstances = [buildAdexInstance(INTERNAL_ID, "internal"), buildAdexInstance(EXTERNAL_ID, "external")];
+
+describe("buildAdexTargetInstances", () => {
+    it("auto-creates a credential-less internal entry for a selected internal instance", () => {
+        const result = buildAdexTargetInstances([INTERNAL_ID], [], availableInstances);
+
+        expect(result).toHaveLength(1);
+        expect(result[0].target).toEqual({ instanceId: INTERNAL_ID, type: "internal", authType: "http-basic" });
+    });
+
+    it("does not create an entry for an external instance without existing credentials", () => {
+        const result = buildAdexTargetInstances([EXTERNAL_ID], [], availableInstances);
+
+        expect(result).toEqual([]);
+    });
+
+    it("keeps the existing entry for a still-selected instance instead of recreating it", () => {
+        const existing = RuleAggregatedDataExchange.create({
+            id: "adex01",
+            target: { instanceId: EXTERNAL_ID, type: "external", authType: "http-basic", username: "u", password: "p" },
+        }).getOrThrow();
+
+        const result = buildAdexTargetInstances([EXTERNAL_ID], [existing], availableInstances);
+
+        expect(result).toEqual([existing]);
+    });
+
+    it("keeps existing external entries and auto-creates the internal one for a mixed selection", () => {
+        const existingExternal = RuleAggregatedDataExchange.create({
+            id: "adex01",
+            target: { instanceId: EXTERNAL_ID, type: "external", authType: "http-basic", username: "u", password: "p" },
+        }).getOrThrow();
+
+        const result = buildAdexTargetInstances([EXTERNAL_ID, INTERNAL_ID], [existingExternal], availableInstances);
+
+        expect(result).toHaveLength(2);
+        expect(result[0]).toEqual(existingExternal);
+        expect(result[1].target).toEqual({ instanceId: INTERNAL_ID, type: "internal", authType: "http-basic" });
+    });
+});

--- a/src/presentation/react/core/hooks/useLocalInstance.ts
+++ b/src/presentation/react/core/hooks/useLocalInstance.ts
@@ -1,0 +1,20 @@
+import { useEffect, useState } from "react";
+import { Instance } from "../../../../domain/instance/entities/Instance";
+import { useAppContext } from "../contexts/AppContext";
+
+export function useLocalInstance(): { localInstance: Instance | undefined; error: boolean } {
+    const { compositionRoot } = useAppContext();
+    const [localInstance, setLocalInstance] = useState<Instance>();
+    const [error, setError] = useState(false);
+
+    useEffect(() => {
+        compositionRoot.instances.getById("LOCAL").then(result => {
+            result.match({
+                success: instance => setLocalInstance(instance),
+                error: () => setError(true),
+            });
+        });
+    }, [compositionRoot]);
+
+    return { localInstance, error };
+}

--- a/src/presentation/webapp/core/pages/instance-creation/GeneralInfoForm.tsx
+++ b/src/presentation/webapp/core/pages/instance-creation/GeneralInfoForm.tsx
@@ -2,10 +2,10 @@ import { Button, Card, CardContent, TextField } from "@material-ui/core";
 import { makeStyles } from "@material-ui/styles";
 import { useSnackbar } from "@eyeseetea/d2-ui-components";
 import _, { Dictionary } from "lodash";
-import React, { useCallback, useState } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import { useHistory } from "react-router-dom";
 import { ValidationError } from "../../../../../domain/common/entities/Validations";
-import { Instance } from "../../../../../domain/instance/entities/Instance";
+import { ExchangeTargetType, exchangeTargetTypes, Instance } from "../../../../../domain/instance/entities/Instance";
 import i18n from "../../../../../utils/i18n";
 import { useAppContext } from "../../../../react/core/contexts/AppContext";
 import SaveButton from "./SaveButton";
@@ -18,6 +18,7 @@ export interface GeneralInfoFormProps {
     onSaved?: (instance: Instance) => void;
     showMetadataMapping?: boolean;
     testConnectionVisible: boolean;
+    isEdit?: boolean;
 }
 
 export const authTypeItems = [
@@ -30,6 +31,13 @@ const typeItems = [
     { id: "aggregated-data-exchange", name: i18n.t("Aggregated Data Exchange") },
 ];
 
+const exchangeTargetTypeLabels: Record<ExchangeTargetType, string> = {
+    external: i18n.t("External"),
+    internal: i18n.t("Internal"),
+};
+
+const exchangeTargetTypeItems = exchangeTargetTypes.map(id => ({ id, name: exchangeTargetTypeLabels[id] }));
+
 const GeneralInfoForm = ({
     instance,
     onChange,
@@ -37,6 +45,7 @@ const GeneralInfoForm = ({
     testConnectionVisible,
     onSaved,
     showMetadataMapping,
+    isEdit,
 }: GeneralInfoFormProps) => {
     const { compositionRoot } = useAppContext();
     const classes = useStyles();
@@ -46,6 +55,22 @@ const GeneralInfoForm = ({
     const [isSaving, setIsSaving] = useState<boolean>(false);
     const [didPasswordChange, setPasswordChange] = useState<boolean>(false);
     const [errors, setErrors] = useState<Dictionary<ValidationError>>({});
+    const [localInstanceUrl, setLocalInstanceUrl] = useState<string>("");
+
+    useEffect(() => {
+        compositionRoot.instances.getById("LOCAL").then(instanceResponse => {
+            instanceResponse.match({
+                success: local => setLocalInstanceUrl(local.url),
+                error: () => setLocalInstanceUrl(""),
+            });
+        });
+    }, [compositionRoot]);
+
+    useEffect(() => {
+        if (instance.isInternalDataExchange && localInstanceUrl && instance.url !== localInstanceUrl) {
+            onChange(instance.update({ url: localInstanceUrl }));
+        }
+    }, [instance, localInstanceUrl, onChange]);
 
     const updateModel = useCallback(
         (field: keyof Instance, value: string) => {
@@ -56,6 +81,18 @@ const GeneralInfoForm = ({
             onChange(newInstance);
         },
         [instance, onChange]
+    );
+
+    const onChangeExchangeTargetType = useCallback(
+        (value: string) => {
+            const exchangeTargetType: ExchangeTargetType = value === "internal" ? "internal" : "external";
+            const url = exchangeTargetType === "internal" ? localInstanceUrl : "";
+            const newInstance = instance.update({ exchangeTargetType, url });
+
+            setErrors(_.keyBy(newInstance.validate(["exchangeTargetType", "url"]), "property"));
+            onChange(newInstance);
+        },
+        [instance, localInstanceUrl, onChange]
     );
 
     const onChangeField = useCallback(
@@ -134,18 +171,34 @@ const GeneralInfoForm = ({
                         value={instance.type}
                         onValueChange={(value: string) => updateModel("type", value)}
                         hideEmpty={true}
+                        disabled={isEdit}
                     />
                 </div>
 
-                <TextField
-                    className={classes.row}
-                    fullWidth={true}
-                    label={i18n.t("URL endpoint (*)")}
-                    value={instance.url ?? ""}
-                    onChange={onChangeField("url")}
-                    error={!!errors["url"]}
-                    helperText={errors["url"]?.description}
-                />
+                {instance.type === "aggregated-data-exchange" && (
+                    <div className={classes.dropdown}>
+                        <Dropdown
+                            items={exchangeTargetTypeItems}
+                            label={i18n.t("Exchange target type (*)")}
+                            value={instance.exchangeTargetType}
+                            onValueChange={onChangeExchangeTargetType}
+                            hideEmpty={true}
+                            disabled={isEdit}
+                        />
+                    </div>
+                )}
+
+                {!instance.isInternalDataExchange && (
+                    <TextField
+                        className={classes.row}
+                        fullWidth={true}
+                        label={i18n.t("URL endpoint (*)")}
+                        value={instance.url ?? ""}
+                        onChange={onChangeField("url")}
+                        error={!!errors["url"]}
+                        helperText={errors["url"]?.description}
+                    />
+                )}
 
                 {instance.type === "dhis" && (
                     <div className={classes.dropdown}>

--- a/src/presentation/webapp/core/pages/instance-creation/GeneralInfoForm.tsx
+++ b/src/presentation/webapp/core/pages/instance-creation/GeneralInfoForm.tsx
@@ -8,6 +8,7 @@ import { ValidationError } from "../../../../../domain/common/entities/Validatio
 import { ExchangeTargetType, exchangeTargetTypes, Instance } from "../../../../../domain/instance/entities/Instance";
 import i18n from "../../../../../utils/i18n";
 import { useAppContext } from "../../../../react/core/contexts/AppContext";
+import { useLocalInstance } from "../../../../react/core/hooks/useLocalInstance";
 import SaveButton from "./SaveButton";
 import { Dropdown } from "../../../../react/core/components/dropdown/Dropdown";
 
@@ -55,16 +56,9 @@ const GeneralInfoForm = ({
     const [isSaving, setIsSaving] = useState<boolean>(false);
     const [didPasswordChange, setPasswordChange] = useState<boolean>(false);
     const [errors, setErrors] = useState<Dictionary<ValidationError>>({});
-    const [localInstanceUrl, setLocalInstanceUrl] = useState<string>("");
 
-    useEffect(() => {
-        compositionRoot.instances.getById("LOCAL").then(instanceResponse => {
-            instanceResponse.match({
-                success: local => setLocalInstanceUrl(local.url),
-                error: () => setLocalInstanceUrl(""),
-            });
-        });
-    }, [compositionRoot]);
+    const { localInstance } = useLocalInstance();
+    const localInstanceUrl = localInstance?.url ?? "";
 
     useEffect(() => {
         if (instance.isInternalDataExchange && localInstanceUrl && instance.url !== localInstanceUrl) {

--- a/src/presentation/webapp/core/pages/instance-creation/InstanceCreationPage.tsx
+++ b/src/presentation/webapp/core/pages/instance-creation/InstanceCreationPage.tsx
@@ -80,6 +80,7 @@ const InstanceCreationPage = () => {
                 testConnectionVisible={isEdit}
                 onSaved={onSaved}
                 showMetadataMapping
+                isEdit={isEdit}
             />
         </TestWrapper>
     );


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes #869dzkuyv [Support internal (same-instance) Aggregate Data Exchange](https://app.clickup.com/t/4528615/869dzkuyv)
-  https://github.com/EyeSeeTea/metadata-synchronization/pull/1039

### :memo: Implementation

Adds the ability to run an Aggregated Data Exchange against the **current instance itself** (source = destination), alongside the existing external exchanges.

#### Feature
- When creating an *aggregated data exchange* instance, a new **Exchange target type** selector lets you choose **External** (existing behavior) or **Internal**.
- For an **Internal** exchange the endpoint URL is hidden and automatically set to the current (local) instance URL — no manual URL entry.
- Only **one** Internal exchange instance can exist.
- Internal exchanges require **no credentials**.
- **Exchange target type** and **instance type** are **immutable after creation**: enforced on save and reflected in the UI (the selectors are disabled when editing).
- Internal exchanges use the **UID** identifier scheme; external exchanges keep **CODE** (same code across instances, different UID).
- When building a synchronization rule of type *Aggregated data exchange* (Aggregated Data Sync or Event Sync):
  - Selecting the **internal** instance needs no credentials and shows no credentials step.
  - The credentials dialog and the **Set Credentials** button only appear when at least one **external** target is selected.
  - In a mixed selection, the internal target is listed as “no credentials required” next to the external ones.

#### Bugs fixed
- The exchange target type was not persisted when an instance was first created (it only appeared after editing it once); it is now saved from creation.
- The credentials dialog wrongly appeared for an **internal-only** selection — a failure that only reproduced when the app ran **installed in the instance** (not on localhost), because an internal exchange shares the local URL. Internal targets are now seeded reliably regardless of environment or sync type.
- The event-only “generate new UIDs” behavior was being triggered incorrectly for internal ADEX (which shares the local URL); it is now scoped to non-ADEX event syncs.
- Creating a rule could fail with a DHIS2 error when the exchange source request name exceeded 50 characters; the request name is now truncated while the exchange name stays full.
- The Data Exchange app showed an “unsupported identifier scheme” warning for internal exchanges; internal now uses UID consistently, clearing it.
- External exchanges using an API token were being wrongly flagged as missing credentials; the completeness check now honors the auth type.
- **Download JSON** failed for Aggregated Data Exchange rules — both internal and external, and from both the wizard Summary step and the rules list — with a generic download error. The preview is now built directly from the rule’s selection (metadata, org units, periods) and no longer depends on the exchange already existing in DHIS2 or on a fixed identifier scheme.
- Fixed and extracted translatable strings (i18n) for the new UI.

### :video_camera: Screenshots/Screen capture

**Create internal ADEX**

[test create internal.webm](https://github.com/user-attachments/assets/db21bb1f-8e60-45ab-b5da-9575cdd896b9)

**Events ADEX**

https://github.com/user-attachments/assets/6e20670a-6855-495b-a26a-ada461d3a5b0

<img width="1535" height="296" alt="test program indicator" src="https://github.com/user-attachments/assets/edfa55d1-3c22-4ce5-8219-4032d932f243" />

<img width="698" height="298" alt="test PI to DE done4" src="https://github.com/user-attachments/assets/7cbb8622-4205-4943-bf16-153f984328c0" />
<img width="698" height="298" alt="test PI to DE done3" src="https://github.com/user-attachments/assets/680794d7-3944-4222-b05c-2cd6f7b81137" />
<img width="698" height="298" alt="test PI to DE done2" src="https://github.com/user-attachments/assets/5b777190-e1c1-4784-a6df-4beeb98bdeee" />
<img width="698" height="298" alt="test PI to DE done1" src="https://github.com/user-attachments/assets/c42617f4-bb11-4ebd-abed-d036ef82061f" />


**Aggregated ADEX**

[test aggregated- DE to DE.webm](https://github.com/user-attachments/assets/bfc37d16-459a-40f5-8ae6-da702572c6bb)

DE souce:

<img width="887" height="305" alt="test agg DE5" src="https://github.com/user-attachments/assets/76e53147-d50f-4677-ade8-e623158c1c00" />
<img width="887" height="305" alt="test agg DE4" src="https://github.com/user-attachments/assets/1e1cec61-c351-440a-b8f4-ea3e03c784a1" />
<img width="887" height="305" alt="test agg DE3" src="https://github.com/user-attachments/assets/cf38ca13-d4f6-467d-ad7f-215ff684f79e" />
<img width="887" height="305" alt="test agg DE2" src="https://github.com/user-attachments/assets/5cc9f041-92eb-4911-af0c-412d5769a156" />
<img width="887" height="305" alt="test agg DE1" src="https://github.com/user-attachments/assets/22b86e5c-4ea5-43d4-8e6d-e653a7f8f063" />


Result:

<img width="711" height="697" alt="test agg DE done5" src="https://github.com/user-attachments/assets/01571e37-372b-4d1b-b9b3-065d18b9a083" />
<img width="711" height="697" alt="test agg DE done4" src="https://github.com/user-attachments/assets/61c15b5a-64f1-4dbc-96cd-d463d3af2dc9" />
<img width="711" height="697" alt="test agg DE done3" src="https://github.com/user-attachments/assets/f3e98527-1f20-44c9-b63e-0763068a6427" />
<img width="711" height="697" alt="test agg DE done2" src="https://github.com/user-attachments/assets/6456280c-f02c-45c1-94e8-d5a248676030" />
<img width="711" height="697" alt="test agg DE done1" src="https://github.com/user-attachments/assets/46356a1f-a4ba-45eb-b689-6188df717d86" />


### :fire: Is there anything the reviewer should know to test it?

- This is the dataset with the target data element from the program indicator:

[dataset-with-DE-from-PI-metadata.json](https://github.com/user-attachments/files/29743445/dataset-with-DE-from-PI-metadata.json)

- It is necesary to set the aggregateExportDataElement field  (the uuid of the target DE) in the program indicator metadata (via API or metadata import, as it may not be available in the UI yet only in Metadata Management App in version 42).

<img width="1004" height="648" alt="image" src="https://github.com/user-attachments/assets/a7a70524-fb01-4af3-bf4f-288f4b2b2975" />


### :bookmark_tabs: Others

-   Any change in the [GUI library](https://github.com/EyeSeeTea/d2-ui-components)? If so, what branch/PR?

-   Any change in the [D2 Api](https://github.com/EyeSeeTea/d2-api)? If so, what branch/PR?
