### PR TITLE
Support DHIS2 2.43

### DIFF
--- a/src/data/aggregated/AggregatedD2ApiRepository.ts
+++ b/src/data/aggregated/AggregatedD2ApiRepository.ts
@@ -86,7 +86,11 @@ export class AggregatedD2ApiRepository implements AggregatedRepository {
                                 }) => ({
                                     dataElement,
                                     period,
-                                    orgUnit,
+                                    // DHIS2 2.43 omits orgUnit on each dataValue when the request filters by a
+                                    // single orgUnit (it's only set once at the response root in that case);
+                                    // <=2.42 and 2.43 with multiple orgUnits always include it per dataValue.
+                                    // Empirically verified against play.im.dhis2.org 2.41/2.42/2.43.
+                                    orgUnit: orgUnit ?? data.orgUnit,
                                     value,
                                     comment,
                                     categoryOptionCombo: categoryOptionCombo ?? defaultCategoryOptionCombo,

--- a/src/data/events/EventsD2ApiRepository.ts
+++ b/src/data/events/EventsD2ApiRepository.ts
@@ -8,6 +8,7 @@ import {
 import { buildPeriodFromParams } from "../../domain/aggregated/utils";
 import { EventsPackage } from "../../domain/events/entities/EventsPackage";
 import { ProgramEvent } from "../../domain/events/entities/ProgramEvent";
+import { ProgramStageRef } from "../../domain/events/mapper/Models";
 import { EventsRepository } from "../../domain/events/repositories/EventsRepository";
 import { Instance } from "../../domain/instance/entities/Instance";
 import { SynchronizationResult } from "../../domain/reports/entities/SynchronizationResult";
@@ -34,10 +35,10 @@ export class EventsD2ApiRepository implements EventsRepository {
 
     public async getEvents(
         params: DataSynchronizationParams,
-        programStageIds: string[] = [],
+        programStages: ProgramStageRef[] = [],
         defaults: string[] = []
     ): Promise<ProgramEvent[]> {
-        const events = await this.getEventsByStrategy(params, programStageIds, defaults);
+        const events = await this.getEventsByStrategy(params, programStages, defaults);
 
         // Temporal fix for notes:
         // If a note already exist and sync again the event the sync fail
@@ -49,17 +50,17 @@ export class EventsD2ApiRepository implements EventsRepository {
 
     private async getEventsByStrategy(
         params: DataSynchronizationParams,
-        programStageIds: string[] = [],
+        programStages: ProgramStageRef[] = [],
         defaults: string[] = []
     ): Promise<ProgramEvent[]> {
         const { allEvents = false, orgUnitPaths = [] } = params;
 
         if (!allEvents) {
-            return this.getSpecificEvents(params, programStageIds, defaults);
+            return this.getSpecificEvents(params, programStages, defaults);
         } else if (allEvents && orgUnitPaths.length < 25) {
-            return this.getEventsByOrgUnit(params, programStageIds, defaults);
+            return this.getEventsByOrgUnit(params, programStages, defaults);
         } else {
-            return this.getAllEvents(params, programStageIds, defaults);
+            return this.getAllEvents(params, programStages, defaults);
         }
     }
 
@@ -77,10 +78,12 @@ export class EventsD2ApiRepository implements EventsRepository {
      */
     private async getAllEvents(
         params: DataSynchronizationParams,
-        programStageIds: string[] = [],
+        programStages: ProgramStageRef[] = [],
         defaults: string[] = []
     ): Promise<ProgramEvent[]> {
-        if (programStageIds.length === 0) return [];
+        if (programStages.length === 0) return [];
+
+        const programStageIds = programStages.map(({ id }) => id);
 
         const { period, orgUnitPaths = [], lastUpdated, eventsSyncPeriodField } = params;
         const { startDate, endDate } = buildPeriodFromParams(params);
@@ -149,10 +152,10 @@ export class EventsD2ApiRepository implements EventsRepository {
 
     private async getEventsByOrgUnit(
         params: DataSynchronizationParams,
-        programStageIds: string[] = [],
+        programStages: ProgramStageRef[] = [],
         defaults: string[] = []
     ): Promise<ProgramEvent[]> {
-        if (programStageIds.length === 0) return [];
+        if (programStages.length === 0) return [];
 
         const { period, orgUnitPaths = [], lastUpdated, eventsSyncPeriodField } = params;
         const { startDate, endDate } = buildPeriodFromParams(params);
@@ -174,12 +177,13 @@ export class EventsD2ApiRepository implements EventsRepository {
                       updatedAfter: lastUpdated ? moment(lastUpdated).toISOString() : undefined,
                   };
 
-        const fetchApi = async (programStage: string, orgUnit: string, page: number) => {
+        const fetchApi = async (program: string, programStage: string, orgUnit: string, page: number) => {
             return this.api.tracker.events
                 .get({
                     pageSize: 250,
                     totalPages: true,
                     page,
+                    program,
                     programStage,
                     orgUnit,
                     ...periodFilter,
@@ -188,14 +192,14 @@ export class EventsD2ApiRepository implements EventsRepository {
                 .getData();
         };
 
-        const result = await promiseMap(programStageIds, async programStage => {
+        const result = await promiseMap(programStages, async ({ id: programStage, program }) => {
             const filteredEvents = await promiseMap(orgUnits, async orgUnit => {
-                const firstResponse = await fetchApi(programStage, orgUnit, 1);
+                const firstResponse = await fetchApi(program.id, programStage, orgUnit, 1);
 
                 const remainingPages = getRemainingPages(firstResponse);
 
                 const paginatedEvents = await promiseMap(remainingPages, async page => {
-                    const response = await fetchApi(programStage, orgUnit, page);
+                    const response = await fetchApi(program.id, programStage, orgUnit, page);
 
                     const events = this.extractEvents(response);
 
@@ -227,19 +231,20 @@ export class EventsD2ApiRepository implements EventsRepository {
 
     private async getSpecificEvents(
         params: DataSynchronizationParams,
-        programStageIds: string[] = [],
+        programStages: ProgramStageRef[] = [],
         defaults: string[] = []
     ): Promise<ProgramEvent[]> {
         const { orgUnitPaths = [], events: filter = [] } = params;
-        if (programStageIds.length === 0 || filter.length === 0) return [];
+        if (programStages.length === 0 || filter.length === 0) return [];
 
         const orgUnits = cleanOrgUnitPaths(orgUnitPaths);
         const result = [];
 
-        for (const programStage of programStageIds) {
+        for (const { id: programStage, program } of programStages) {
             for (const ids of _.chunk(filter, 300)) {
                 const response = await this.api.tracker.events
                     .get({
+                        program: program.id,
                         programStage,
                         event: ids.join(";"),
                         fields: { $all: true },

--- a/src/data/metadata/__tests__/integration/sync-events.spec.ts
+++ b/src/data/metadata/__tests__/integration/sync-events.spec.ts
@@ -90,41 +90,47 @@ describe("Sync events", () => {
         local.get("/dataValueSets", async () => ({ dataValues: [] }));
         local.get("/routes/DESTINATION/run/api/dataValueSets", async () => ({ dataValues: [] }));
 
-        local.get("/tracker/events", async () => ({
-            page: 1,
-            pageCount: 1,
-            pageSize: 1,
-            total: 1,
-            instances: [
-                {
-                    storedBy: "widp.admin",
-                    scheduledAt: "2020-04-11T00:00:02.846",
-                    program: "program1",
-                    event: "test-event-1",
-                    programStage: "EGA9fqLFtxM",
-                    orgUnit: "Global",
-                    status: "ACTIVE",
-                    orgUnitName: "Global",
-                    occurredAt: "2020-04-11T00:00:00.000",
-                    attributeCategoryOptions: "Y7fcspgsU43",
-                    updatedAt: "2020-06-09T07:06:35.514",
-                    createdAt: "2020-06-09T07:06:35.513",
-                    deleted: false,
-                    attributeOptionCombo: "Xr12mI7VPn3",
-                    dataValues: [
-                        {
-                            updatedAt: "2020-06-09T07:06:35.515",
-                            storedBy: "widp.admin",
-                            createdAt: "2020-06-09T07:06:35.515",
-                            dataElement: "id1",
-                            value: "true",
-                            providedElsewhere: false,
-                        },
-                    ],
-                    notes: [],
-                },
-            ],
-        }));
+        local.get("/tracker/events", async (_schema, request) => {
+            if (!request.queryParams.program) {
+                throw new Error("Missing required 'program' query param in /tracker/events request");
+            }
+
+            return {
+                page: 1,
+                pageCount: 1,
+                pageSize: 1,
+                total: 1,
+                instances: [
+                    {
+                        storedBy: "widp.admin",
+                        scheduledAt: "2020-04-11T00:00:02.846",
+                        program: "program1",
+                        event: "test-event-1",
+                        programStage: "EGA9fqLFtxM",
+                        orgUnit: "Global",
+                        status: "ACTIVE",
+                        orgUnitName: "Global",
+                        occurredAt: "2020-04-11T00:00:00.000",
+                        attributeCategoryOptions: "Y7fcspgsU43",
+                        updatedAt: "2020-06-09T07:06:35.514",
+                        createdAt: "2020-06-09T07:06:35.513",
+                        deleted: false,
+                        attributeOptionCombo: "Xr12mI7VPn3",
+                        dataValues: [
+                            {
+                                updatedAt: "2020-06-09T07:06:35.515",
+                                storedBy: "widp.admin",
+                                createdAt: "2020-06-09T07:06:35.515",
+                                dataElement: "id1",
+                                value: "true",
+                                providedElsewhere: false,
+                            },
+                        ],
+                        notes: [],
+                    },
+                ],
+            };
+        });
 
         local.get("/routes/DESTINATION/run/api/tracker/events", async () => ({
             page: 1,

--- a/src/data/tracked-entity-instances/TEID2ApiRepository.ts
+++ b/src/data/tracked-entity-instances/TEID2ApiRepository.ts
@@ -26,6 +26,13 @@ import { getD2APiFromInstance } from "../../utils/d2-utils";
 import { getPageCount, getRemainingPages } from "../../utils/pagination";
 import { teiTransformations } from "../transformations/PackageTransformations";
 
+// d2-api's tracker/trackedEntities types don't declare `trackedEntities` (plural, comma-separated),
+// the replacement for the deprecated `trackedEntity` param required to satisfy DHIS2 2.42+'s
+// "either program, trackedEntityType or trackedEntities" validation (E1003) on cross-program lookups.
+type GetTrackedEntitiesParams = Parameters<D2Api["tracker"]["trackedEntities"]["get"]>[0] & {
+    trackedEntities?: string;
+};
+
 export class TEID2ApiRepository implements TEIRepository {
     private api: D2Api;
 
@@ -124,15 +131,31 @@ export class TEID2ApiRepository implements TEIRepository {
         if (orgUnits.length === 0) return [];
         if (ids.length === 0) return [];
 
-        // Cross-program lookup by TEI ids: the DHIS2 /tracker/trackedEntities endpoint
-        // accepts omitting `program`, but d2-api types mark it as required. Cast to bypass.
+        // Cross-program lookup by TEI ids: the DHIS2 /tracker/trackedEntities endpoint accepts
+        // omitting `program`, but d2-api types mark it as required. Cast to bypass.
+        // Empirically verified against play.im.dhis2.org 2.40/2.41/2.42/2.43 that there's no
+        // single param that works on all versions:
+        // - <= 2.40: only the deprecated singular `trackedEntity` filters by id. The plural
+        //   `trackedEntities` either 409s (no program/trackedEntityType given) or, when `program`
+        //   is added to satisfy that, silently ignores the id filter and returns the whole list.
+        // - 2.41: singular `trackedEntity` alone still works, but sending both params together is
+        //   itself rejected (400 E1003, "only one of trackedEntity/trackedEntities").
+        // - >= 2.42: singular `trackedEntity` alone fails (400 E1003, "either program,
+        //   trackedEntityType or trackedEntities should be specified"); only the plural
+        //   `trackedEntities` works.
+        // So the param must be chosen based on the target server's version, not sent unconditionally.
+        const useTrackedEntitiesPlural = this.targetInstance.apiVersion >= 41;
+        const trackedEntityParam = useTrackedEntitiesPlural
+            ? { trackedEntities: ids.join(",") }
+            : { trackedEntity: ids.join(";") };
+
         const result: TrackedEntitiesGetResponse<any> = await this.api.tracker.trackedEntities
             .get({
                 fields: teiFields,
                 ouMode: "SELECTED",
                 orgUnit: orgUnits.join(";"),
-                trackedEntity: ids.join(";"),
-            } as Parameters<typeof this.api.tracker.trackedEntities.get>[0])
+                ...trackedEntityParam,
+            } as GetTrackedEntitiesParams)
             .getData();
 
         const trackedEntities = result.instances || (hasTrackedEntitiesProperty(result) ? result.trackedEntities : []);

--- a/src/domain/events/builders/EventsPayloadBuilder.ts
+++ b/src/domain/events/builders/EventsPayloadBuilder.ts
@@ -13,6 +13,7 @@ import { eventsFields } from "../usecases/EventsSyncUseCase";
 import { Ref } from "../../common/entities/Ref";
 import { TEIRepository } from "../../tracked-entity-instances/repositories/TEIRepository";
 import { EventsPayload } from "../entities/EventsPayload";
+import { ProgramStageRef, toProgramStageRefs } from "../mapper/Models";
 
 export class EventsPayloadBuilder {
     constructor(private repositoryFactory: DynamicRepositoryFactory, private localInstance: Instance) {}
@@ -30,17 +31,13 @@ export class EventsPayloadBuilder {
             programStages = [],
         } = await this.extractMetadata(this.localInstance, metadataIds);
 
-        const stageIdsFromPrograms = programs
-            ? (programs as Program[]).map(program => program.programStages.map(({ id }) => id)).flat()
-            : [];
+        const stagesFromPrograms = toProgramStageRefs(programs as Program[]);
 
-        const progamStageIds = [...programStages.map(({ id }) => id), ...stageIdsFromPrograms];
+        const allProgramStages = _.uniqBy([...programStages, ...stagesFromPrograms], "id");
 
-        const retrievedEvents = (await eventsRepository.getEvents(dataParams, [...new Set(progamStageIds)])).map(
-            event => {
-                return dataParams.generateNewUid ? { ...event, event: generateUid() } : event;
-            }
-        );
+        const retrievedEvents = (await eventsRepository.getEvents(dataParams, allProgramStages)).map(event => {
+            return dataParams.generateNewUid ? { ...event, event: generateUid() } : event;
+        });
 
         const events = excludeEventCoordinates
             ? retrievedEvents.map(event => ({ ...event, geometry: undefined }))
@@ -169,5 +166,5 @@ export class EventsPayloadBuilder {
 type EventsMetadataExtracted = {
     programs?: Pick<Program, "id" | "programType" | "programStages" | "programIndicators">[];
     programIndicators?: Ref[];
-    programStages?: Ref[];
+    programStages?: ProgramStageRef[];
 };

--- a/src/domain/events/mapper/Models.ts
+++ b/src/domain/events/mapper/Models.ts
@@ -8,3 +8,9 @@ export interface ProgramStageRef {
     id: string;
     program: Ref;
 }
+
+export function toProgramStageRefs(programs: { id: string; programStages?: Ref[] }[]): ProgramStageRef[] {
+    return programs.flatMap(program =>
+        (program.programStages ?? []).map(({ id }) => ({ id, program: { id: program.id } }))
+    );
+}

--- a/src/domain/events/repositories/EventsRepository.ts
+++ b/src/domain/events/repositories/EventsRepository.ts
@@ -2,11 +2,12 @@ import { DataImportParams, DataSynchronizationParams } from "../../aggregated/en
 import { SynchronizationResult } from "../../reports/entities/SynchronizationResult";
 import { EventsPackage } from "../entities/EventsPackage";
 import { ProgramEvent } from "../entities/ProgramEvent";
+import { ProgramStageRef } from "../mapper/Models";
 
 export interface EventsRepository {
     getEvents(
         params: DataSynchronizationParams,
-        programStageIds?: string[],
+        programStages?: ProgramStageRef[],
         defaults?: string[]
     ): Promise<ProgramEvent[]>;
 

--- a/src/domain/events/usecases/ListEventsUseCase.ts
+++ b/src/domain/events/usecases/ListEventsUseCase.ts
@@ -3,6 +3,7 @@ import { UseCase } from "../../common/entities/UseCase";
 import { DynamicRepositoryFactory } from "../../common/factories/DynamicRepositoryFactory";
 import { Instance } from "../../instance/entities/Instance";
 import { ProgramEvent } from "../entities/ProgramEvent";
+import { ProgramStageRef } from "../mapper/Models";
 
 export class ListEventsUseCase implements UseCase {
     constructor(private repositoryFactory: DynamicRepositoryFactory, protected localInstance: Instance) {}
@@ -10,9 +11,9 @@ export class ListEventsUseCase implements UseCase {
     public async execute(
         instance: Instance,
         params: DataSynchronizationParams,
-        programStageIds: string[] = [],
+        programStages: ProgramStageRef[] = [],
         defaults: string[] = []
     ): Promise<ProgramEvent[]> {
-        return this.repositoryFactory.eventsRepository(instance).getEvents(params, programStageIds, defaults);
+        return this.repositoryFactory.eventsRepository(instance).getEvents(params, programStages, defaults);
     }
 }

--- a/src/presentation/react/core/components/sync-wizard/data/EventsSelectionStep.tsx
+++ b/src/presentation/react/core/components/sync-wizard/data/EventsSelectionStep.tsx
@@ -9,6 +9,7 @@ import { Typography } from "@material-ui/core";
 import _ from "lodash";
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { ProgramEvent } from "../../../../../../domain/events/entities/ProgramEvent";
+import { toProgramStageRefs } from "../../../../../../domain/events/mapper/Models";
 import { DataElement, Program } from "../../../../../../domain/metadata/entities/MetadataEntities";
 import { SynchronizationRule } from "../../../../../../domain/rules/entities/SynchronizationRule";
 import i18n from "../../../../../../utils/i18n";
@@ -57,6 +58,8 @@ export default function EventsSelectionStep({ syncRule, onChange }: SyncWizardSt
             result.match({
                 error: () => snackbar.error(i18n.t("Invalid origin instance")),
                 success: instance => {
+                    const programStages = toProgramStageRefs(programs);
+
                     compositionRoot.events
                         .list(
                             instance,
@@ -64,7 +67,7 @@ export default function EventsSelectionStep({ syncRule, onChange }: SyncWizardSt
                                 ...memoizedSyncRule.dataParams,
                                 allEvents: true,
                             },
-                            programs.map(program => program.programStages.map(({ id }) => id)).flat()
+                            programStages
                         )
                         .then(setObjects)
                         .catch(setError);

--- a/src/presentation/webapp/msf-aggregate-data/pages/MSFHomePagePresenter.ts
+++ b/src/presentation/webapp/msf-aggregate-data/pages/MSFHomePagePresenter.ts
@@ -3,6 +3,7 @@ import moment from "moment";
 import { DataSyncAggregation } from "../../../../domain/aggregated/entities/DataSyncAggregation";
 import { DataSyncPeriod } from "../../../../domain/aggregated/entities/DataSyncPeriod";
 import { buildPeriodFromParams } from "../../../../domain/aggregated/utils";
+import { ProgramStageRef, toProgramStageRefs } from "../../../../domain/events/mapper/Models";
 import { Instance } from "../../../../domain/instance/entities/Instance";
 import { SynchronizationReport } from "../../../../domain/reports/entities/SynchronizationReport";
 import { SynchronizationRule } from "../../../../domain/rules/entities/SynchronizationRule";
@@ -183,7 +184,7 @@ async function validatePreviousDataValues(
             if (!rule.dataParams || !rule.dataParams.period) return undefined;
             const { startDate } = buildPeriodFromParams(rule.dataParams);
 
-            const programStageIds = await getRuleProgramStageIds(compositionRoot, rule, instance);
+            const programStages = await getRuleProgramStageIds(compositionRoot, rule, instance);
 
             const events = await promiseMap(rule.dataSyncOrgUnitPaths, async orgUnit => {
                 const executionKey = `${rule.id}-${cleanOrgUnitPath(orgUnit)}`;
@@ -199,7 +200,7 @@ async function validatePreviousDataValues(
                         orgUnitPaths: [orgUnit],
                         allEvents: true,
                     },
-                    programStageIds
+                    programStages
                 );
             });
 
@@ -527,7 +528,7 @@ async function getRuleProgramStageIds(
     compositionRoot: CompositionRoot,
     rule: SynchronizationRule,
     instance: Instance
-): Promise<string[]> {
+): Promise<ProgramStageRef[]> {
     const { objects } = await compositionRoot.metadata.list(
         {
             type: "programIndicators",
@@ -538,12 +539,13 @@ async function getRuleProgramStageIds(
         instance
     );
 
-    return _(objects as Partial<{ id: string; program: { id: string; programStages: Ref[] } }>[])
-        .map(({ program }) => program?.programStages.map(({ id }) => id))
-        .flatten()
+    const programs = _(objects as Partial<{ id: string; program: { id: string; programStages: Ref[] } }>[])
+        .map(({ program }) => program)
         .compact()
-        .uniq()
+        .uniqBy("id")
         .value();
+
+    return toProgramStageRefs(programs);
 }
 
 const aggregationTimeUnits = {


### PR DESCRIPTION
### :pushpin: References

- **Issue:** https://app.clickup.com/t/4528615/869e15u54

### :memo: Implementation

DHIS2 tightened validation on two `/tracker/*` GET endpoints across recent server versions, in each case requiring a parameter that used to be optional/omittable. Both were found via real HAR captures against `play.im.dhis2.org/stable-2-43-0-1` and confirmed empirically against 2.40/2.41/2.42/2.43 play instances.

- **`/tracker/events`** (2.43+): requires `program` alongside `programStage`; previously only `programStage` was sent. Fix threads `{program, programStage}` pairs end-to-end (reusing the existing `ProgramStageRef` type) instead of bare `programStage` strings, touching `EventsRepository`, `ListEventsUseCase`, `EventsD2ApiRepository`, `EventsPayloadBuilder`, `EventsSelectionStep.tsx`, and `MSFHomePagePresenter.ts`. Sending `program` alongside `programStage` is a no-op on 2.40/2.41/2.42 and required on 2.43+, so no version check is needed here.
- **`/tracker/trackedEntities`** cross-program lookup by TEI ids (2.42+): the deprecated singular `trackedEntity` param alone now fails with `E1003`. Unlike the events fix, there's no single param choice that works on every version — `<=2.40` only supports the singular `trackedEntity` (the plural doesn't filter by id yet), `2.41` accepts either but rejects both together, and `>=2.42` requires the plural `trackedEntities`. Fixed in `TEID2ApiRepository.getTEIsById()` by branching on `targetInstance.apiVersion`.
- **`/api/dataValueSets`** (2.43+): on GET, when the query filters by a single `orgUnit`, DHIS2 2.43 stops repeating `orgUnit` on each returned dataValue and sets it only once at the response root instead. `AggregatedD2ApiRepository.getAggregated()` blindly destructured `orgUnit` off each item, so the subsequent sync POST carried an empty `orgUnit` on every dataValue in that case. Fixed with a fallback (`orgUnit ?? data.orgUnit`) — the per-item field is still used whenever DHIS2 does send it, so no version check is needed.

### :video_camera: Screenshots/Screen capture



### :fire: Is there anything the reviewer should know to test it?

- Added a regression assertion to the `/tracker/events` mock in `sync-events.spec.ts` that fails if `program` is missing from the request.
- All three fixes were empirically verified against real `play.im.dhis2.org` instances (2.40.12, 2.41.9, 2.42.5.1, 2.43.0.1) by hitting the endpoints directly with curl, not just via mocked tests. For the `orgUnit` fix specifically: verified via POST/GET round-trip with real test data on single- and multi-orgUnit queries on 2.43 to nail the boundary, then cleaned up the test data values afterward.
- Full suite green, `tsc --noEmit` clean.

### :bookmark_tabs: Others

- No changes in the GUI library or D2 Api.
